### PR TITLE
Updated finetune.delete example with ft model instead of job

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ openai.FineTuningJob.cancel("ft-abc123")
 openai.FineTuningJob.list_events(id="ft-abc123", limit=10)
 
 # Delete a fine-tuned model (must be an owner of the org the model was created in)
-openai.Model.delete("ft-abc123")
+openai.Model.delete("ft:gpt-3.5-turbo:my-org:custom_suffix:id")
 ```
 
 For more information on fine-tuning, read the [fine-tuning guide](https://platform.openai.com/docs/guides/fine-tuning) in the OpenAI documentation.


### PR DESCRIPTION
Update openai.finetune.delete with apt fine-tune model name instead of fine-tune job ID resolves #596 