### PR TITLE
Support model-based (/engineless) completions in openai cli

### DIFF
--- a/openai/api_resources/abstract/engine_api_resource.py
+++ b/openai/api_resources/abstract/engine_api_resource.py
@@ -37,12 +37,6 @@ class EngineAPIResource(APIResource):
         organization=None,
         **params,
     ):
-        """
-        Create a new instance of this model.
-
-        Parameters:
-        timeout (float): the number of seconds to wait on the promise returned by the API, where 0 means wait forever.
-        """
         engine = params.pop("engine", None)
         timeout = params.pop("timeout", None)
         stream = params.get("stream", False)

--- a/openai/api_resources/completion.py
+++ b/openai/api_resources/completion.py
@@ -3,16 +3,29 @@ import time
 from openai import util
 from openai.api_resources.abstract import DeletableAPIResource, ListableAPIResource
 from openai.api_resources.abstract.engine_api_resource import EngineAPIResource
-from openai.error import TryAgain
+from openai.error import TryAgain, InvalidRequestError
 
 
 class Completion(EngineAPIResource, ListableAPIResource, DeletableAPIResource):
-    engine_required = True
+    engine_required = False
     OBJECT_NAME = "completion"
 
     @classmethod
-    def create(cls, *args, timeout=None, **kwargs):
+    def create(cls, *args, **kwargs):
+        """
+        Creates a new completion for the provided prompt and parameters.
+
+        See https://beta.openai.com/docs/api-reference/completions/create for a list
+        of valid parameters.
+        """
         start = time.time()
+        timeout = kwargs.get("timeout", None)
+        if kwargs.get("model", None) is None and kwargs.get("engine", None) is None:
+            raise InvalidRequestError(
+                "Must provide an 'engine' or 'model' parameter to create a Completion.",
+                param="engine",
+            )
+
         while True:
             try:
                 return super().create(*args, **kwargs)

--- a/openai/version.py
+++ b/openai/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.7.1"
+VERSION = "0.8.0"

--- a/openai/version.py
+++ b/openai/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.7.0"
+VERSION = "0.7.1"


### PR DESCRIPTION
This PR does several things:

- Support engineless completions in the SDK/CLI. (Context: `/v1/completions` is now a thing. If the `engine` parameter is not supplied, we make requests to that path. Otherwise, if `engine` is provided, requests are made to `/v1/engine/<ENGINE>/completions`. We expect most users to still use `engine` right now.)
- A few cosmetic improvements
- Undocuments the timeout parameter on completions