### PR TITLE
fix(wandb): no results if not succeeded

### DIFF
--- a/openai/wandb_logger.py
+++ b/openai/wandb_logger.py
@@ -101,10 +101,11 @@ class WandbLogger:
         status = fine_tune.get("status")
 
         # check run completed successfully
-        if show_individual_warnings and status != "succeeded":
-            print(
-                f'Fine-tune {fine_tune_id} has the status "{status}" and will not be logged'
-            )
+        if status != "succeeded":
+            if show_individual_warnings:
+                print(
+                    f'Fine-tune {fine_tune_id} has the status "{status}" and will not be logged'
+                )
             return
 
         # check run has not been logged already


### PR DESCRIPTION
Fixes issue where we tried to access a results file even when finetune status was not "succeeded"