### PR TITLE
fix doc links in chat_completion.py

### DIFF
--- a/openai/api_resources/chat_completion.py
+++ b/openai/api_resources/chat_completion.py
@@ -14,7 +14,7 @@ class ChatCompletion(EngineAPIResource):
         """
         Creates a new chat completion for the provided messages and parameters.
 
-        See https://platform.openai.com/docs/api-reference/chat-completions/create
+        See https://platform.openai.com/docs/api-reference/completions/create
         for a list of valid parameters.
         """
         start = time.time()
@@ -34,7 +34,7 @@ class ChatCompletion(EngineAPIResource):
         """
         Creates a new chat completion for the provided messages and parameters.
 
-        See https://platform.openai.com/docs/api-reference/chat-completions/create
+        See https://platform.openai.com/docs/api-reference/completions/create
         for a list of valid parameters.
         """
         start = time.time()


### PR DESCRIPTION
currently, these docs are broken, as the url has changed from `/chat-completions/` to `/completions/`

⚠️ Broken: https://platform.openai.com/docs/api-reference/chat-completions/create
✅ Working: https://platform.openai.com/docs/api-reference/completions/create
