### PR TITLE
Fix unit tests for Windows

### DIFF
--- a/openai/tests/test_file_cli.py
+++ b/openai/tests/test_file_cli.py
@@ -8,7 +8,7 @@ STILL_PROCESSING = "File is still processing. Check back later."
 
 def test_file_cli(tmp_path: Path) -> None:
     contents = json.dumps({"prompt": "1 + 3 =", "completion": "4"}) + "\n"
-    train_file = tmp_path / "example.jsonl"
+    train_file = tmp_path / "data.jsonl"
     train_file.write_bytes(contents.encode("utf-8"))
     create_output = subprocess.check_output(
         ["openai", "api", "files.create", "-f", train_file, "-p", "fine-tune"]
@@ -26,7 +26,7 @@ def test_file_cli(tmp_path: Path) -> None:
             ["openai", "api", "files.delete", "-i", file_id],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            encoding="utf-8",
+            text=True,
         )
         if delete_result.returncode == 0:
             break

--- a/openai/tests/test_file_cli.py
+++ b/openai/tests/test_file_cli.py
@@ -11,7 +11,7 @@ def test_file_cli(tmp_path: Path) -> None:
     train_file = tmp_path / "data.jsonl"
     train_file.write_bytes(contents.encode("utf-8"))
     create_output = subprocess.check_output(
-        ["openai", "api", "files.create", "-f", train_file, "-p", "fine-tune"]
+        ["openai", "api", "files.create", "-f", str(train_file), "-p", "fine-tune"]
     )
 
     file_obj = json.loads(create_output)

--- a/openai/tests/test_file_cli.py
+++ b/openai/tests/test_file_cli.py
@@ -13,10 +13,13 @@ def test_file_cli(tmp_path: Path) -> None:
     create_output = subprocess.check_output(
         ["openai", "api", "files.create", "-f", train_file, "-p", "fine-tune"]
     )
+
     file_obj = json.loads(create_output)
     assert file_obj["bytes"] == len(contents)
+
     file_id: str = file_obj["id"]
     assert file_id.startswith("file-")
+
     start_time = time.time()
     while True:
         delete_result = subprocess.run(

--- a/openai/tests/test_file_cli.py
+++ b/openai/tests/test_file_cli.py
@@ -1,19 +1,18 @@
 import json
 import subprocess
 import time
-from tempfile import NamedTemporaryFile
+from pathlib import Path
 
 STILL_PROCESSING = "File is still processing. Check back later."
 
 
-def test_file_cli() -> None:
+def test_file_cli(tmp_path: Path) -> None:
     contents = json.dumps({"prompt": "1 + 3 =", "completion": "4"}) + "\n"
-    with NamedTemporaryFile(suffix=".jsonl", mode="wb") as train_file:
-        train_file.write(contents.encode("utf-8"))
-        train_file.flush()
-        create_output = subprocess.check_output(
-            ["openai", "api", "files.create", "-f", train_file.name, "-p", "fine-tune"]
-        )
+    train_file = tmp_path / "example.jsonl"
+    train_file.write_bytes(contents.encode("utf-8"))
+    create_output = subprocess.check_output(
+        ["openai", "api", "files.create", "-f", train_file, "-p", "fine-tune"]
+    )
     file_obj = json.loads(create_output)
     assert file_obj["bytes"] == len(contents)
     file_id: str = file_obj["id"]

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -42,7 +42,6 @@ def test_long_examples_validator(tmp_path: Path) -> None:
         text=True,
         input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time
         stderr=subprocess.PIPE,
-        encoding="utf-8",
     )
 
     # validate data was prepared successfully

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -30,18 +30,18 @@ def test_long_examples_validator(tmp_path: Path) -> None:
         {"prompt": long_prompt, "completion": long_completion},  # 2 of 2 duplicates
     ]
 
