### PR TITLE
Add license metadata for pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+license = {file = "LICENSE"}
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
 [tool.black]
 target-version = ['py36']
 exclude = '.*\.ipynb'


### PR DESCRIPTION
Add license metadata for pypi.

Please see the documentation at:

https://packaging.python.org/en/latest/specifications/declaring-project-metadata/?highlight=license

Having this would make it easier to use this package in a corporate environment where python package licenses need to be approved.