### PR TITLE
Remove model param in Completion call

### DIFF
--- a/examples/azure/finetuning.ipynb
+++ b/examples/azure/finetuning.ipynb
@@ -385,7 +385,7 @@
    "source": [
     "print('Sending a test completion job')\n",
     "start_phrase = 'When I go to the store, I want a'\n",
-    "response = openai.Completion.create(engine=deployment_id, model=model, prompt=start_phrase, max_tokens=4)\n",
+    "response = openai.Completion.create(engine=deployment_id, prompt=start_phrase, max_tokens=4)\n",
     "text = response['choices'][0]['text'].replace('\\n', '').replace(' .', '.').strip()\n",
     "print(f'\"{start_phrase} {text}\"')\n"
    ]


### PR DESCRIPTION
The `model` param is not required for Azure, and its presence results in an authentication error.

Removing it enables it to succeed.

Example error:
```
---------------------------------------------------------------------------
AuthenticationError                       Traceback (most recent call last)
<ipython-input-49-6182fea6bc5b> in <module>
      1 print('Sending a test completion job')
      2 start_phrase = 'When I go to the store, I want a'
----> 3 response = openai.Completion.create(engine=deployment_id, model=model, prompt=start_phrase, max_tokens=4)
      4 text = response['choices'][0]['text'].replace('\n', '').replace(' .', '.').strip()
      5 print(f'"{start_phrase} {text}"')

~/miniconda3/envs/gpt/lib/python3.9/site-packages/openai/api_resources/completion.py in create(cls, *args, **kwargs)
     29         while True:
     30             try:
---> 31                 return super().create(*args, **kwargs)
     32             except TryAgain as e:
     33                 if timeout is not None and time.time() > start + timeout:

~/miniconda3/envs/gpt/lib/python3.9/site-packages/openai/api_resources/abstract/engine_api_resource.py in create(cls, api_key, api_base, api_type, request_id, api_version, organization, **params)
     98         )
     99         url = cls.class_url(engine, api_type, api_version)
--> 100         response, _, api_key = requestor.request(
    101             "post",
    102             url,

~/miniconda3/envs/gpt/lib/python3.9/site-packages/openai/api_requestor.py in request(self, method, url, params, headers, files, stream, request_id)
    118             request_id=request_id,
    119         )
--> 120         resp, got_stream = self._interpret_response(result, stream)
    121         return resp, got_stream, self.api_key
    122 

~/miniconda3/envs/gpt/lib/python3.9/site-packages/openai/api_requestor.py in _interpret_response(self, result, stream)
    325         else:
    326             return (
--> 327                 self._interpret_response_line(
    328                     result.content, result.status_code, result.headers, stream=False
    329                 ),

~/miniconda3/envs/gpt/lib/python3.9/site-packages/openai/api_requestor.py in _interpret_response_line(self, rbody, rcode, rheaders, stream)
    358         stream_error = stream and "error" in resp.data
    359         if stream_error or not 200 <= rcode < 300:
--> 360             raise self.handle_error_response(
    361                 rbody, rcode, resp.data, rheaders, stream_error=stream_error
    362             )

AuthenticationError: Incorrect API key provided: dummy-key. You can find your API key at https://beta.openai.com./
```
