### PR TITLE
Handle OpenAIErrors created with 'str' json_body

### DIFF
--- a/openai/error.py
+++ b/openai/error.py
@@ -58,6 +58,7 @@ class OpenAIError(Exception):
     def construct_error_object(self):
         if (
             self.json_body is None
+            or not isinstance(self.json_body, dict)
             or "error" not in self.json_body
             or not isinstance(self.json_body["error"], dict)
         ):


### PR DESCRIPTION
`api_requestor.py` recently started respecting `text/plain` response `Content-Type`s. Azure OpenAI can sometimes return errors with that Content-Type that are still JSON strings with error info, which can break OpenAIErrors default behavior of checking for `error` being `in` the supplied `json_body`. Classic Python, `in` works for `dict` or `str` but `json_body["error"]` will only work if `json_body` is a `dict`.

This is the minimal fix to now throw KeyError and let the unparsed json_body + message bubble up in the OpenAIError.