### PR TITLE
Fix how the ca-certificate filename is accessed so it works with pyin…

### DIFF
--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import pkg_resources
 
 # OpenAI Python bindings.
 #
@@ -20,7 +21,7 @@ default_http_client = None
 app_info = None
 enable_telemetry = True
 max_network_retries = 0
-ca_bundle_path = os.path.join(os.path.dirname(__file__), "data/ca-certificates.crt")
+ca_bundle_path =  pkg_resources.resource_filename(__name__,  "data/ca-certificates.crt")
 debug = False
 
 # Set to either 'debug' or 'info', controls console logging


### PR DESCRIPTION
…staller.

See #17 for details.