### PR TITLE
Lazy import pandas

### DIFF
--- a/openai/datalib/common.py
+++ b/openai/datalib/common.py
@@ -15,3 +15,6 @@ NUMPY_INSTRUCTIONS = INSTRUCTIONS.format(library="numpy")
 
 class MissingDependencyError(Exception):
     pass
+
+class DependencyUnchecked():
+    ...

--- a/openai/datalib/pandas_helper.py
+++ b/openai/datalib/pandas_helper.py
@@ -1,15 +1,21 @@
-from openai.datalib.common import INSTRUCTIONS, MissingDependencyError
+from openai.datalib.common import INSTRUCTIONS, MissingDependencyError, DependencyUnchecked
 
-try:
-    import pandas
-except ImportError:
-    pandas = None
 
-HAS_PANDAS = bool(pandas)
+pandas = DependencyUnchecked()
+HAS_PANDAS = False
 
 PANDAS_INSTRUCTIONS = INSTRUCTIONS.format(library="pandas")
 
 
 def assert_has_pandas():
+    global pandas, HAS_PANDAS
+    if isinstance(pandas, DependencyUnchecked):
+        try:
+            import pandas as pd
+            pandas = pd
+        except ImportError:
+            pandas = None
+        HAS_PANDAS = bool(pandas)
+
     if not HAS_PANDAS:
         raise MissingDependencyError(PANDAS_INSTRUCTIONS)


### PR DESCRIPTION
Fixes https://github.com/openai/openai-python/issues/525

Results from code Code snippets in issue
```
0.3406072079669684 <openai.datalib.common.DependencyUnchecked object at 0x100f66500>
6.4803954580565915 <module 'pandas' from '/Users/pedrovicente/.virtualenvs/openai-python-uihn/lib/python3.10/site-packages/pandas/__init__.py'>
1.459033228456974e-06 <module 'pandas' from '/Users/pedrovicente/.virtualenvs/openai-python-uihn/lib/python3.10/site-packages/pandas/__init__.py'>
```

See import time now takes 0.3s