### PR TITLE
Add openairc file

### DIFF
--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -1,4 +1,5 @@
 import os
+import configparser
 
 # OpenAI Python bindings.
 #
@@ -8,6 +9,21 @@ import os
 
 api_key = os.environ.get("OPENAI_API_KEY")
 organization = os.environ.get("OPENAI_ORGANIZATION")
+
+home = os.path.expanduser("~")
+config_home = os.environ.get("XDG_CONFIG_HOME", os.path.join(home, ".config"))
+config_parser = configparser.RawConfigParser()
+config_location = os.path.join(config_home, "openairc")
+if os.path.exists(config_location):
+    config_parser.read(config_location)
+
+    if not api_key:
+        api_key = config_parser.get("api", "APIKey")
+
+    if not organization:
+        organization = config_parser.get("api", "Organization")
+
+
 client_id = None
 api_base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com")
 file_api_base = None


### PR DESCRIPTION
After merging this PR, users will be able to store their authentication information in the `openairc` file.

Currently, if the credentials are not in the environment, every application has to load the credentials itself, e.g. 
- https://github.com/tom-doerr/zsh_codex
- https://github.com/tom-doerr/codex-readme
- https://github.com/tom-doerr/vim_codex

Having the openai module load the config means less work for users and developers.


`~/.config/openairc`:
```
[api]
Organization = org-j----------------------P
APIKey = sk-U----------------------------------------------A
```
