### PR TITLE
Use kwargs

### DIFF
--- a/openai/api_resources/abstract/api_resource.py
+++ b/openai/api_resources/abstract/api_resource.py
@@ -16,7 +16,7 @@ class APIResource(OpenAIObject):
     def retrieve(
         cls, id, api_key=None, request_id=None, request_timeout=None, **params
     ):
-        instance = cls(id, api_key, **params)
+        instance = cls(id=id, api_key=api_key, **params)
         instance.refresh(request_id=request_id, request_timeout=request_timeout)
         return instance
 
@@ -24,7 +24,7 @@ class APIResource(OpenAIObject):
     def aretrieve(
         cls, id, api_key=None, request_id=None, request_timeout=None, **params
     ):
-        instance = cls(id, api_key, **params)
+        instance = cls(id=id, api_key=api_key, **params)
         return instance.arefresh(request_id=request_id, request_timeout=request_timeout)
 
     def refresh(self, request_id=None, request_timeout=None):


### PR DESCRIPTION
Related to https://github.com/openai/openai-python/issues/231

When Completion is incorrectly used, the error suggests an bug in the codebase:

```
openai.api_key = "openai-key"
id_ = "cmpl-id"
result = openai.Completion.retrieve(id_chat)
# EngineAPIResource.init() takes from 1 to 2 positional arguments but 3 are given
```

With kwargs used, the params are passed correctly and a clearer error is thrown:

```
# InvalidRequestError: Invalid URL (GET /v1/completions/cmpl-id)
```