### PR TITLE
Fixed args in refresh_from call in ErrorObject

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -2,7 +2,6 @@ import json
 import platform
 import threading
 import warnings
-from email import header
 from json import JSONDecodeError
 from typing import Dict, Iterator, Optional, Tuple, Union
 from urllib.parse import urlencode, urlsplit, urlunsplit

--- a/openai/api_resources/error_object.py
+++ b/openai/api_resources/error_object.py
@@ -18,5 +18,9 @@ class ErrorObject(OpenAIObject):
         # values here to facilitate generic error handling.
         values = merge_dicts({"message": None, "type": None}, values)
         return super(ErrorObject, self).refresh_from(
-            values, api_key, api_version, organization, response_ms
+            values=values,
+            api_key=api_key,
+            api_version=api_version,
+            organization=organization,
+            response_ms=response_ms,
         )


### PR DESCRIPTION
- [x] 3rd argument in refresh_from is `api_type`. Passing these arguments in order (*args) instead of using keyworded arguments causes setting `api_type` value to `organization` value and `organization` value to `response_ms` value. 
- [x] Removed unused imported module "email"