### PR TITLE
Fix support for api_version in Audio.translate

### DIFF
--- a/openai/api_resources/audio.py
+++ b/openai/api_resources/audio.py
@@ -59,6 +59,7 @@ class Audio(APIResource):
             api_key=api_key,
             api_base=api_base,
             api_type=api_type,
+            api_version=api_version,
             **params,
         )
         url = cls._get_url("transcriptions")


### PR DESCRIPTION
Currently `api_version` is not passed to the `_prepare_request` when using `Audio.translate` endpoint. This PR fixes that.