### PR TITLE
allow azure openai keys from api_key_path

### DIFF
--- a/openai/tests/test_util.py
+++ b/openai/tests/test_util.py
@@ -30,6 +30,11 @@ def test_openai_api_key_path_with_malformed_key(api_key_file) -> None:
     with pytest.raises(ValueError, match="Malformed API key"):
         util.default_api_key()
 
+def test_openai_api_key_path_with_azure_key(api_key_file) -> None:
+    openai.api_type = "azure"
+    print("key-with-no-sk-prefix", file=api_key_file)
+    api_key_file.flush()
+    assert util.default_api_key() == "key-with-no-sk-prefix"
 
 def test_key_order_openai_object_rendering() -> None:
     sample_response = {

--- a/openai/util.py
+++ b/openai/util.py
@@ -177,7 +177,7 @@ def default_api_key() -> str:
     if openai.api_key_path:
         with open(openai.api_key_path, "rt") as k:
             api_key = k.read().strip()
-            if not api_key.startswith("sk-"):
+            if openai.api_type in ("open_ai", "openai") and not api_key.startswith("sk-"):
                 raise ValueError(f"Malformed API key in {openai.api_key_path}.")
             return api_key
     elif openai.api_key is not None:


### PR DESCRIPTION
Checking for "sk-" prefix prevents providing an Azure API key or token in the `api_key_path` file. Update to check `api_type` first, so we can enable this and maintain the behavior of checking for a malformed key (in the openai case).