### PR TITLE
CLI: Fix missing max_tokens arg of chat_completions.create

### DIFF
--- a/openai/cli.py
+++ b/openai/cli.py
@@ -126,7 +126,7 @@ class ChatCompletion:
             messages=messages,
             # Optional
             n=args.n,
-            max_tokens=100,
+            max_tokens=args.max_tokens,
             temperature=args.temperature,
             top_p=args.top_p,
             stop=args.stop,


### PR DESCRIPTION
Fix https://github.com/openai/openai-python/issues/283.