### PR TITLE
Fix test_long_examples_validator

### DIFF
--- a/openai/validators.py
+++ b/openai/validators.py
@@ -423,7 +423,7 @@ def completions_space_start_validator(df):
 
     def add_space_start(x):
         x["completion"] = x["completion"].apply(
-            lambda x: ("" if x[0] == " " else " ") + x
+            lambda x: ("" if x == "" or x[0] == " " else " ") + x
         )
         return x
 

--- a/openai/validators.py
+++ b/openai/validators.py
@@ -423,7 +423,7 @@ def completions_space_start_validator(df):
 
     def add_space_start(x):
         x["completion"] = x["completion"].apply(
-            lambda x: ("" if x == "" or x[0] == " " else " ") + x
+            lambda s: ("" if s.startswith(" ") else " ") + s
         )
         return x
 


### PR DESCRIPTION
Currently `test_long_examples_validator` fails with the following error message:

```
>       assert prepared_data_cmd_output.stderr == ""
E       assert ('Traceback (most recent call last):\n'\n '  File "/Users/lirentu/.pyenv/versions/3.9.11/bin/openai", line 8, in '\n '<module>\n'\n '    sys.exit(main())\n'\n '  File "/Users/lirentu/git/openai-python/openai/_openai_scripts.py", line '\n '78, in main\n'\n '    args.func(args)\n'\n '  File "/Users/lirentu/git/openai-python/openai/cli.py", line 592, in '\n 'prepare_data\n'\n '    apply_validators(\n'\n '  File "/Users/lirentu/git/openai-python/openai/validators.py", line 843, in '\n 'apply_validators\n'\n '    df, optional_applied = apply_optional_remediation(\n'\n '  File "/Users/lirentu/git/openai-python/openai/validators.py", line 611, in '\n 'apply_optional_remediation\n'\n '    df = remediation.optional_fn(df)\n'\n '  File "/Users/lirentu/git/openai-python/openai/validators.py", line 425, in '\n 'add_space_start\n'\n '    x["completion"] = x["completion"].apply(\n'\n '  File '\n '"/Users/lirentu/.pyenv/versions/3.9.11/lib/python3.9/site-packages/pandas/core/series.py", '\n 'line 4433, in apply\n'\n '    return SeriesApply(self, func, convert_dtype, args, kwargs).apply()\n'\n '  File '\n '"/Users/lirentu/.pyenv/versions/3.9.11/lib/python3.9/site-packages/pandas/core/apply.py", '\n 'line 1088, in apply\n'\n '    return self.apply_standard()\n'\n '  File '\n '"/Users/lirentu/.pyenv/versions/3.9.11/lib/python3.9/site-packages/pandas/core/apply.py", '\n 'line 1143, in apply_standard\n'\n '    mapped = lib.map_infer(\n'\n '  File "pandas/_libs/lib.pyx", line 2870, in pandas._libs.lib.map_infer\n'\n '  File "/Users/lirentu/git/openai-python/openai/validators.py", line 426, in '\n '<lambda>\n'\n '    lambda x: ("" if x[0] == " " else " ") + x\n'\n 'IndexError: string index out of range\n') == ''
E         + Traceback (most recent call last):
E         +   File "/Users/lirentu/.pyenv/versions/3.9.11/bin/openai", line 8, in <module>
E         +     sys.exit(main())
E         +   File "/Users/lirentu/git/openai-python/openai/_openai_scripts.py", line 78, in main
E         +     args.func(args)
E         +   File "/Users/lirentu/git/openai-python/openai/cli.py", line 592, in prepare_data
E         +     apply_validators(
E         +   File "/Users/lirentu/git/openai-python/openai/validators.py", line 843, in apply_validators
E         +     df, optional_applied = apply_optional_remediation(
E         +   File "/Users/lirentu/git/openai-python/openai/validators.py", line 611, in apply_optional_remediation
E         +     df = remediation.optional_fn(df)
E         +   File "/Users/lirentu/git/openai-python/openai/validators.py", line 425, in add_space_start
E         +     x["completion"] = x["completion"].apply(
E         +   File "/Users/lirentu/.pyenv/versions/3.9.11/lib/python3.9/site-packages/pandas/core/series.py", line 4433, in apply
E         +     return SeriesApply(self, func, convert_dtype, args, kwargs).apply()
E         +   File "/Users/lirentu/.pyenv/versions/3.9.11/lib/python3.9/site-packages/pandas/core/apply.py", line 1088, in apply
E         +     return self.apply_standard()
E         +   File "/Users/lirentu/.pyenv/versions/3.9.11/lib/python3.9/site-packages/pandas/core/apply.py", line 1143, in apply_standard
E         +     mapped = lib.map_infer(
E         +   File "pandas/_libs/lib.pyx", line 2870, in pandas._libs.lib.map_infer
E         +   File "/Users/lirentu/git/openai-python/openai/validators.py", line 426, in <lambda>
E         +     lambda x: ("" if x[0] == " " else " ") + x
E         + IndexError: string index out of range

openai/tests/test_long_examples_validator.py:50: AssertionError
```

The root cause is that the `x` in the lambda can be an empty string.

This PR fixes this issue by adding an extra check. It assumes that when the string is empty, no extra space is needed.

Such issue can be prevented by adding a CI to run the unit tests automatically. You may want to merge #203. I have also put up a CI PR https://github.com/tuliren/openai-python/pull/1 with all tests passing on my fork, and can re-create the PR against this repo if that's helpful.
