### PR TITLE
Fix KeyError occurring using fine_tunes.prepare_data

### DIFF
--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -40,7 +40,9 @@ def test_long_examples_validator() -> None:
             shell=True
         )
 
-    assert prepared_data_cmd_output.stderr == ""  # validate data was prepared successfully
-    assert "indices of the long examples has changed" in prepared_data_cmd_output.stdout  # validate get_long_indexes() applied during optional_fn() call in long_examples_validator()
+    # validate data was prepared successfully
+    assert prepared_data_cmd_output.stderr == ""  
+    # validate get_long_indexes() applied during optional_fn() call in long_examples_validator()
+    assert "indices of the long examples has changed" in prepared_data_cmd_output.stdout
     
     return prepared_data_cmd_output.stdout

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -3,7 +3,12 @@ import subprocess
 from tempfile import NamedTemporaryFile
 
 
-def test_prepare_data() -> None:
+def test_long_examples_validator() -> None:
+
+    """
+    Ensures that long_examples_validator() handles previously applied recommendations,
+    namely dropped duplicates, without resulting in a KeyError.
+    """
 
     # data
     short_prompt = "a prompt "
@@ -29,13 +34,13 @@ def test_prepare_data() -> None:
             [f"openai tools fine_tunes.prepare_data -f {training_data.name}"], 
             stdout=subprocess.PIPE, 
             text=True, 
-            input="y\ny\ny\ny\ny",  # apply all recommendations, but one at a time
+            input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time
             stderr=subprocess.PIPE,
             encoding="utf-8",
             shell=True
         )
 
-    assert prepared_data_cmd_output.stderr == ""  # validate no errors
+    assert prepared_data_cmd_output.stderr == ""  # validate data was prepared successfully
     assert "indices of the long examples has changed" in prepared_data_cmd_output.stdout  # validate get_long_indexes() applied during optional_fn() call in long_examples_validator()
     
     return prepared_data_cmd_output.stdout

--- a/openai/tests/test_prepare_data.py
+++ b/openai/tests/test_prepare_data.py
@@ -1,0 +1,41 @@
+import json
+import subprocess
+from tempfile import NamedTemporaryFile
+
+
+def test_prepare_data() -> None:
+
+    # data
+    short_prompt = "a prompt "
+    long_prompt = short_prompt * 500
+
+    short_completion = "a completion "
+    long_completion = short_completion * 500
+
+    # the order of these matters
+    unprepared_training_data = [
+        {"prompt": long_prompt, "completion": long_completion},  # 1 of 2 duplicates
+        {"prompt": short_prompt, "completion": short_completion}, 
+        {"prompt": long_prompt, "completion": long_completion},  # 2 of 2 duplicates
+
+    ]
+
+    with NamedTemporaryFile(suffix="jsonl", mode="w") as training_data:
+        for prompt_completion_row in unprepared_training_data:
+            training_data.write(json.dumps(prompt_completion_row) + "\n")
+            training_data.flush()
+    
+        prepared_data_cmd_output = subprocess.run(
+            [f"openai tools fine_tunes.prepare_data -f {training_data.name}"], 
+            stdout=subprocess.PIPE, 
+            text=True, 
+            input="y\ny\ny\ny\ny",  # apply all recommendations, but one at a time
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            shell=True
+        )
+
+    assert prepared_data_cmd_output.stderr == ""  # validate no errors
+    assert "indices of the long examples has changed" in prepared_data_cmd_output.stdout  # validate get_long_indexes() applied during optional_fn() call in long_examples_validator()
+    
+    return prepared_data_cmd_output.stdout

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -166,8 +166,6 @@ def long_examples_validator(df):
 
         long_indexes = get_long_indexes(df)
 
-        print("long_indexes:", long_indexes)
-
         if len(long_indexes) > 0:
             immediate_msg = f"\n- There are {len(long_indexes)} examples that are very long. These are rows: {long_indexes}\nFor conditional generation, and for classification the examples shouldn't be longer than 2048 tokens."
             optional_msg = f"Remove {len(long_indexes)} long examples."

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -162,21 +162,21 @@ def long_examples_validator(df):
             long_examples = d.apply(
                 lambda x: len(x.prompt) + len(x.completion) > 10000, axis=1
             )
-            long_indexes = d.index[long_examples].tolist()
-            return long_indexes
+            return d.reset_index().index[long_examples].tolist()
 
         long_indexes = get_long_indexes(df)
 
+        print("long_indexes:", long_indexes)
+
         if len(long_indexes) > 0:
             immediate_msg = f"\n- There are {len(long_indexes)} examples that are very long. These are rows: {long_indexes}\nFor conditional generation, and for classification the examples shouldn't be longer than 2048 tokens."
-            optional_msg = f"Remove {len(long_indexes)} long examples"
+            optional_msg = f"Remove {len(long_indexes)} long examples."
 
             def optional_fn(x):
                 
                 long_indexes_to_drop = get_long_indexes(x)
                 if long_indexes != long_indexes_to_drop:
