### PR TITLE
allow api_version to be set by environment variable

### DIFF
--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -48,8 +48,9 @@ api_key_path: Optional[str] = os.environ.get("OPENAI_API_KEY_PATH")
 organization = os.environ.get("OPENAI_ORGANIZATION")
 api_base = os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1")
 api_type = os.environ.get("OPENAI_API_TYPE", "open_ai")
-api_version = (
-    "2023-03-15-preview" if api_type in ("azure", "azure_ad", "azuread") else None
+api_version = os.environ.get(
+    "OPENAI_API_VERSION",
+    ("2023-03-15-preview" if api_type in ("azure", "azure_ad", "azuread") else None),
 )
 verify_ssl_certs = True  # No effect. Certificates are always verified.
 proxy = None


### PR DESCRIPTION
Adds the `OPENAI_API_VERSION` environment variable so this can be configured while using the CLI.