### PR TITLE
Fix NameError when running example code from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ openai.api_version = "2023-05-15"
 chat_completion = openai.ChatCompletion.create(deployment_id="deployment-name", model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
 
 # print the completion
-print(completion.choices[0].message.content)
+print(chat_completion.choices[0].message.content)
 ```
 
 Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, embedding, and fine-tuning operations.


### PR DESCRIPTION
Replace the variable `completion` with `chat_completion` to fix the NameError.