### PR TITLE
[Azure] CLI: Add support for azure openai chat completion API

### DIFF
--- a/openai/cli.py
+++ b/openai/cli.py
@@ -123,6 +123,7 @@ class ChatCompletion:
         resp = openai.ChatCompletion.create(
             # Required
             model=args.model,
+            engine=args.engine,
             messages=messages,
             # Optional
             n=args.n,
@@ -715,12 +716,6 @@ Mutually exclusive with `top_p`.""",
     opt = sub.add_argument_group("optional arguments")
 
     req.add_argument(
-        "-m",
-        "--model",
-        help="The model to use.",
-        required=True,
-    )
-    req.add_argument(
         "-g",
         "--message",
         action="append",
@@ -729,6 +724,19 @@ Mutually exclusive with `top_p`.""",
         help="A message in `{role} {content}` format. Use this argument multiple times to add multiple messages.",
         required=True,
     )
+
+    group = opt.add_mutually_exclusive_group()
+    group.add_argument(
+        "-e",
+        "--engine",
+        help="The engine to use. See https://learn.microsoft.com/en-us/azure/cognitive-services/openai/chatgpt-quickstart?pivots=programming-language-python for more about what engines are available.",
+    )
+    group.add_argument(
+        "-m",
+        "--model",
+        help="The model to use.",
+    )
+
     opt.add_argument(
         "-n",
         "--n",


### PR DESCRIPTION
The Azure API need to pass parameter `engine`. Follow the pattern `Completion.create` to make `model` optional and add `engine` as a parameter too.

Tested on Azure OpenAI API passed with
```
openapi api chat_completions.create -e chatgpt -g user "hello"
```