### PR TITLE
[fix][python] 413: catch AttributeError in handle_error_response

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -401,7 +401,7 @@ class APIRequestor:
     def handle_error_response(self, rbody, rcode, resp, rheaders, stream_error=False):
         try:
             error_data = resp["error"]
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, AttributeError):
             raise error.APIError(
                 "Invalid response object from API: %r (HTTP response code "
                 "was %d)" % (rbody, rcode),


### PR DESCRIPTION
This should provide a graceful fail to #413,

More specifically, I often encouter the following error :
<img width="966" alt="image" src="https://github.com/openai/openai-python/assets/22848576/dd43785d-da9b-4539-b285-dedd4bac9e36">
And because of the python client, I failed to identify the root cause of the error. 

After this fix it would output the original error message no matter what the server side response looks like.

This is just a temporary solution. A complete solution would be letting the client code understand all the possible server error responses.

Let me know if there is anything else to be done. I would like to create a follow up PR, but since I don't know the exact protocol from openai server, is there any hints/docs that can guide me there?

Reviews would be greatly appreciated ~ @3293406747 @Smit-Parmar @hallacy @rachellim @ddeville @BorisPower