### PR TITLE
Add custom backend type

### DIFF
--- a/openai/api_resources/abstract/engine_api_resource.py
+++ b/openai/api_resources/abstract/engine_api_resource.py
@@ -24,6 +24,7 @@ class EngineAPIResource(APIResource):
         engine: Optional[str] = None,
         api_type: Optional[str] = None,
         api_version: Optional[str] = None,
+        backend_url: Optional[str] = None,
     ):
         # Namespaces are separated in object names with periods (.) and in URLs
         # with forward slashes (/), so replace the former with the latter.
@@ -56,6 +57,14 @@ class EngineAPIResource(APIResource):
 
             extn = quote_plus(engine)
             return "/engines/%s/%s" % (extn, base)
+
+        elif typed_api_type == ApiType.CUSTOM:
+            if backend_url is None:
+                raise error.InvalidRequestError(
+                    "You must provide the `backend_url` parameter for a custom backend type"
+                )
+
+            return backend_url
 
         else:
             raise error.InvalidAPIType("Unsupported API type %s" % api_type)
@@ -110,7 +119,7 @@ class EngineAPIResource(APIResource):
             api_version=api_version,
             organization=organization,
         )
-        url = cls.class_url(engine, api_type, api_version)
+        url = cls.class_url(engine, api_type, api_version, backend_url=params.pop("backend_url", None))
         return (
             deployment_id,
             engine,


### PR DESCRIPTION
Fixes #547 

This allows the usage such as:

```python
import os
import requests
import json
import openai

openai.api_base = "https://my-custom-api-url"
openai.api_type = 'custom'

response = openai.ChatCompletion.create(
    engine="custom",
    messages=[
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "Does Azure OpenAI support customer managed keys?"},
    ],
    headers={
        "X-My-Custom-Authentication-Header": "some_value"
    },
    backend_url='/request_path_where_the_openai_model/responds' # appended to openai.api_base
)

print(response)
print(response['choices'][0]['message']['content'])
```