### PR TITLE
Fix: SSE Stream parser expects additional space after colon "data:"

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -98,16 +98,18 @@ def _make_session() -> requests.Session:
 
 
 def parse_stream_helper(line: bytes) -> Optional[str]:
-    if line:
-        if line.strip() == b"data: [DONE]":
+    if line and line.startswith(b"data:"):
+        if line.startswith(b"data: "):
+            # SSE event may be valid when it contains leading whitespace
+            line = line[len(b"data: "):]
+        else:
+            line = line[len(b"data:"):]
+        if line.strip() in b"[DONE]":
             # return here will cause GeneratorExit exception in urllib3
             # and it will close http connection with TCP Reset
             return None
-        if line.startswith(b"data: "):
-            line = line[len(b"data: "):]
-            return line.decode("utf-8")
         else:
-            return None
+            return line.decode("utf-8")
     return None
 
 

--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -100,11 +100,11 @@ def _make_session() -> requests.Session:
 def parse_stream_helper(line: bytes) -> Optional[str]:
     if line and line.startswith(b"data:"):
         if line.startswith(b"data: "):
-            # SSE event may be valid when it contains leading whitespace
+            # SSE event may be valid when it contain whitespace
             line = line[len(b"data: "):]
         else:
             line = line[len(b"data:"):]
-        if line.strip() in b"[DONE]":
+        if line.strip() == b"[DONE]":
             # return here will cause GeneratorExit exception in urllib3
             # and it will close http connection with TCP Reset
             return None


### PR DESCRIPTION
This commit updates the SSE parser to handle cases where there is an optional space after the "data:" prefix. Described in detail here - https://github.com/openai/openai-python/issues/498

To address this, I modified the parser code to use the startswith method and then strip any leading or trailing whitespaces from the line. This ensures that the parser can handle both cases where there is a space after "data:" and where there isn't. The modified code now correctly decodes the line as UTF-8 and returns the parsed data.

This change improves compatibility with different SSE implementations and ensures that the parser functions correctly in various scenarios. It provides a more flexible solution that aligns with the SSE specification and accommodates libraries like springframework that omit the space after "data:".

Fixes https://github.com/openai/openai-python/issues/498