### PR TITLE
Make `numpy` and `pandas` optional for ~7 times smaller deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,23 @@ python setup.py install
 
 ### Optional dependencies
 
-Data libraries including `numpy` and `pandas` are not installed by default due to their size. They’re needed for some functionality of this library, but generally not for talking to the API. If you encounter a `MissingDependencyError`, install them with:
-
-```sh
-pip install openai[datalib]
-````
-
-Dependencies for [`openapi.embeddings_utils`](openai/embeddings_utils.py):
+Install dependencies for [`openapi.embeddings_utils`](openai/embeddings_utils.py):
 
 ```sh
 pip install openai[embeddings]
 ```
 
-Support for [Weights & Biases](https://wandb.me/openai-docs):
+Install support for [Weights & Biases](https://wandb.me/openai-docs):
 
 ```
 pip install openai[wandb]
 ```
 
+Data libraries including `numpy` and `pandas` are not installed by default due to their size. They’re needed for some functionality of this library, but generally not for talking to the API. If you encounter a `MissingDependencyError`, install them with:
+
+```sh
+pip install openai[datalib]
+````
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ Install from source with:
 python setup.py install
 ```
 
+### Optional dependencies
+
+Data libraries including `numpy` and `pandas` are not installed by default due to their size. They’re needed for some functionality of this library, but generally not for talking to the API. If you encounter a `MissingDependencyError`, install them with:
+
+```sh
+pip install openai[datalib]
+````
+
+Dependencies for [`openapi.embeddings_utils`](openai/embeddings_utils.py):
+
+```sh
+pip install openai[embeddings]
+```
+
+Support for [Weights & Biases](https://wandb.me/openai-docs):
+
+```
+pip install openai[wandb]
+```
+
+
 ## Usage
 
 The library needs to be configured with your account's secret key which is available on the [website](https://beta.openai.com/account/api-keys). Either set it as the `OPENAI_API_KEY` environment variable before using the library:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Install support for [Weights & Biases](https://wandb.me/openai-docs):
 pip install openai[wandb]
 ```
 
-Data libraries including `numpy` and `pandas` are not installed by default due to their size. They’re needed for some functionality of this library, but generally not for talking to the API. If you encounter a `MissingDependencyError`, install them with:
+Data libraries like `numpy` and `pandas` are not installed by default due to their size. They’re needed for some functionality of this library, but generally not for talking to the API. If you encounter a `MissingDependencyError`, install them with:
 
 ```sh
 pip install openai[datalib]

--- a/openai/api_resources/embedding.py
+++ b/openai/api_resources/embedding.py
@@ -1,10 +1,10 @@
 import base64
 import time
 
-from openai.datalib import numpy as np, assert_has_numpy
 
 from openai import util
 from openai.api_resources.abstract.engine_api_resource import EngineAPIResource
+from openai.datalib import numpy as np, assert_has_numpy
 from openai.error import TryAgain
 
 

--- a/openai/api_resources/embedding.py
+++ b/openai/api_resources/embedding.py
@@ -1,10 +1,9 @@
 import base64
 import time
 
-import numpy as np
+from openai.datalib import numpy as np, assert_has_numpy
 
 from openai import util
-from openai.api_resources.abstract import DeletableAPIResource, ListableAPIResource
 from openai.api_resources.abstract.engine_api_resource import EngineAPIResource
 from openai.error import TryAgain
 
@@ -40,6 +39,7 @@ class Embedding(EngineAPIResource):
 
                         # If an engine isn't using this optimization, don't do anything
                         if type(data["embedding"]) == str:
+                            assert_has_numpy()
                             data["embedding"] = np.frombuffer(
                                 base64.b64decode(data["embedding"]), dtype="float32"
                             ).tolist()

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -6,8 +6,8 @@ using this library in environments with code size constraints, like AWS Lambda.
 
 This module serves as an import proxy and provides a few utilities for dealing with the optionality.
 
-Since the basic use case of this library (talking to the OpenAI API) doesn’t generally require data libraries,
-it’s safe to make them optional. The rare case when data libraries are needed are handled through assertions
+Since the primary use case of this library (talking to the OpenAI API) doesn’t generally require data libraries,
+it’s safe to make them optional. The rare case when data libraries are needed is handled through assertions
 with instructive error messages.
 
 See also `setup.py`.

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -7,8 +7,8 @@ using this library in environments with code size constraints, like AWS Lambda.
 This module serves as an import proxy and provides a few utilities for dealing with the optionality.
 
 Since the primary use case of this library (talking to the OpenAI API) doesn’t generally require data libraries,
-it’s safe to make them optional. The rare case when data libraries are needed is handled through assertions
-with instructive error messages.
+it’s safe to make them optional. The rare case when data libraries are needed in the client is handled through
+assertions with instructive error messages.
 
 See also `setup.py`.
 

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -1,0 +1,40 @@
+"""
+This module helps make data libraries like `numpy` and `pandas` optional dependencies.
+
+The libraries add up to 100M+, which makes it challenging to deploy applications
+using this library in environments with code size constraints, like AWS Lambda.
+
+This module serves as an import proxy and provides a few utilities for dealing with the optionality.
+
+Since the basic use case of this library (talking to the OpenAI API) doesn’t generally require data libraries,
+it’s safe to make them optional. The rare case when data libraries are needed are handled through assertions
+with instructive error messages.
+
+See also `setup.py`.
+
+"""
+try:
+    import numpy
+except ImportError:
+    numpy = None
+
+try:
+    import pandas
+except ImportError:
+    pandas = None
+
+HAS_NUMPY = bool(numpy)
+HAS_PANDAS = bool(pandas)
+
+NUMPY_INSTRUCTIONS = "numpy is not installed: pip install openai[datalib]"
+PANDAS_INSTRUCTIONS = "pandas is not installed: pip install openai[datalib]"
+
+
+def assert_has_numpy():
+    if not HAS_NUMPY:
+        raise Exception(NUMPY_INSTRUCTIONS)
+
+
+def assert_has_pandas():
+    if not HAS_NUMPY:
+        raise Exception(PANDAS_INSTRUCTIONS)

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -1,7 +1,7 @@
 """
 This module helps make data libraries like `numpy` and `pandas` optional dependencies.
 
-The libraries add up to 130M+, which makes it challenging to deploy applications
+The libraries add up to 130MB+, which makes it challenging to deploy applications
 using this library in environments with code size constraints, like AWS Lambda.
 
 This module serves as an import proxy and provides a few utilities for dealing with the optionality.

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -36,5 +36,5 @@ def assert_has_numpy():
 
 
 def assert_has_pandas():
-    if not HAS_NUMPY:
+    if not HAS_PANDAS:
         raise Exception(PANDAS_INSTRUCTIONS)

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -26,15 +26,31 @@ except ImportError:
 HAS_NUMPY = bool(numpy)
 HAS_PANDAS = bool(pandas)
 
-NUMPY_INSTRUCTIONS = "numpy is not installed: pip install openai[datalib]"
-PANDAS_INSTRUCTIONS = "pandas is not installed: pip install openai[datalib]"
+INSTRUCTIONS = """
+
+OpenAI error: 
+
+    missing `{library}` 
+
+This feature requires additional dependencies:
+
+    $ pip install openai[datalib]
+
+"""
+
+NUMPY_INSTRUCTIONS = INSTRUCTIONS.format(library="numpy")
+PANDAS_INSTRUCTIONS = INSTRUCTIONS.format(library="pandas")
+
+
+class MissingDependencyError(Exception):
+    pass
 
 
 def assert_has_numpy():
     if not HAS_NUMPY:
-        raise Exception(NUMPY_INSTRUCTIONS)
+        raise MissingDependencyError(NUMPY_INSTRUCTIONS)
 
 
 def assert_has_pandas():
     if not HAS_PANDAS:
-        raise Exception(PANDAS_INSTRUCTIONS)
+        raise MissingDependencyError(PANDAS_INSTRUCTIONS)

--- a/openai/datalib.py
+++ b/openai/datalib.py
@@ -1,7 +1,7 @@
 """
 This module helps make data libraries like `numpy` and `pandas` optional dependencies.
 
-The libraries add up to 100M+, which makes it challenging to deploy applications
+The libraries add up to 130M+, which makes it challenging to deploy applications
 using this library in environments with code size constraints, like AWS Lambda.
 
 This module serves as an import proxy and provides a few utilities for dealing with the optionality.

--- a/openai/embeddings_utils.py
+++ b/openai/embeddings_utils.py
@@ -2,8 +2,6 @@ import textwrap as tr
 from typing import List, Optional
 
 import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
 import plotly.express as px
 from scipy import spatial
 from sklearn.decomposition import PCA
@@ -12,6 +10,8 @@ from sklearn.metrics import average_precision_score, precision_recall_curve
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 import openai
+from openai.datalib import numpy as np
+from openai.datalib import pandas as pd
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -2,9 +2,14 @@ import json
 import subprocess
 from tempfile import NamedTemporaryFile
 
+import pytest
 
+from openai.datalib import HAS_PANDAS, HAS_NUMPY, NUMPY_INSTRUCTIONS, PANDAS_INSTRUCTIONS
+
+
+@pytest.mark.skipif(not HAS_PANDAS, reason=PANDAS_INSTRUCTIONS)
+@pytest.mark.skipif(not HAS_NUMPY, reason=NUMPY_INSTRUCTIONS)
 def test_long_examples_validator() -> None:
-
     """
     Ensures that long_examples_validator() handles previously applied recommendations,
     namely dropped duplicates, without resulting in a KeyError.

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import Any, Callable, NamedTuple, Optional
 
-import pandas as pd
+from openai.datalib import pandas as pd, assert_has_pandas
 
 
 class Remediation(NamedTuple):
@@ -474,6 +474,7 @@ def read_any_format(fname, fields=["prompt", "completion"]):
      - for .xlsx it will read the first sheet
      - for .txt it will assume completions and split on newline
     """
+    assert_has_pandas()
     remediation = None
     necessary_msg = None
     immediate_msg = None

--- a/openai/wandb_logger.py
+++ b/openai/wandb_logger.py
@@ -13,10 +13,9 @@ if WANDB_AVAILABLE:
     import re
     from pathlib import Path
 
-    import numpy as np
-    import pandas as pd
-
     from openai import File, FineTune
+    from openai.datalib import numpy as np
+    from openai.datalib import pandas as pd
 
 
 class WandbLogger:

--- a/openai/wandb_logger.py
+++ b/openai/wandb_logger.py
@@ -242,7 +242,9 @@ class WandbLogger:
             type="fine_tune_details",
             metadata=fine_tune,
         )
