### PR TITLE
Add api_key parameter to Moderation.create

### DIFF
--- a/openai/api_resources/moderation.py
+++ b/openai/api_resources/moderation.py
@@ -4,20 +4,18 @@ from openai.openai_object import OpenAIObject
 
 
 class Moderation(OpenAIObject):
-    VALID_MODEL_NAMES: List[str] = [
-        "text-moderation-stable", "text-moderation-latest"]
+    VALID_MODEL_NAMES: List[str] = ["text-moderation-stable", "text-moderation-latest"]
 
     @classmethod
     def get_url(self):
         return "/moderations"
 
     @classmethod
-    def create(cls, input: Union[str, List[str]], model: Optional[str] = None,
-               api_key: Optional[str] = None):
+    def create(cls, input: Union[str, List[str]], model: Optional[str] = None, api_key: Optional[str] = None):
         if model is not None and model not in cls.VALID_MODEL_NAMES:
             raise ValueError(
                 f"The parameter model should be chosen from {cls.VALID_MODEL_NAMES} "
-                f"and it is default to be None.",
+                f"and it is default to be None."
             )
 
         instance = cls(api_key=api_key)

--- a/openai/api_resources/moderation.py
+++ b/openai/api_resources/moderation.py
@@ -4,21 +4,23 @@ from openai.openai_object import OpenAIObject
 
 
 class Moderation(OpenAIObject):
-    VALID_MODEL_NAMES: List[str] = ["text-moderation-stable", "text-moderation-latest"]
+    VALID_MODEL_NAMES: List[str] = [
+        "text-moderation-stable", "text-moderation-latest"]
 
     @classmethod
     def get_url(self):
         return "/moderations"
 
     @classmethod
-    def create(cls, input: Union[str, List[str]], model: Optional[str] = None):
+    def create(cls, input: Union[str, List[str]], model: Optional[str] = None,
+               api_key: Optional[str] = None):
         if model is not None and model not in cls.VALID_MODEL_NAMES:
             raise ValueError(
                 f"The parameter model should be chosen from {cls.VALID_MODEL_NAMES} "
-                f"and it is default to be None."
+                f"and it is default to be None.",
             )
 
-        instance = cls()
+        instance = cls(api_key=api_key)
         params = {"input": input}
         if model is not None:
             params["model"] = model


### PR DESCRIPTION
Fixes https://github.com/openai/openai-python/issues/122

This PR enables making moderation endpoint calls without setting API key as environment variable or binding API key to `openai` module globally.