### PR TITLE
Add  the param "verify" to support choose if SSL verify on ChatCompletion.create

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -228,6 +228,7 @@ class APIRequestor:
         stream: Literal[True],
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[Iterator[OpenAIResponse], bool, str]:
         pass
 
@@ -243,6 +244,7 @@ class APIRequestor:
         stream: Literal[True],
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[Iterator[OpenAIResponse], bool, str]:
         pass
 
@@ -257,6 +259,7 @@ class APIRequestor:
         stream: Literal[False] = ...,
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[OpenAIResponse, bool, str]:
         pass
 
@@ -271,6 +274,7 @@ class APIRequestor:
         stream: bool = ...,
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[Union[OpenAIResponse, Iterator[OpenAIResponse]], bool, str]:
         pass
 
@@ -284,6 +288,7 @@ class APIRequestor:
         stream: bool = False,
         request_id: Optional[str] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+        verify: Optional[bool] = ...,
     ) -> Tuple[Union[OpenAIResponse, Iterator[OpenAIResponse]], bool, str]:
         result = self.request_raw(
             method.lower(),
@@ -294,6 +299,7 @@ class APIRequestor:
             stream=stream,
             request_id=request_id,
             request_timeout=request_timeout,
+            verify=verify,
         )
         resp, got_stream = self._interpret_response(result, stream)
         return resp, got_stream, self.api_key
@@ -309,6 +315,7 @@ class APIRequestor:
         stream: Literal[True],
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[AsyncGenerator[OpenAIResponse, None], bool, str]:
         pass
 
@@ -324,6 +331,7 @@ class APIRequestor:
         stream: Literal[True],
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[AsyncGenerator[OpenAIResponse, None], bool, str]:
         pass
 
@@ -338,6 +346,7 @@ class APIRequestor:
         stream: Literal[False] = ...,
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[OpenAIResponse, bool, str]:
         pass
 
@@ -352,6 +361,7 @@ class APIRequestor:
         stream: bool = ...,
         request_id: Optional[str] = ...,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = ...,
+        verify: Optional[bool] = ...,
     ) -> Tuple[Union[OpenAIResponse, AsyncGenerator[OpenAIResponse, None]], bool, str]:
         pass
 
@@ -365,6 +375,7 @@ class APIRequestor:
         stream: bool = False,
         request_id: Optional[str] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+        verify: Optional[bool] = None,
     ) -> Tuple[Union[OpenAIResponse, AsyncGenerator[OpenAIResponse, None]], bool, str]:
         ctx = aiohttp_session()
         session = await ctx.__aenter__()
@@ -378,6 +389,7 @@ class APIRequestor:
                 files=files,
                 request_id=request_id,
                 request_timeout=request_timeout,
+                verify=verify,
             )
             resp, got_stream = await self._interpret_async_response(result, stream)
         except Exception:
@@ -577,6 +589,7 @@ class APIRequestor:
         stream: bool = False,
         request_id: Optional[str] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+        verify: Optional[bool] = None,
     ) -> requests.Response:
         abs_url, headers, data = self._prepare_request_raw(
             url, supplied_headers, method, params, files, request_id
@@ -602,6 +615,7 @@ class APIRequestor:
                 stream=stream,
                 timeout=request_timeout if request_timeout else TIMEOUT_SECS,
                 proxies=_thread_context.session.proxies,
+                verify=verify,
             )
         except requests.exceptions.Timeout as e:
             raise error.Timeout("Request timed out: {}".format(e)) from e
@@ -634,6 +648,7 @@ class APIRequestor:
         files=None,
         request_id: Optional[str] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+        verify: Optional[Union[bool, str]] = None,
     ) -> aiohttp.ClientResponse:
         abs_url, headers, data = self._prepare_request_raw(
             url, supplied_headers, method, params, files, request_id
@@ -663,6 +678,7 @@ class APIRequestor:
             "data": data,
             "proxy": _aiohttp_proxies_arg(openai.proxy),
             "timeout": timeout,
+            "verify": verify,
         }
         try:
             result = await session.request(**request_kwargs)

--- a/openai/api_resources/abstract/engine_api_resource.py
+++ b/openai/api_resources/abstract/engine_api_resource.py
@@ -163,7 +163,7 @@ class EngineAPIResource(APIResource):
             request_timeout=request_timeout,
             verify=verify,
         )
-        
+
         if stream:
             # must be an iterator
             assert not isinstance(response, OpenAIResponse)

--- a/openai/api_resources/abstract/engine_api_resource.py
+++ b/openai/api_resources/abstract/engine_api_resource.py
@@ -77,6 +77,7 @@ class EngineAPIResource(APIResource):
         stream = params.get("stream", False)
         headers = params.pop("headers", None)
         request_timeout = params.pop("request_timeout", None)
+        verify = params.pop("verify", None)
         typed_api_type = cls._get_api_type_and_version(api_type=api_type)[0]
         if typed_api_type in (util.ApiType.AZURE, util.ApiType.AZURE_AD):
             if deployment_id is None and engine is None:
@@ -121,6 +122,7 @@ class EngineAPIResource(APIResource):
             typed_api_type,
             requestor,
             url,
+            verify,
             params,
         )
 
@@ -145,6 +147,7 @@ class EngineAPIResource(APIResource):
             typed_api_type,
             requestor,
             url,
+            verify,
             params,
         ) = cls.__prepare_create_request(
             api_key, api_base, api_type, api_version, organization, **params
@@ -158,8 +161,9 @@ class EngineAPIResource(APIResource):
             stream=stream,
             request_id=request_id,
             request_timeout=request_timeout,
+            verify=verify,
         )
-
+        
         if stream:
             # must be an iterator
             assert not isinstance(response, OpenAIResponse)
@@ -210,6 +214,7 @@ class EngineAPIResource(APIResource):
             typed_api_type,
             requestor,
             url,
+            verify,
             params,
         ) = cls.__prepare_create_request(
             api_key, api_base, api_type, api_version, organization, **params
@@ -222,6 +227,7 @@ class EngineAPIResource(APIResource):
             stream=stream,
             request_id=request_id,
             request_timeout=request_timeout,
+            verify=verify,
         )
 
         if stream:


### PR DESCRIPTION
This  commit is relate to   https://github.com/openai/openai-python/issues/561  

This submission is to enable ChatCompletion.create to choose whether to perform SSL verification on its own. Now the default value for this parameter is None, which is consistent with the default value for “verify”  in the requests module. Through this submission, when you want to ignore SSL verification, you can directly specify verify=False in the create method to avoid it.

the "verify" param in  requests.request
![image](https://github.com/openai/openai-python/assets/23066239/688dcd33-5c1d-4658-bf44-3b8915feab60)


my  key change  point 
<img width="995" alt="image" src="https://github.com/openai/openai-python/assets/23066239/607518e7-0483-4e0b-94e3-2cfe06018acb">

