### PR TITLE
fix: add fallback for step metrics

### DIFF
--- a/openai/wandb_logger.py
+++ b/openai/wandb_logger.py
@@ -159,7 +159,7 @@ class WandbLogger:
         df_results = pd.read_csv(io.StringIO(results))
         for _, row in df_results.iterrows():
             metrics = {k: v for k, v in row.items() if not np.isnan(v)}
-            step = metrics.pop("step")
+            step = metrics.pop("step", None)
             if step is not None:
                 step = int(step)
             wandb.log(metrics, step=step)


### PR DESCRIPTION
Fix for the following error:

```traceback
Traceback (most recent call last):
  File "/Users/me/Desktop/Projects/project/.venv/bin/openai", line 8, in <module>
    sys.exit(main())
  File "/Users/me/Desktop/Projects/project/.venv/lib/python3.10/site-packages/openai/_openai_scripts.py", line 63, in main
    args.func(args)
  File "/Users/me/Desktop/Projects/project/.venv/lib/python3.10/site-packages/openai/cli.py", line 527, in sync
    resp = openai.wandb_logger.WandbLogger.sync(
  File "/Users/me/Desktop/Projects/project/.venv/lib/python3.10/site-packages/openai/wandb_logger.py", line 73, in sync
    fine_tune_logged = [
  File "/Users/me/Desktop/Projects/project/.venv/lib/python3.10/site-packages/openai/wandb_logger.py", line 74, in <listcomp>
    cls._log_fine_tune(
  File "/Users/me/Desktop/Projects/project/.venv/lib/python3.10/site-packages/openai/wandb_logger.py", line 162, in _log_fine_tune
    step = metrics.pop("step")
KeyError: 'step'
```