### PR TITLE
Added helpful error message telling user to use ChatCompletion

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -340,6 +340,10 @@ class APIRequestor:
 
         if "internal_message" in error_data:
             error_data["message"] += "\n\n" + error_data["internal_message"]
+        if "Did you mean to use v1/chat/completions?" in error_data["message"]:
+            error_data["message"] = "Please use ChatCompletion instead of Completion when using the"\
+                                    "'gpt-3.5-turbo' models. For more information see "\
+                                    "https://platform.openai.com/docs/guides/chat/introduction."
 
         util.log_info(
             "OpenAI API error received",

--- a/openai/tests/test_endpoints.py
+++ b/openai/tests/test_endpoints.py
@@ -78,6 +78,13 @@ def test_timeout_raises_error():
             request_timeout=0.01,
         )
 
+def test_calling_turbo_raises_helpful_error():
+    with pytest.raises(error.InvalidRequestError) as excinfo:
+        openai.Completion.create(
+            prompt="test",
+            model="gpt-3.5-turbo",
+        )
+    assert "ChatCompletion" in str(excinfo.value)
 
 def test_timeout_does_not_error():
     # A query that should be fast

--- a/openai/tests/test_endpoints.py
+++ b/openai/tests/test_endpoints.py
@@ -78,7 +78,7 @@ def test_timeout_raises_error():
             request_timeout=0.01,
         )
 
-def test_calling_turbo_raises_helpful_error():
+def test_calling_chat_completion_incorrectly_raises_helpful_error():
     with pytest.raises(error.InvalidRequestError) as excinfo:
         openai.Completion.create(
             prompt="test",


### PR DESCRIPTION
### Problem

Many users (including me) are trying to call the "gpt-3.5-turbo" from the `Completion` class.   See #250.

```
response = openai.Completion.create(
    model="gpt-3.5-turbo",
    prompt="Who won the world series in 2020?",
)
```

Which returns a confusing error message, telling the user to use a different endpoint. 

```
    677         stream_error = stream and "error" in resp.data
    678         if stream_error or not 200 <= rcode < 300:
--> 679             raise self.handle_error_response(
    680                 rbody, rcode, resp.data, rheaders, stream_error=stream_error
    681             )

InvalidRequestError: This is a chat model and not supported in the v1/completions endpoint. Did you mean to use v1/chat/completions?
```

### Proposal

Given this is a library that wraps the API, it'd be more helpful to tell the user to use the `ChatCompletion` class instead.  My pull requests wraps the error and displays the following.
 
```
        stream_error = stream and "error" in resp.data
        if stream_error or not 200 <= rcode < 300:
>           raise self.handle_error_response(
                rbody, rcode, resp.data, rheaders, stream_error=stream_error
            )
E           openai.error.InvalidRequestError: Please use ChatCompletion instead of Completion when using the'gpt-3.5-turbo' models. For more information see https://platform.openai.com/docs/guides/chat/introduction.
```

### Approach
My initial thought was to add some sort of kwarg checking in `Completion` but it looks like this is a lean wrapper class.  Searching further it looks like `handle_error_response` is a good spot to put this since it already does something similar for internal errors.

### Caveats
This approach is fairly tightly coupled to the OpenAI API error response message, I'm not sure how stable these messages are.  With that said if the error message does change, this will not affect any other functionality.