### PR TITLE
Add proxy argument support for openai client

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ openai api chat_completions.create -m gpt-3.5-turbo -g user "Hello world"
 
 # generate images via DALL·E API
 openai api image.create -p "two dogs playing chess, cartoon" -n 1
+
+# using openai through a proxy
+openai --proxy=http://proxy.com api models.list
 ```
 
 ## Example code

--- a/openai/_openai_scripts.py
+++ b/openai/_openai_scripts.py
@@ -25,6 +25,7 @@ def main():
     )
     parser.add_argument("-b", "--api-base", help="What API base url to use.")
     parser.add_argument("-k", "--api-key", help="What API key to use.")
+    parser.add_argument("-p", "--proxy", nargs='+', help="What proxy to use.")
     parser.add_argument(
         "-o",
         "--organization",
@@ -58,6 +59,13 @@ def main():
         openai.api_base = args.api_base
     if args.organization is not None:
         openai.organization = args.organization
+    if args.proxy is not None:
+        openai.proxy = {}
+        for proxy in args.proxy:
+            if proxy.startswith('https'):
+                openai.proxy['https'] = proxy
+            elif proxy.startswith('http'):
+                openai.proxy['http'] = proxy
 
     try:
         args.func(args)


### PR DESCRIPTION
Due to the fact that the openai cli cannot function properly in some poor network environments without a proxy, add a '--proxy' parameter to overcome this difficulty.

v1. support "--proxy" parameter.
v2. give proxy example in README.
v3. supports using multiple "--proxy" parameters.
 