### PR TITLE
Pass in keyword arguments in embedding utility functions

### DIFF
--- a/openai/embeddings_utils.py
+++ b/openai/embeddings_utils.py
@@ -15,51 +15,54 @@ from openai.datalib.pandas_helper import pandas as pd
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
-def get_embedding(text: str, engine="text-similarity-davinci-001") -> List[float]:
+def get_embedding(text: str, engine="text-similarity-davinci-001", **kwargs) -> List[float]:
 
     # replace newlines, which can negatively affect performance.
     text = text.replace("\n", " ")
 
-    return openai.Embedding.create(input=[text], engine=engine)["data"][0]["embedding"]
+    print(engine)
+    print(kwargs)
+
+    return openai.Embedding.create(input=[text], engine=engine, **kwargs)["data"][0]["embedding"]
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
 async def aget_embedding(
-    text: str, engine="text-similarity-davinci-001"
+    text: str, engine="text-similarity-davinci-001", **kwargs
 ) -> List[float]:
 
     # replace newlines, which can negatively affect performance.
     text = text.replace("\n", " ")
 
-    return (await openai.Embedding.acreate(input=[text], engine=engine))["data"][0][
+    return (await openai.Embedding.acreate(input=[text], engine=engine, **kwargs))["data"][0][
         "embedding"
     ]
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
 def get_embeddings(
-    list_of_text: List[str], engine="text-similarity-babbage-001"
+    list_of_text: List[str], engine="text-similarity-babbage-001", **kwargs
 ) -> List[List[float]]:
     assert len(list_of_text) <= 2048, "The batch size should not be larger than 2048."
 
     # replace newlines, which can negatively affect performance.
     list_of_text = [text.replace("\n", " ") for text in list_of_text]
 
-    data = openai.Embedding.create(input=list_of_text, engine=engine).data
+    data = openai.Embedding.create(input=list_of_text, engine=engine, **kwargs).data
     data = sorted(data, key=lambda x: x["index"])  # maintain the same order as input.
     return [d["embedding"] for d in data]
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
 async def aget_embeddings(
-    list_of_text: List[str], engine="text-similarity-babbage-001"
+    list_of_text: List[str], engine="text-similarity-babbage-001", **kwargs
 ) -> List[List[float]]:
     assert len(list_of_text) <= 2048, "The batch size should not be larger than 2048."
 
     # replace newlines, which can negatively affect performance.
     list_of_text = [text.replace("\n", " ") for text in list_of_text]
 
-    data = (await openai.Embedding.acreate(input=list_of_text, engine=engine)).data
+    data = (await openai.Embedding.acreate(input=list_of_text, engine=engine, **kwargs)).data
     data = sorted(data, key=lambda x: x["index"])  # maintain the same order as input.
     return [d["embedding"] for d in data]
 

--- a/openai/embeddings_utils.py
+++ b/openai/embeddings_utils.py
@@ -20,9 +20,6 @@ def get_embedding(text: str, engine="text-similarity-davinci-001", **kwargs) -> 
     # replace newlines, which can negatively affect performance.
     text = text.replace("\n", " ")
 
-    print(engine)
-    print(kwargs)
-
     return openai.Embedding.create(input=[text], engine=engine, **kwargs)["data"][0]["embedding"]
 
 


### PR DESCRIPTION
The embedding utility functions currently only accept a minimum number of arguments. If a user needs to specify a few more keywords, that person can no longer use these functions, making them less useful than they could be. An example is shown in #392, in which an extra `request_timeout` argument can help bypass an unresolved bug.

This PR solves this problem by adding `kwargs` to all these utility functions.
