### PR TITLE
Azure OpenAI 2022-12-01

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All endpoints have a `.create` method that support a `request_timeout` param.  T
 
 ### Microsoft Azure Endpoints
 
-In order to use the library with Microsoft Azure endpoints, you need to set the api_type, api_base and api_version in addition to the api_key. The api_type must be set to 'azure' and the others correspond to the properties of your endpoint.
+In order to use the library with Microsoft Azure endpoints, you need to set the `api_type`, `api_base` and `api_version` in addition to the `api_key`. The `api_type` must be set to 'azure' and the others correspond to the properties of your endpoint.
 In addition, the deployment name must be passed as the engine parameter.
 
 ```python
@@ -66,7 +66,7 @@ import openai
 openai.api_type = "azure"
 openai.api_key = "..."
 openai.api_base = "https://example-endpoint.openai.azure.com"
-openai.api_version = "2021-11-01-preview"
+openai.api_version = "2022-12-01"
 
 # create a completion
 completion = openai.Completion.create(engine="deployment-name", prompt="Hello world")
@@ -74,21 +74,19 @@ completion = openai.Completion.create(engine="deployment-name", prompt="Hello wo
 # print the completion
 print(completion.choices[0].text)
 
-# create a search and pass the deployment-name as the engine Id.
-search = openai.Engine(id="deployment-name").search(documents=["White House", "hospital", "school"], query ="the president")
-
 # print the search
 print(search)
 ```
 
-Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, search and fine-tuning operations.
+Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, embeddings, and fine-tuning operations.
 For a detailed example on how to use fine-tuning and other operations using Azure endpoints, please check out the following Jupyter notebooks:
+* [Using Azure completions](https://github.com/openai/openai-cookbook/tree/main/examples/azure/completions.ipynb)
 * [Using Azure fine-tuning](https://github.com/openai/openai-cookbook/tree/main/examples/azure/finetuning.ipynb)
 * [Using Azure embeddings](https://github.com/openai/openai-cookbook/blob/main/examples/azure/embeddings.ipynb)
 
 ### Microsoft Azure Active Directory Authentication
 
-In order to use Microsoft Active Directory to authenticate to your Azure endpoint, you need to set the api_type to "azure_ad" and pass the acquired credential token to api_key. The rest of the parameters need to be set as specified in the previous section.
+In order to use Microsoft Active Directory to authenticate to your Azure endpoint, you need to set the `api_type` to "azure_ad" and pass the acquired credential token to `api_key`. The rest of the parameters need to be set as specified in the previous section.
 
 
 ```python
@@ -103,7 +101,7 @@ token = default_credential.get_token("https://cognitiveservices.azure.com")
 openai.api_type = "azure_ad"
 openai.api_key = token.token
 openai.api_base = "https://example-endpoint.openai.azure.com/"
-openai.api_version = "2022-03-01-preview"
+openai.api_version = "2022-12-01"
 
 # ...
 ```

--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ completion = openai.Completion.create(engine="deployment-name", prompt="Hello wo
 
 # print the completion
 print(completion.choices[0].text)
-
-# print the search
-print(search)
 ```
 
 Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, embedding, and fine-tuning operations.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ print(completion.choices[0].text)
 print(search)
 ```
 
-Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, embeddings, and fine-tuning operations.
+Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, embedding, and fine-tuning operations.
 For a detailed example on how to use fine-tuning and other operations using Azure endpoints, please check out the following Jupyter notebooks:
 * [Using Azure completions](https://github.com/openai/openai-cookbook/tree/main/examples/azure/completions.ipynb)
 * [Using Azure fine-tuning](https://github.com/openai/openai-cookbook/tree/main/examples/azure/finetuning.ipynb)
@@ -95,7 +95,7 @@ import openai
 
 # Request credential
 default_credential = DefaultAzureCredential()
-token = default_credential.get_token("https://cognitiveservices.azure.com")
+token = default_credential.get_token("https://cognitiveservices.azure.com/.default")
 
 # Setup parameters
 openai.api_type = "azure_ad"

--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -34,7 +34,7 @@ organization = os.environ.get("OPENAI_ORGANIZATION")
 api_base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
 api_type = os.environ.get("OPENAI_API_TYPE", "open_ai")
 api_version = (
-    "2022-03-01-preview" if api_type in ("azure", "azure_ad", "azuread") else None
+    "2022-12-01" if api_type in ("azure", "azure_ad", "azuread") else None
 )
 verify_ssl_certs = True  # No effect. Certificates are always verified.
 proxy = None


### PR DESCRIPTION
* Set default azure `api_version` to `2022-12-01`
* Remove search example from README because search is not longer supported
* Changed token authority (see https://github.com/openai/openai-cookbook/commit/3c334e70ddd3f7b9e63e1136bb583d02bd8127bc)