-    training_data = tmp_path / "data.jsonl"
-    print(training_data)  # show the full path to the temporary file
-    with open(training_data, mode="w") as file:
+    train_file = tmp_path / "data.jsonl"
+    print(train_file)  # show the full path to the temporary file
+    with open(train_file, mode="w", encoding="utf-8") as file:
         for prompt_completion_row in unprepared_training_data:
             print(json.dumps(prompt_completion_row), file=file)
 
     prepared_data_cmd_output = subprocess.run(
-        ["openai", "tools", "fine_tunes.prepare_data", "-f", training_data],
+        ["openai", "tools", "fine_tunes.prepare_data", "-f", train_file],
         stdout=subprocess.PIPE,
-        text=True,
-        input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time
         stderr=subprocess.PIPE,
+        input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time
+        text=True,
     )
 
     # validate data was prepared successfully

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -37,7 +37,7 @@ def test_long_examples_validator(tmp_path: Path) -> None:
             print(json.dumps(prompt_completion_row), file=file)
 
     prepared_data_cmd_output = subprocess.run(
-        ["openai", "tools", "fine_tunes.prepare_data", "-f", train_file],
+        ["openai", "tools", "fine_tunes.prepare_data", "-f", str(train_file)],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -37,7 +37,7 @@ def test_long_examples_validator() -> None:
             training_data.flush()
 
         prepared_data_cmd_output = subprocess.run(
-            [f"openai tools fine_tunes.prepare_data -f {training_data.name}"],
+            f"openai tools fine_tunes.prepare_data -f {training_data.name}",
             stdout=subprocess.PIPE,
             text=True,
             input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time

--- a/openai/tests/test_long_examples_validator.py
+++ b/openai/tests/test_long_examples_validator.py
@@ -37,13 +37,12 @@ def test_long_examples_validator() -> None:
             training_data.flush()
 
         prepared_data_cmd_output = subprocess.run(
-            f"openai tools fine_tunes.prepare_data -f {training_data.name}",
+            ["openai", "tools", "fine_tunes.prepare_data", "-f", training_data.name],
             stdout=subprocess.PIPE,
             text=True,
             input="y\ny\ny\ny\ny",  # apply all recommendations, one at a time
             stderr=subprocess.PIPE,
             encoding="utf-8",
-            shell=True,
         )
 
     # validate data was prepared successfully

--- a/openai/tests/test_util.py
+++ b/openai/tests/test_util.py
@@ -15,12 +15,12 @@ def api_key_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> Path:
 
 
 def test_openai_api_key_path(api_key_file: Path) -> None:
-    api_key_file.write_text("sk-foo\n")
+    api_key_file.write_text("sk-foo\n", encoding="utf-8")
     assert util.default_api_key() == "sk-foo"
 
 
 def test_openai_api_key_path_with_malformed_key(api_key_file: Path) -> None:
-    api_key_file.write_text("malformed-api-key\n")
+    api_key_file.write_text("malformed-api-key\n", encoding="utf-8")
     with pytest.raises(ValueError, match="Malformed API key"):
         util.default_api_key()
 

--- a/openai/tests/test_util.py
+++ b/openai/tests/test_util.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 from pytest import MonkeyPatch
 
-import openai
 from openai import util
 
 


### PR DESCRIPTION
Fixes #536

This fixes the four unit tests that were inadvertently incompatible with Windows, so that they now work on all systems, by:

1. **Using the [`tmp_path`](https://docs.pytest.org/en/6.2.x/tmpdir.html#the-tmp-path-fixture) pytest fixture instead of `NamedTemporaryFile`.** It is possible to fix this while still using `NamedTempoaryFile`, but doing so involves suppressing automatic deletion, manually closing the file, and then taking care of deletion. In contrast, `tmp_path` works on all systems and, in pytest tests, it is a more idiomatic way to deal with temporary files. It does work differently, creating a directory inside which one creates whatever files are desired, but this turned out to work just as well for expressing the test logic (in my opinion).

   In one of the places where I made this change, I also replaced manual monkey patching with the [`monkeypatch`](https://docs.pytest.org/en/6.2.x/monkeypatch.html) pytest fixture. I did this because the combination of those two changes allowed the code to be simplified (otherwise it might have become more complicated).

3. **Passing a list of separate arguments to `subprocess.run` and not using `shell=True`.** Other approaches, like passing a string instead of a list and keeping `shell=True`, also work. But this way is more similar to the other uses of `subprocess` functions in this project's unit tests.

4. **Having `subprocess.run` use the default system encoding for child processes' standard streams**, when accessing them in text mode. Because the child processes are also Python--they are scripts provided by this project--their stdin, stdout, and stderr automatically use the system's default encoding, as detected by Python. Therefore, while omitting `encoding="utf-8"` in a call to *any* function that accepts it *feels* wrong, it fixes the problem here and I believe is more robust.

   Of course, that is only for `subprocess.run`. Accessing named files on disk should generally specify `encoding="utf-8"`, which I have not removed (and I added it in a couple places where it was missing).

This only modifies test code; other code is unchanged. I've checked that no new `mypy` or `black --check` warnings are introduced.

I have tried to take care to avoid creating new incompatibilities, either with Windows or other operating systems. One thing I've done to avoid that is to make a number of small, self-contained changes in separate commits, and to describe each. (In one case, I did temporarily introduce a new incompatibility, due to https://github.com/python/cpython/issues/85919. A subsequent commit fixes it.) I assume this is okay, because pull requests in this project are usually merged using "squash and merge." However, I'd be pleased to make any requested changes (including abridging commit messages if necessary). Maintainers can also push changes to my branch.

The other thing I've done to avoid introducing new problems is to test these changes on all 15 combinations of supported Python version (3.7, 3.8, 3.9, 3.10, 3.11) and major supported operating system (Ubuntu and macOS to check that I wasn't breaking them, and Windows to make sure this really does fix the incompatibilities without introducing new ones). I tested Windows and Ubuntu, with all five Python versions, both locally and on CI, and macOS just on CI. I used a CI workflow based on @tuliren's workflow at https://github.com/tuliren/openai-python/pull/1, with Windows and macOS platforms added (and a few other changes). With #535 unfixed, [tests fail, but in the correct and expected way](https://github.com/EliahKagan/openai-python/actions/runs/5539654470/jobs/10110825488). With #535 fixed (see #406), [all tests pass on all operating systems](https://github.com/EliahKagan/openai-python/actions/runs/5539646070/jobs/10110806674).

Please note that this PR does *not* itself address #535, which is *conceptually* unrelated to the changes here. I just needed to test it in both ways to make sure I was really making the tests compatible with Windows, in the case of `test_long_examples_validator`.