### PR TITLE
Fix Audio.transcribe() not passing organization

### DIFF
--- a/openai/api_resources/audio.py
+++ b/openai/api_resources/audio.py
@@ -59,6 +59,7 @@ class Audio(APIResource):
             api_key=api_key,
             api_base=api_base,
             api_type=api_type,
+            organization=organization,
             **params,
         )
         url = cls._get_url("transcriptions")


### PR DESCRIPTION
Related to #340

cc @hallacy 