### PR TITLE
Fixes #184: JSON parsing issue when async streaming

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -96,8 +96,10 @@ def parse_stream_helper(line: bytes) -> Optional[str]:
             # and it will close http connection with TCP Reset
             return None
         if line.startswith(b"data: "):
-            line = line[len(b"data: ") :]
-        return line.decode("utf-8")
+            line = line[len(b"data: "):]
+            return line.decode("utf-8")
+        else:
+            return None
     return None
 
 
@@ -109,13 +111,10 @@ def parse_stream(rbody: Iterator[bytes]) -> Iterator[str]:
 
 
 async def parse_stream_async(rbody: aiohttp.StreamReader):
-    async for chunk, _ in rbody.iter_chunks():
-        # While the `ChunkTupleAsyncStreamIterator` iterator is meant to iterate over chunks (and thus lines) it seems
-        # to still sometimes return multiple lines at a time, so let's split the chunk by lines again.
-        for line in chunk.splitlines():
-            _line = parse_stream_helper(line)
-            if _line is not None:
-                yield _line
+    async for line in rbody:
+        _line = parse_stream_helper(line)
+        if _line is not None:
+            yield _line
 
 
 class APIRequestor:


### PR DESCRIPTION
I was able to reproduce #184 where sometimes calling `Completion.acreate(stream=True)` would result in a JSON parsing issue. 

This was happening because our code was trying to parse incomplete JSON objects. It was receiving chunks that looked like this (notice the incomplete line at the end):

```
data: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": "\\n", "index": 0, "logprobs": null, "finish_details": null}], "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": "Hello", "index": 0, "logprobs": null, "finish_details": null, "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": " again", "index": 0, "logprobs": null, "finish_details": null, "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": "!", "index": 0, "logprobs": null, "finish_details": null, "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": " Is", "index": 0, "logprobs": null, "finish_details": null, "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": " there", "index": 0, "logprobs": null, "finish_details": null, "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "created": 1675757473, "choices": [{"text": " something", "index": 0, "logprobs": null, "finish_details": null, "model": "text-davinci-003"}\n\ndata: {"id": "cmpl-6hDMH0KtbEmSdkAvX4xEHy7be8XMz", "object": "text_completion", "c
```

It looks like we were using the wrong function from `aiohttp` to parse streaming bodies. Instead of `rbody.iter_chunks()` we should be using `async for line in rbody` instead. See docs here: https://docs.aiohttp.org/en/stable/streams.html#asynchronous-iteration-support.

This change immediately fixed the issue in my code.

