### PR TITLE
Include long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,15 @@ version_path = os.path.join(
 )
 with open(version_path, "rt") as f:
     exec(f.read(), version_contents)
+    
+with open("README.md", "r") as fh:
+    long_description = fh.read()
 
 setup(
     name="openai",
     description="Python client library for the OpenAI API",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     version=version_contents["VERSION"],
     install_requires=[
         "requests>=2.20",  # to get the patch for CVE-2018-18074


### PR DESCRIPTION
Currently, there is no 'long' description of the project, i.e., the project page on pypi is empty.

![image](https://user-images.githubusercontent.com/4815944/208649913-3a2ef8e6-ab47-4469-9d78-f9ca62d7b90e.png)

This PR uses the content of the `README.md` as long description.