### PR TITLE
Fix API requestor hanging when not using a global session

### DIFF
--- a/openai/api_resources/file.py
+++ b/openai/api_resources/file.py
@@ -192,16 +192,17 @@ class File(ListableAPIResource, DeletableAPIResource):
             id, api_key, api_base, api_type, api_version, organization
         )
 
-        result = await requestor.arequest_raw("get", url)
-        if not 200 <= result.status < 300:
-            raise requestor.handle_error_response(
-                result.content,
-                result.status,
-                json.loads(cast(bytes, result.content)),
-                result.headers,
-                stream_error=False,
-            )
-        return result.content
+        async with api_requestor.aiohttp_session() as session:
+            result = await requestor.arequest_raw("get", url, session)
+            if not 200 <= result.status < 300:
+                raise requestor.handle_error_response(
+                    result.content,
+                    result.status,
+                    json.loads(cast(bytes, result.content)),
+                    result.headers,
+                    stream_error=False,
+                )
+            return result.content
 
     @classmethod
     def __find_matching_files(cls, name, all_files, purpose):


### PR DESCRIPTION
When a global session wasn't set in `openai.aiosession`, we would create a temp `ClientSession` on the fly. Unfortunately, this session wasn't scoped correctly since it was closed upon returning from `arequest_raw` but `_interpret_async_response` would later call `await result.read()` on the response, which would hang since the backing session had already been closed.

This patch ensures that the session is kept open for the duration of the request *and* the entire parsing of the response.