-                    print(
-                        f"The indices of the long examples has changed as a result of a previously applied recommendation.\nThe {len(long_indexes_to_drop)} long examples to be dropped are now at the following indices: {long_indexes_to_drop}")
+                    sys.stdout.write(f"The indices of the long examples has changed as a result of a previously applied recommendation.\nThe {len(long_indexes_to_drop)} long examples to be dropped are now at the following indices: {long_indexes_to_drop}\n")
                 return x.drop(long_indexes_to_drop)
 
     return Remediation(

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -128,7 +128,7 @@ def duplicated_rows_validator(df, fields=["prompt", "completion"]):
     This validator will suggest to the user to remove duplicate rows if they exist.
     """
     duplicated_rows = df.duplicated(subset=fields)
-    duplicated_indexes = df.reset_index().index[duplicated_rows].tolist()
+    duplicated_indexes = df.index[duplicated_rows].tolist()
     immediate_msg = None
     optional_msg = None
     optional_fn = None
@@ -158,17 +158,26 @@ def long_examples_validator(df):
 
     ft_type = infer_task_type(df)
     if ft_type != "open-ended generation":
-        long_examples = df.apply(
-            lambda x: len(x.prompt) + len(x.completion) > 10000, axis=1
-        )
-        long_indexes = df.reset_index().index[long_examples].tolist()
+        def find_long_indexes(d):
+            long_examples = d.apply(
+                lambda x: len(x.prompt) + len(x.completion) > 10000, axis=1
+            )
+            long_indexes = d.index[long_examples].tolist()
+            return long_indexes
+
+        long_indexes = find_long_indexes(df)
 
         if len(long_indexes) > 0:
             immediate_msg = f"\n- There are {len(long_indexes)} examples that are very long. These are rows: {long_indexes}\nFor conditional generation, and for classification the examples shouldn't be longer than 2048 tokens."
             optional_msg = f"Remove {len(long_indexes)} long examples"
 
             def optional_fn(x):
-                return x.drop(long_indexes)
+                
+                long_indexes_to_drop = find_long_indexes(x)
+                if long_indexes != long_indexes_to_drop:
+                    print(
+                        f"The indices of the long examples has changed as a result of a previously applied recommendation.\nThe {len(long_indexes_to_drop)} long examples to be dropped are now at the following indices: {long_indexes_to_drop}")
+                return x.drop(long_indexes_to_drop)
 
     return Remediation(
         name="long_examples",

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -158,14 +158,14 @@ def long_examples_validator(df):
 
     ft_type = infer_task_type(df)
     if ft_type != "open-ended generation":
-        def find_long_indexes(d):
+        def get_long_indexes(d):
             long_examples = d.apply(
                 lambda x: len(x.prompt) + len(x.completion) > 10000, axis=1
             )
             long_indexes = d.index[long_examples].tolist()
             return long_indexes
 
-        long_indexes = find_long_indexes(df)
+        long_indexes = get_long_indexes(df)
 
         if len(long_indexes) > 0:
             immediate_msg = f"\n- There are {len(long_indexes)} examples that are very long. These are rows: {long_indexes}\nFor conditional generation, and for classification the examples shouldn't be longer than 2048 tokens."
@@ -173,7 +173,7 @@ def long_examples_validator(df):
 
             def optional_fn(x):
                 
-                long_indexes_to_drop = find_long_indexes(x)
+                long_indexes_to_drop = get_long_indexes(x)
                 if long_indexes != long_indexes_to_drop:
                     print(
                         f"The indices of the long examples has changed as a result of a previously applied recommendation.\nThe {len(long_indexes_to_drop)} long examples to be dropped are now at the following indices: {long_indexes_to_drop}")

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -168,7 +168,7 @@ def long_examples_validator(df):
 
         if len(long_indexes) > 0:
             immediate_msg = f"\n- There are {len(long_indexes)} examples that are very long. These are rows: {long_indexes}\nFor conditional generation, and for classification the examples shouldn't be longer than 2048 tokens."
-            optional_msg = f"Remove {len(long_indexes)} long examples."
+            optional_msg = f"Remove {len(long_indexes)} long examples"
 
             def optional_fn(x):
                 

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -128,7 +128,7 @@ def duplicated_rows_validator(df, fields=["prompt", "completion"]):
     This validator will suggest to the user to remove duplicate rows if they exist.
     """
     duplicated_rows = df.duplicated(subset=fields)
-    duplicated_indexes = df.index[duplicated_rows].tolist()
+    duplicated_indexes = df.reset_index().index[duplicated_rows].tolist()
     immediate_msg = None
     optional_msg = None
     optional_fn = None


### PR DESCRIPTION
### Description
KeyError occurs when running `openai tools fine_tunes.prepare_data -f training_file.jsonl` when `training_file.jsonl` contains a prompt/completion that is BOTH a duplicate and a long example. Without trying to change too much, this fix would:
- wrap the retrieval of `long_examples` and `long_indexes` into a function, calling it preemptively within `long_examples_validator` to provide analysis information about how many rows are long examples, then calling it when actually dropping rows within `optional_fn` and providing info to the user if the keys that are being dropped have changed. 

### Related Issue
Fixes #121 

### Other Notes
I am also happy to provide a file that can be used to reproduce this error.

### Example Output:
When the error would normally occur, instead you would see:
```
❯ openai tools fine_tunes.prepare_data -f training_file_0927.jsonl
Analyzing...
- There are 2 duplicated prompt-completion sets. These are rows: [5, 6]
- There are 2 examples that are very long. These are rows: [3, 6]
Based on the analysis we will perform the following actions:
- [Recommended] Remove 2 duplicate rows [Y/n]: y
- [Recommended] Remove 2 long examples [Y/n]: y
The indices of the long examples has changed as a result of a previously applied recommendation.
The 1 long examples to be dropped are now at the following indices: [3]
- [Recommended] Add a suffix separator ` ->` to all prompts [Y/n]: y 
```