-        with artifact.new_file("fine_tune_details.json") as f:
+        with artifact.new_file(
+            "fine_tune_details.json", mode="w", encoding="utf-8"
+        ) as f:
             json.dump(fine_tune, f, indent=2)
         wandb.run.log_artifact(
             artifact,
@@ -276,7 +278,7 @@ class WandbLogger:
                 )
                 return
             artifact = wandb.Artifact(artifact_name, type=artifact_type, metadata=file)
-            with artifact.new_file(filename, mode="w") as f:
+            with artifact.new_file(filename, mode="w", encoding="utf-8") as f:
                 f.write(file_content)
 
             # create a Table

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,14 @@ version_path = os.path.join(
 with open(version_path, "rt") as f:
     exec(f.read(), version_contents)
 
+
+# See `openai/datalib.py`.
+DATA_LIBRARIES = [
+    "numpy",
+    "pandas>=1.2.3",  # Needed for CLI fine-tuning data preparation tool
+    "pandas-stubs>=1.1.0.11",  # Needed for type hints for mypy
+]
+
 setup(
     name="openai",
     description="Python client library for the OpenAI API",
@@ -16,21 +24,27 @@ setup(
     install_requires=[
         "requests>=2.20",  # to get the patch for CVE-2018-18074
         "tqdm",  # Needed for progress bars
-        "pandas>=1.2.3",  # Needed for CLI fine-tuning data preparation tool
-        "pandas-stubs>=1.1.0.11",  # Needed for type hints for mypy
         "openpyxl>=3.0.7",  # Needed for CLI fine-tuning data preparation tool xlsx format
-        "numpy",
         "typing_extensions",  # Needed for type hints for mypy
     ],
     extras_require={
-        "dev": ["black~=21.6b0", "pytest==6.*"],
-        "wandb": ["wandb"],
+        "dev": [
+            "black~=21.6b0",
+            "pytest==6.*",
+            "pytest_mock",
+        ],
+        "datalib": DATA_LIBRARIES,
+        "wandb": [
+            "wandb",
+            *DATA_LIBRARIES,
+        ],
         "embeddings": [
             "scikit-learn>=1.0.2",  # Needed for embedding utils, versions >= 1.1 require python 3.8
             "tenacity>=8.0.1",
             "matplotlib",
             "sklearn",
             "plotly",
+            *DATA_LIBRARIES,
         ],
     },
     python_requires=">=3.7.1",

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ DATA_LIBRARIES = [
     "numpy",
     "pandas>=1.2.3",  # Needed for CLI fine-tuning data preparation tool
     "pandas-stubs>=1.1.0.11",  # Needed for type hints for mypy
+    "openpyxl>=3.0.7",  # Needed for CLI fine-tuning data preparation tool xlsx format
 ]
 
 setup(
@@ -24,7 +25,6 @@ setup(
     install_requires=[
         "requests>=2.20",  # to get the patch for CVE-2018-18074
         "tqdm",  # Needed for progress bars
-        "openpyxl>=3.0.7",  # Needed for CLI fine-tuning data preparation tool xlsx format
         "typing_extensions",  # Needed for type hints for mypy
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ with open(version_path, "rt") as f:
     exec(f.read(), version_contents)
 
 
-# See `openai/datalib.py`.
 DATA_LIBRARIES = [
+    # These libraries are optional because of their size. See `openai/datalib.py`.
     "numpy",
     "pandas>=1.2.3",  # Needed for CLI fine-tuning data preparation tool
     "pandas-stubs>=1.1.0.11",  # Needed for type hints for mypy


### PR DESCRIPTION
This PR makes data libraries like `numpy` and `pandas` optional dependencies. These libraries add up to 146MB, which makes it challenging to deploy applications using this library in environments with code size constraints, such as AWS Lambda.

Since the primary use case of this library (talking to the OpenAI API) doesn’t generally require data libraries, it’s safe to make them optional. The rare case when the data libraries are needed in the API client is handled through assertions with instructive error messages. 



## Requirements before

Installing `openai-python` requires the `numpy`, `pandas`, and `openpyxl` data libraries that add up to 146MB:

```bash
$ pip install -e .
$ du -sh $VIRTUAL_ENV/lib/python*/site-packages/
167M	/Users/jakub/.virtualenvs/openai-python/lib/python3.11/site-packages/
```


## Requirements after

Installing `openai-python` doesn’t require the data libraries by default, **resulting in ~7 times smaller aggregate size of dependencies:**

```bash
$ pip install -e .
$ du -sh $VIRTUAL_ENV/lib/python*/site-packages/
23M	/Users/jakub/.virtualenvs/openai-python/lib/python3.11/site-packages/
```

Data libraries can be installed manually using the new `datalib` extras, if needed:

```
$ pip install -e .[datalib]
$ du -sh $VIRTUAL_ENV/lib/python*/site-packages/
167M	/Users/jakub/.virtualenvs/openai-python/lib/python3.11/site-packages/
```

And they are now also included in the existing `embeddings` and `wantdb` extras:

```
$ pip install -e .[embeddings]
$ pip install -e .[wantdb]
```