### PR TITLE
Allow headers to come back when calling create

### DIFF
--- a/openai/api_resources/abstract/engine_api_resource.py
+++ b/openai/api_resources/abstract/engine_api_resource.py
@@ -133,6 +133,7 @@ class EngineAPIResource(APIResource):
         request_id=None,
         api_version=None,
         organization=None,
+        get_headers=False,
         **params,
     ):
         (
@@ -186,6 +187,9 @@ class EngineAPIResource(APIResource):
 
             if timeout is not None:
                 obj.wait(timeout=timeout or None)
+
+        if (get_headers):
+            return (obj, response._headers)
 
         return obj
 


### PR DESCRIPTION
I have a caching proxy layer and would like to see if there was a cache hit or not by inspecting the headers. 