### PR TITLE
Align `request_timeout` Behavior in Async and Non-Async APIs

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -562,11 +562,12 @@ class APIRequestor:
         if isinstance(request_timeout, tuple):
             timeout = aiohttp.ClientTimeout(
                 connect=request_timeout[0],
-                total=request_timeout[1],
+                sock_read=request_timeout[1],
             )
         else:
             timeout = aiohttp.ClientTimeout(
-                total=request_timeout if request_timeout else TIMEOUT_SECS
+                connect=request_timeout if request_timeout else TIMEOUT_SECS,
+                sock_read=request_timeout if request_timeout else TIMEOUT_SECS,
             )
 
         if files:


### PR DESCRIPTION
In the non-Async API, the `requests` library is employed. Per the [`requests` library documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts), the `timeout` accepts either a single float value (representing both connect and read timeouts) or a tuple (specifying connect and read timeouts separately).

Conversely, in the Async API, a single float for `request_timeout` represents the total timeout (as documented [here](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout)). When given as a tuple, it corresponds to the connect and total timeouts. This inconsistency exists between the Async and non-Async APIs.

Prior to this pull request, the Async API lacked the ability to set a read timeout as in the non-Async API. This limitation was problematic because:
- A large total timeout value (e.g., 5 minutes) would force users to wait the entire time despite potentially not receiving new messages after the first 5 seconds (a very common issue in the GPT-4 API).
- A small total timeout value (e.g., 15 seconds) might be inadequate for the server to generate a substantial response.

This issue can be remedied by setting the read timeout (i.e., the number of seconds the client waits between bytes received from the server) to a reasonable value like 15 seconds.