### PR TITLE
[Fix] Fix audio api methods arguments not being considered

### DIFF
--- a/openai/api_resources/audio.py
+++ b/openai/api_resources/audio.py
@@ -52,7 +52,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, file.name, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            file.name,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("transcriptions")
         response, _, api_key = requestor.request("post", url, files=files, params=data)
         return util.convert_to_openai_object(
@@ -71,7 +81,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, file.name, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            file.name,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("translations")
         response, _, api_key = requestor.request("post", url, files=files, params=data)
         return util.convert_to_openai_object(
@@ -91,7 +111,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, filename, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            filename,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("transcriptions")
         response, _, api_key = requestor.request("post", url, files=files, params=data)
         return util.convert_to_openai_object(
@@ -111,7 +141,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, filename, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            filename,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("translations")
         response, _, api_key = requestor.request("post", url, files=files, params=data)
         return util.convert_to_openai_object(
@@ -130,7 +170,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, file.name, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            file.name,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("transcriptions")
         response, _, api_key = await requestor.arequest(
             "post", url, files=files, params=data
@@ -151,7 +201,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, file.name, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            file.name,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("translations")
         response, _, api_key = await requestor.arequest(
             "post", url, files=files, params=data
@@ -173,7 +233,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, filename, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            filename,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("transcriptions")
         response, _, api_key = await requestor.arequest(
             "post", url, files=files, params=data
@@ -195,7 +265,17 @@ class Audio(APIResource):
         organization=None,
         **params,
     ):
-        requestor, files, data = cls._prepare_request(file, filename, model, **params)
+        requestor, files, data = cls._prepare_request(
+            file,
+            filename,
+            model,
+            api_key,
+            api_base,
+            api_type,
+            api_version,
+            organization,
+            **params,
+        )
         url = cls._get_url("translations")
         response, _, api_key = await requestor.arequest(
             "post", url, files=files, params=data


### PR DESCRIPTION
Methods of Audio package are not passing arguments to `cls.__prepare_request`.

This prevents to override the configuration of the client from the method.

Before:
```python
@classmethod
def transcribe(
    cls,
    model,
    file,
    api_key=None,
    api_base=None,
    api_type=None,
    api_version=None,
    organization=None,
    **params,
):
    requestor, files, data = cls._prepare_request(file, file.name, model, **params)
```

After:
```python
def translate(
    cls,
    model,
    file,
    api_key=None,
    api_base=None,
    api_type=None,
    api_version=None,
    organization=None,
    **params,
):
    requestor, files, data = cls._prepare_request(
        file,
        file.name,
        model,
        api_key,
        api_base,
        api_type,
        api_version,
        organization,
        **params,
    )
```

After this fix you will be able to override for example `api_key` directly calling the method.

```python
openai.Audio.transcribe("whisper-1", file, api_key="my-api-key")
```