### PR TITLE
Add Testing to the Makefile and Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,8 @@ upload:
 	python -m pip install twine
 	python -m twine upload dist/openai-*
 	rm -rf dist
+
+test:
+	python -m pip install -e .
+	python -m pip install pytest pytest-mock aiohttp pytest-asyncio
+	python -m pytest openai/tests/

--- a/openai/api_resources/completion.py
+++ b/openai/api_resources/completion.py
@@ -1,7 +1,6 @@
 import time
 
 from openai import util
-from openai.api_resources.abstract import DeletableAPIResource, ListableAPIResource
 from openai.api_resources.abstract.engine_api_resource import EngineAPIResource
 from openai.error import TryAgain
 


### PR DESCRIPTION
This PR includes:

-  Additions to the the `MakeFile` to include methods for testing. 
-  Minor clleaned up some un-used imports in `ChatCompletion`. 