### PR TITLE
Upadte READE.md,chatml.md  (replace some invalid link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ pre-defined set of classes for API resources that initialize
 themselves dynamically from API responses which makes it compatible
 with a wide range of versions of the OpenAI API.
 
-You can find usage examples for the OpenAI Python library in our [API reference](https://beta.openai.com/docs/api-reference?lang=python) and the [OpenAI Cookbook](https://github.com/openai/openai-cookbook/).
+You can find usage examples for the OpenAI Python library in our [API reference](https://platform.openai.com/docs/api-reference?lang=python) and the [OpenAI Cookbook](https://github.com/openai/openai-cookbook/).
 
 ## Installation
 
@@ -31,7 +31,7 @@ Install dependencies for [`openai.embeddings_utils`](openai/embeddings_utils.py)
 pip install openai[embeddings]
 ```
 
-Install support for [Weights & Biases](https://wandb.me/openai-docs):
+Install support for [Weights & Biases](https://docs.wandb.ai/guides/integrations/openai?utm_source=wandb_docs&utm_medium=code&utm_campaign=OpenAI+API):
 
 ```
 pip install openai[wandb]
@@ -96,8 +96,8 @@ print(completion.choices[0].message.content)
 Please note that for the moment, the Microsoft Azure endpoints can only be used for completion, embedding, and fine-tuning operations.
 For a detailed example of how to use fine-tuning and other operations using Azure endpoints, please check out the following Jupyter notebooks:
 
-- [Using Azure completions](https://github.com/openai/openai-cookbook/tree/main/examples/azure/completions.ipynb)
-- [Using Azure fine-tuning](https://github.com/openai/openai-cookbook/tree/main/examples/azure/finetuning.ipynb)
+- [Using Azure completions](https://github.com/openai/openai-cookbook/blob/main/examples/azure/completions.ipynb)
+- [Using Azure functions](https://github.com/openai/openai-cookbook/blob/main/examples/azure/functions.ipynb)
 - [Using Azure embeddings](https://github.com/openai/openai-cookbook/blob/main/examples/azure/embeddings.ipynb)
 
 ### Microsoft Azure Active Directory Authentication
@@ -229,17 +229,17 @@ Examples of fine-tuning are shared in the following Jupyter notebooks:
   - [Step 2: Creating a synthetic Q&A dataset](https://github.com/openai/openai-cookbook/blob/main/examples/fine-tuned_qa/olympics-2-create-qa.ipynb)
   - [Step 3: Train a fine-tuning model specialized for Q&A](https://github.com/openai/openai-cookbook/blob/main/examples/fine-tuned_qa/olympics-3-train-qa.ipynb)
 
-Sync your fine-tunes to [Weights & Biases](https://wandb.me/openai-docs) to track experiments, models, and datasets in your central dashboard with:
+Sync your fine-tunes to [Weights & Biases](https://docs.wandb.ai/guides/integrations/openai?utm_source=wandb_docs&utm_medium=code&utm_campaign=OpenAI+API) to track experiments, models, and datasets in your central dashboard with:
 
 ```bash
 openai wandb sync
 ```
 
-For more information on fine-tuning, read the [fine-tuning guide](https://beta.openai.com/docs/guides/fine-tuning) in the OpenAI documentation.
+For more information on fine-tuning, read the [fine-tuning guide](https://platform.openai.com/docs/guides/fine-tuning) in the OpenAI documentation.
 
 ### Moderation
 
-OpenAI provides a Moderation endpoint that can be used to check whether content complies with the OpenAI [content policy](https://platform.openai.com/docs/usage-policies)
+OpenAI provides a Moderation endpoint that can be used to check whether content complies with the OpenAI [content policy](https://openai.com/policies/usage-policies)
 
 ```python
 import openai

--- a/chatml.md
+++ b/chatml.md
@@ -1,6 +1,6 @@
 (This document is a preview of the underlying format consumed by
 ChatGPT models. As a developer, you can use our [higher-level
-API](https://platform.openai.com/docs/guides/chat) and won't need to
+API](https://platform.openai.com/docs/guides/gpt/chat-completions-api) and won't need to
 interact directly with this format today — but expect to have the
 option in the future!)
 


### PR DESCRIPTION
Hi, Dear maintainers in openai.
 When I read the Readme.md  ，I find that  there  has some link has been invalid ,maybe not found or redirect to other link.
For example,
![image](https://github.com/openai/openai-python/assets/23066239/75b1000d-ba3f-4562-afad-d42d23f8108a)

In addition, I also found that an ipynb file was no longer found. And the newly added files in the corresponding directory have not been updated to readme.md
![image](https://github.com/openai/openai-python/assets/23066239/1a50797d-4dc5-4070-85dd-694731abe507)
![image](https://github.com/openai/openai-python/assets/23066239/8a349703-eb37-4d31-95d5-1ad14e30cb7c)
![image](https://github.com/openai/openai-python/assets/23066239/19061e0b-9284-4a95-a88e-ab81e3432b9d)

So I submitted this MR and hope to correct these links.

