### PR TITLE
Replace self with cls in classmethods for consistency

### DIFF
--- a/openai/api_resources/customer.py
+++ b/openai/api_resources/customer.py
@@ -3,7 +3,7 @@ from openai.openai_object import OpenAIObject
 
 class Customer(OpenAIObject):
     @classmethod
-    def get_url(self, customer, endpoint):
+    def get_url(cls, customer, endpoint):
         return f"/customer/{customer}/{endpoint}"
 
     @classmethod

--- a/openai/api_resources/moderation.py
+++ b/openai/api_resources/moderation.py
@@ -7,7 +7,7 @@ class Moderation(OpenAIObject):
     VALID_MODEL_NAMES: List[str] = ["text-moderation-stable", "text-moderation-latest"]
 
     @classmethod
-    def get_url(self):
+    def get_url(cls):
         return "/moderations"
 
     @classmethod


### PR DESCRIPTION
This PR updates the code to use "cls" as the first argument for class methods for improved readability and consistency with community conventions.