### PR TITLE
Switch to the recommended model (text-embedding-ada-002)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ openai.api_key = "sk-..."  # supply your API key however you choose
 text_string = "sample text"
 
 # choose an embedding
-model_id = "text-similarity-davinci-001"
+model_id = "text-embedding-ada-002"
 
 # compute the embedding of the text
 embedding = openai.Embedding.create(input=text_string, model=model_id)['data'][0]['embedding']

--- a/openai/embeddings_utils.py
+++ b/openai/embeddings_utils.py
@@ -15,7 +15,7 @@ from openai.datalib.pandas_helper import pandas as pd
 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
-def get_embedding(text: str, engine="text-similarity-davinci-001", **kwargs) -> List[float]:
+def get_embedding(text: str, engine="text-embedding-ada-002", **kwargs) -> List[float]:
 
     # replace newlines, which can negatively affect performance.
     text = text.replace("\n", " ")
@@ -25,7 +25,7 @@ def get_embedding(text: str, engine="text-similarity-davinci-001", **kwargs) -> 
 
 @retry(wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
 async def aget_embedding(
-    text: str, engine="text-similarity-davinci-001", **kwargs
+    text: str, engine="text-embedding-ada-002", **kwargs
 ) -> List[float]:
 
     # replace newlines, which can negatively affect performance.


### PR DESCRIPTION
_NOTE: NLP newbie here, happy to take any feedback; have written about my thought-process for this change below._

---

Was looking at the documentation for embedding model in Python. Then, when I had a sample working, the length of the embedding at `12,288` was too long to what the current trend is and made me look into this in a little more detail. Then came across relevant blog posts and documentation based on which I think this is the right change.

Ref: https://openai.com/blog/new-and-improved-embedding-model

> The new model, `text-embedding-ada-002`, replaces five separate models for text search, text similarity, and code search, and outperforms our previous most capable model, Davinci, at most tasks, while being priced 99.8% lower.

Ref: https://platform.openai.com/docs/guides/embeddings/what-are-embeddings

> We recommend using `text-embedding-ada-002` for nearly all use cases. It’s better, cheaper, and simpler to use. Read the [blog post announcement](https://openai.com/blog/new-and-improved-embedding-model).

<img width="1280" alt="Screenshot 2023-06-22 at 11 22 10" src="https://github.com/openai/openai-python/assets/2899501/a5bd0d49-3cd5-4c83-ba1d-9d5bd1c37db7">
