### PR TITLE
Minor fixes to tools (prepare_data validators)

### DIFF
--- a/openai/version.py
+++ b/openai/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.9.3"
+VERSION = "0.9.4"


### PR DESCRIPTION
* ensure that only a single whitespace is prepended. Ensure the message regarding the prompt separator is displayed only if a prompt separator exists.

* change pandas contains to not use regex, which can trip if the common_suffix is actually a regex