### PR TITLE
[Azure] Version '2023-03-15-preview' as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ import openai
 openai.api_type = "azure"
 openai.api_key = "..."
 openai.api_base = "https://example-endpoint.openai.azure.com"
-openai.api_version = "2022-12-01"
+openai.api_version = "2023-03-15-preview"
 
 # create a completion
-completion = openai.Completion.create(engine="deployment-name", prompt="Hello world")
+completion = openai.Completion.create(deployment_id="deployment-name", prompt="Hello world")
 
 # print the completion
 print(completion.choices[0].text)
@@ -116,7 +116,7 @@ token = default_credential.get_token("https://cognitiveservices.azure.com/.defau
 openai.api_type = "azure_ad"
 openai.api_key = token.token
 openai.api_base = "https://example-endpoint.openai.azure.com/"
-openai.api_version = "2022-12-01"
+openai.api_version = "2023-03-15-preview"
 
 # ...
 ```

--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -37,7 +37,7 @@ organization = os.environ.get("OPENAI_ORGANIZATION")
 api_base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
 api_type = os.environ.get("OPENAI_API_TYPE", "open_ai")
 api_version = (
-    "2022-12-01" if api_type in ("azure", "azure_ad", "azuread") else None
+    "2023-03-15-preview" if api_type in ("azure", "azure_ad", "azuread") else None
 )
 verify_ssl_certs = True  # No effect. Certificates are always verified.
 proxy = None


### PR DESCRIPTION
Chat completions on Azure have been released to the public under a preview version '2023-03-15-preview': [Reference](https://techcommunity.microsoft.com/t5/ai-cognitive-services-blog/working-with-gpt-4-and-chatgpt-models-on-azure-preview/ba-p/3773595)

Thus we would like to have this preview version as the default.