### PR TITLE
fix: `assert_has_numpy` before using `np.from_buffer`

### DIFF
--- a/openai/api_resources/embedding.py
+++ b/openai/api_resources/embedding.py
@@ -79,6 +79,7 @@ class Embedding(EngineAPIResource):
 
                         # If an engine isn't using this optimization, don't do anything
                         if type(data["embedding"]) == str:
+                            assert_has_numpy()
                             data["embedding"] = np.frombuffer(
                                 base64.b64decode(data["embedding"]), dtype="float32"
                             ).tolist()


### PR DESCRIPTION
it seems `Embeddings.acreate` should call `assert_has_numpy` before attempting to use `np.frombuffer`, as is done on L42 of `Embeddings.create` [here](https://github.com/openai/openai-python/blob/main/openai/api_resources/embedding.py#L42)

I encountered the following on 3.11, `openai==0.27.8` using `Embeddings.acreate` in an env where `numpy` was not installed:
```
File ~/src/open-source/marvin/src/marvin/utilities/embeddings.py:11, in create_openai_embeddings(texts)
      8 async def create_openai_embeddings(texts: List[str]) -> List[List[float]]:
      9     """Create OpenAI embeddings for a list of texts."""
---> 11     embeddings = await openai.Embedding.acreate(
     12         input=[text.replace("\n", " ") for text in texts],
     13         engine=marvin.settings.embedding_engine,
     14     )
     16     return [
     17         r["embedding"] for r in sorted(embeddings["data"], key=lambda x: x["index"])
     18     ]

File ~/micromamba/envs/marvin/lib/python3.11/site-packages/openai/api_resources/embedding.py:82, in Embedding.acreate(cls, *args, **kwargs)
     78         for data in response.data:
     79
     80             # If an engine isn't using this optimization, don't do anything
     81             if type(data["embedding"]) == str:
---> 82                 data["embedding"] = np.frombuffer(
     83                     base64.b64decode(data["embedding"]), dtype="float32"
     84                 ).tolist()
     86     return response
     87 except TryAgain as e:

AttributeError: 'NoneType' object has no attribute 'frombuffer'
```

which appears to be because the "helper" is setting the module to `None` like
```python
try:
    import numpy
except ImportError:
    numpy = None
```

calling `assert_has_numpy` before attempting to use `np.frombuffer` in `acreate` raises a more helpful error
```python
File ~/micromamba/envs/marvin/lib/python3.11/site-packages/openai/api_resources/embedding.py:82, in Embedding.acreate(cls, *args, **kwargs)
     78     for data in response.data:
     79
     80         # If an engine isn't using this optimization, don't do anything
     81         if type(data["embedding"]) == str:
---> 82             assert_has_numpy()
     83             data["embedding"] = np.frombuffer(
     84                 base64.b64decode(data["embedding"]), dtype="float32"
     85             ).tolist()
     87 return response

File ~/micromamba/envs/marvin/lib/python3.11/site-packages/openai/datalib/numpy_helper.py:15, in assert_has_numpy()
     13 def assert_has_numpy():
     14     if not HAS_NUMPY:
---> 15         raise MissingDependencyError(NUMPY_INSTRUCTIONS)

MissingDependencyError:

OpenAI error:

    missing `numpy`

This feature requires additional dependencies:

    $ pip install openai[datalib]
```