### PR TITLE
Preserve Non-ASCII Characters in `print(OpenAIObject)`

### DIFF
--- a/openai/openai_object.py
+++ b/openai/openai_object.py
@@ -278,7 +278,7 @@ class OpenAIObject(dict):
 
     def __str__(self):
         obj = self.to_dict_recursive()
-        return json.dumps(obj, indent=2)
+        return json.dumps(obj, indent=2, ensure_ascii=False)
 
     def to_dict(self):
         return dict(self)


### PR DESCRIPTION
Thank you for this wonderful library.

I propose a tweak to output non-ascii characters as they are in the `OpenAIObject`, rather than converting them to code points.
I believe this will make prompt engineering easier in languages other than English.

### Demo environment

- Python 3.10.9
- openai 0.27.8

### AS IS

```python
>>> import openai
>>> response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Translate 'Hello World' in Japanese."}], temperature=0)
>>> print(response)
{
  "id": "chatcmpl-7UEcHK0KMyGWJcApHYeF3RZZmz78g",
  "object": "chat.completion",
  "created": 1687440381,
  "model": "gpt-3.5-turbo-0301",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "\u3053\u3093\u306b\u3061\u306f\u4e16\u754c (Konnichiwa Sekai)"
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 16,
    "completion_tokens": 12,
    "total_tokens": 28
  }
}
```

I am not sure what is written in "content" when I print the `response`.

### Proposal

```python
>>> import openai
>>> response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Translate 'Hello World' in Japanese."}], temperature=0)
>>> print(response)
{
  "id": "chatcmpl-7UEdDKhNd9EQv8L3f4n9UlaSk4LRQ",
  "object": "chat.completion",
  "created": 1687440439,
  "model": "gpt-3.5-turbo-0301",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "こんにちは世界 (Konnichiwa Sekai)"
      },
      "finish_reason": "stop"
    }
  ],
  "usage": {
    "prompt_tokens": 16,
    "completion_tokens": 12,
    "total_tokens": 28
  }
}
```

"content" is easy to understand! 😃

FYI: The background to proposing this pull request is written in the following blog entry (in Japanese):
https://nikkie-ftnext.hatenablog.com/entry/openai-python-why-response-printed-with-non-ascii-escaped