### PR TITLE
Fix recording of reponse headers in exceptions.

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -300,7 +300,7 @@ class APIRequestor:
     ) -> OpenAIResponse:
         if rcode == 503:
             raise error.ServiceUnavailableError(
-                "The server is overloaded or not ready yet.", rbody, rcode, rheaders
+                "The server is overloaded or not ready yet.", rbody, rcode, headers=rheaders
             )
         try:
             if hasattr(rbody, "decode"):
@@ -308,7 +308,7 @@ class APIRequestor:
             data = json.loads(rbody)
         except (JSONDecodeError, UnicodeDecodeError):
             raise error.APIError(
-                f"HTTP code {rcode} from API ({rbody})", rbody, rcode, rheaders
+                f"HTTP code {rcode} from API ({rbody})", rbody, rcode, headers=rheaders
             )
         resp = OpenAIResponse(data, rheaders)
         # In the future, we might add a "status" parameter to errors


### PR DESCRIPTION
These were passed as positional arguments, but in the wrong position, which meant they were passed into [the `json_body` parameter](https://github.com/openai/openai-python/blob/62f8d40ffc6d3a723f5f1d99fee7febfd47026b5/openai/error.py#L10) of the `OpenAIError` constructor.