### PR TITLE
Fix http reuse connections

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -62,7 +62,9 @@ def parse_stream(rbody):
     for line in rbody:
         if line:
             if line == b"data: [DONE]":
-                return
+                # return here will cause GeneratorExit exception in urllib3
+                # and it will close http connection with TCP Reset
+                continue
             if hasattr(line, "decode"):
                 line = line.decode("utf-8")
             if line.startswith("data: "):


### PR DESCRIPTION
Fix reusing of HTTP Connection
`return` while reading lines will close Generator and cause `GeneratorExit` exception, that will close connection & socket

In this case system will produce TCP RST packet.



Closes https://github.com/openai/openai-python/issues/95