### PR TITLE
Set trust_env=True for aiohttp to repsect http_proxy env vars

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -774,5 +774,6 @@ async def aiohttp_session() -> AsyncIterator[aiohttp.ClientSession]:
     if user_set_session:
         yield user_set_session
     else:
-        async with aiohttp.ClientSession() as session:
+        # Read `http(s)_proxy` environment variables to align with the requests library
+        async with aiohttp.ClientSession(trust_env=True) as session:
             yield session


### PR DESCRIPTION
A simple patch that prevent developers (specially in China) getting confused when switching from sync apis to async apis