### PR TITLE
openai.proxy settings should override env var HTTPS_PROXY

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -521,6 +521,7 @@ class APIRequestor:
                 files=files,
                 stream=stream,
                 timeout=request_timeout if request_timeout else TIMEOUT_SECS,
+                proxies=_thread_context.session.proxies,
             )
         except requests.exceptions.Timeout as e:
             raise error.Timeout("Request timed out: {}".format(e)) from e


### PR DESCRIPTION
By default, the Requests library use the proxy settings from the environment variable HTTPS_PROXY. It has higher priority than the "proxies" setting in the session, which may lead to confusing behaviors if both environment variables and the "openai.proxy" config are set. This patch explicitly informs the Requests library to use the "openai.proxy" config when generating requests.