### PR TITLE
Fixes for embedding requirements install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,9 +45,9 @@ embeddings =
   scikit-learn >= 1.0.2  # Needed for embedding utils, versions >= 1.1 require python 3.8
   tenacity >= 8.0.1
   matplotlib
-  sklearn
   plotly
   numpy
+  scipy
   pandas >= 1.2.3  # Needed for CLI fine-tuning data preparation tool
   pandas-stubs >= 1.1.0.11  # Needed for type hints for mypy
   openpyxl >= 3.0.7  # Needed for CLI fine-tuning data preparation tool xlsx format


### PR DESCRIPTION
I noticed sklearn is in the install which is deprecated and scikit-learn is already in there as well, and scipy was missing.

This fixes #210 