### PR TITLE
Fix File.find_matching_files()

### DIFF
--- a/openai/api_resources/file.py
+++ b/openai/api_resources/file.py
@@ -198,7 +198,7 @@ class File(ListableAPIResource, DeletableAPIResource):
             return result.content
 
     @classmethod
-    def __find_matching_files(cls, name, all_files, purpose):
+    def __find_matching_files(cls, name, bytes, all_files, purpose):
         matching_files = []
         basename = os.path.basename(name)
         for f in all_files:
@@ -234,7 +234,7 @@ class File(ListableAPIResource, DeletableAPIResource):
             api_version=api_version,
             organization=organization,
         ).get("data", [])
-        return cls.__find_matching_files(name, all_files, purpose)
+        return cls.__find_matching_files(name, bytes, all_files, purpose)
 
     @classmethod
     async def afind_matching_files(
@@ -258,4 +258,4 @@ class File(ListableAPIResource, DeletableAPIResource):
                 organization=organization,
             )
         ).get("data", [])
-        return cls.__find_matching_files(name, all_files, purpose)
+        return cls.__find_matching_files(name, bytes, all_files, purpose)


### PR DESCRIPTION
`File.__find_matching_files()` can't correctly detect matching files because of missing file size info. It compares remote file size with the `bytes` builtin.

Regression: 0abf64137c18b45925d5015bae80429adb46fac6.

This PR adds `bytes` argument to the `File.__find_matching_files()`.

PS: Better to rename `bytes -> bytes_` to not shadow builtin name and prevent such issues in the future.