### PR TITLE
🐛 fixed asyncio streaming bugs

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -6,11 +6,10 @@ import sys
 import threading
 import time
 import warnings
-from contextlib import asynccontextmanager
 from json import JSONDecodeError
 from typing import (
+    AsyncContextManager,
     AsyncGenerator,
-    AsyncIterator,
     Callable,
     Dict,
     Iterator,
@@ -366,8 +365,9 @@ class APIRequestor:
         request_id: Optional[str] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
     ) -> Tuple[Union[OpenAIResponse, AsyncGenerator[OpenAIResponse, None]], bool, str]:
-        ctx = aiohttp_session()
+        ctx = AioHTTPSession()
         session = await ctx.__aenter__()
+        result = None
         try:
             result = await self.arequest_raw(
                 method.lower(),
@@ -381,6 +381,9 @@ class APIRequestor:
             )
             resp, got_stream = await self._interpret_async_response(result, stream)
         except Exception:
+            # Close the request before exiting session context.
+            if result is not None:
+                result.release()
             await ctx.__aexit__(None, None, None)
             raise
         if got_stream:
@@ -391,10 +394,15 @@ class APIRequestor:
                     async for r in resp:
                         yield r
                 finally:
+                    # Close the request before exiting session context. Important to do it here
+                    # as if stream is not fully exhausted, we need to close the request nevertheless.
+                    result.release()
                     await ctx.__aexit__(None, None, None)
 
             return wrap_resp(), got_stream, self.api_key
         else:
+            # Close the request before exiting session context.
+            result.release()
             await ctx.__aexit__(None, None, None)
             return resp, got_stream, self.api_key
 
@@ -768,11 +776,22 @@ class APIRequestor:
         return resp
 
 
-@asynccontextmanager
-async def aiohttp_session() -> AsyncIterator[aiohttp.ClientSession]:
-    user_set_session = openai.aiosession.get()
-    if user_set_session:
-        yield user_set_session
-    else:
-        async with aiohttp.ClientSession() as session:
-            yield session
+class AioHTTPSession(AsyncContextManager):
+    def __init__(self):
+        self._session = None
+        self._should_close_session = False
+
+    async def __aenter__(self):
+        self._session = openai.aiosession.get()
+        if self._session is None:
+            self._session = await aiohttp.ClientSession().__aenter__()
+            self._should_close_session = True
+
+        return self._session
+    
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        if self._session is None:
+            raise RuntimeError("Session is not initialized")
+
+        if self._should_close_session:
+            await self._session.__aexit__(exc_type, exc_value, traceback)


### PR DESCRIPTION
# This PR fixes two problems with current library.

## Not closing responses
Currently the `aiohttp.ClientResponse` objects are never closed, which might be problem for long-running sessions, with streaming. Since users might not consume the whole stream, the request object is never released and the hope is that the session close will release it. However it's possible to supply a long-running session which is not closed when the request ends. I thus added a code which will release/close the responses.
Relates issues: https://github.com/openai/openai-python/issues/570

## Problematic session managements
The aiohttp.session management is done using `@asynccontextmanager` (see https://github.com/openai/openai-python/blob/main/openai/api_requestor.py#L771-L778) . This is problematic because it creates an async generator. Let's see why.  Given the following code:

```
import asyncio
import os
from langchain.chat_models import ChatOpenAI
import openai
async def run():
    response = await openai.ChatCompletion.acreate(
        model='gpt-3.5-turbo',
        messages=[
            {'role': 'user', 'content': 'Count to 100, with a comma between each number and no newlines. E.g., 1, 2, 3, ...'}
        ],
        temperature=0,
        stream=True  # again, we set stream=True
    )

    async for x in response:
        break


asyncio.run(run(), debug=True)
```

We will a receive an error:
`RuntimeError: aclose(): asynchronous generator is already running.`


This happens when we have a async generator which is being iterated over using `async for` (More precisely when we are awaiting `generator.__anext__`) and at the same time we are trying to close the generator (More precisely when we try to await at the same time `generator.__anext__`). 

But where it happens ?
First at the code will create a completion which will create the `aiohttp_session` (session generator) and at the same time will create another generator at https://github.com/openai/openai-python/blob/main/openai/api_requestor.py#L386-L399 (response generator), which will be then returned by the completion. We then iterate one time over the response generator and then stop, without closing the generator. The event loop then ends. When we have an event-loop and the event-loop ends, all the async-generators which didn't end are finalized/closed in `loop.shutdown_asyncgens()`. This means that both of the above generators will be finialized at the same time!!! The response generator then call __anext__ on session generator (throught `ctx.__aexit__`) and at the same time the session generator is being finalized which results in the error.

I thus rewrote the `aiohttp_session`, to be the real context manager, which will not have this problem.
Related issue: https://github.com/openai/openai-python/issues/503

Let me know what you think ;)
PS: It was incredibly painful to debug it hhhhhh