### PR TITLE
Do not require typing_extensions with Python 3.8+

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -7,7 +7,12 @@ from typing import Dict, Iterator, Optional, Tuple, Union, overload
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 import requests
-from typing_extensions import Literal
+
+# Literal is available from Python 3.8
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import openai
 from openai import error, util, version

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "pandas-stubs>=1.1.0.11",  # Needed for type hints for mypy
         "openpyxl>=3.0.7",  # Needed for CLI fine-tuning data preparation tool xlsx format
         "numpy",
-        "typing_extensions",  # Needed for type hints for mypy
+        'typing_extensions;python_version<"3.8"',  # Needed for type hints for mypy
     ],
     extras_require={
         "dev": ["black~=21.6b0", "pytest==6.*"],


### PR DESCRIPTION
typing_extensions are only used for Literal which is available in the standard library since Python 3.8