### PR TITLE
Periodically close open `request.Sessions` to avoid buggy interaction with Docker Desktop

### DIFF
--- a/openai/openai_object.py
+++ b/openai/openai_object.py
@@ -278,7 +278,7 @@ class OpenAIObject(dict):
 
     def __str__(self):
         obj = self.to_dict_recursive()
-        return json.dumps(obj, sort_keys=True, indent=2)
+        return json.dumps(obj, indent=2)
 
     def to_dict(self):
         return dict(self)

--- a/openai/tests/test_util.py
+++ b/openai/tests/test_util.py
@@ -1,3 +1,4 @@
+import json
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -28,3 +29,27 @@ def test_openai_api_key_path_with_malformed_key(api_key_file) -> None:
     api_key_file.flush()
     with pytest.raises(ValueError, match="Malformed API key"):
         util.default_api_key()
+
+
+def test_key_order_openai_object_rendering() -> None:
+    sample_response = {
+        "id": "chatcmpl-7NaPEA6sgX7LnNPyKPbRlsyqLbr5V",
+        "object": "chat.completion",
+        "created": 1685855844,
+        "model": "gpt-3.5-turbo-0301",
+        "usage": {"prompt_tokens": 57, "completion_tokens": 40, "total_tokens": 97},
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "The 2020 World Series was played at Globe Life Field in Arlington, Texas. It was the first time that the World Series was played at a neutral site because of the COVID-19 pandemic.",
+                },
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+    }
+
+    oai_object = util.convert_to_openai_object(sample_response)
+    # The `__str__` method was sorting while dumping to json
+    assert list(json.loads(str(oai_object)).keys()) == list(sample_response.keys())


### PR DESCRIPTION
This PR fixes https://github.com/openai/openai-python/issues/140 by forcing open `Session`s to be closed periodically (every 3 minutes at most). This PR also changes the rendering of API responses to maintain the sorting provided by the backend.