### PR TITLE
fix(download): Fix download url by reverting change

### DIFF
--- a/openai/api_resources/file.py
+++ b/openai/api_resources/file.py
@@ -138,14 +138,9 @@ class File(ListableAPIResource, DeletableAPIResource):
 
         if typed_api_type in (ApiType.AZURE, ApiType.AZURE_AD):
             base = cls.class_url()
-            url = "/%s%s/%s?api-version=%s" % (
-                cls.azure_api_prefix,
-                base,
-                id,
-                api_version,
-            )
+            url = f"/{cls.azure_api_prefix}{base}/{id}/content?api-version={api_version}"
         elif typed_api_type == ApiType.OPEN_AI:
-            url = "%s/%s" % (cls.class_url(), id)
+            url = f"{cls.class_url()}/{id}/content"
         else:
             raise error.InvalidAPIType("Unsupported API type %s" % api_type)
 


### PR DESCRIPTION
Fixes https://github.com/openai/openai-python/issues/196, and probably https://github.com/openai/openai-python/pull/185 and https://github.com/openai/openai-python/pull/183

This MR reverts the change in https://github.com/openai/openai-python/pull/146/files#r1084884786 so that the requests hit the `/content` url of the api again.


cc @Andrew-Chen-Wang @ddeville 



To reproduce, on the older openai==0.25.0
`
```
openai api fine_tunes.results -i <job_id_here>
```

You'll get the output of the actual CSV file

E.g.

step,elapsed_tokens,elapsed_examples,training_loss,training_sequence_accuracy,training_token_accuracy
1,22048,32,0.011019098009307718,0.0,0.0
1,32288,32,0.007613447834811513,0.0,0.0


On the current openai==0.26.2

You get instead

{
  "object": "file",
  "id": "file-66NnpqAXzw3In27fROPIU03P",
  "purpose": "fine-tune-results",
  "filename": "compiled_results.csv",
  "bytes": 386756,
  "created_at": 1674504271,
  "status": "processed",
  "status_details": null
}
