### PR TITLE
Support arbitrary extra keyword arguments in requests.

### DIFF
--- a/openai/__init__.py
+++ b/openai/__init__.py
@@ -56,6 +56,12 @@ api_version = os.environ.get(
 verify_ssl_certs = True  # No effect. Certificates are always verified.
 proxy = None
 app_info = None
+# Extra keyword arguments to pass to
+# https://requests.readthedocs.io/en/latest/api/#requests.Session.request
+request_extra_kwargs = {}
+# Extra keyword arguments to pass to
+# https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientSession.request
+arequest_extra_kwargs = {}
 enable_telemetry = False  # Ignored; the telemetry feature was removed.
 ca_bundle_path = None  # No longer used, feature was removed
 debug = False

--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -602,6 +602,7 @@ class APIRequestor:
                 stream=stream,
                 timeout=request_timeout if request_timeout else TIMEOUT_SECS,
                 proxies=_thread_context.session.proxies,
+                **openai.request_extra_kwargs,
             )
         except requests.exceptions.Timeout as e:
             raise error.Timeout("Request timed out: {}".format(e)) from e
@@ -663,6 +664,7 @@ class APIRequestor:
             "data": data,
             "proxy": _aiohttp_proxies_arg(openai.proxy),
             "timeout": timeout,
+            **openai.arequest_extra_args,
         }
         try:
             result = await session.request(**request_kwargs)


### PR DESCRIPTION
Hi! I'm working on a project that requires proxied access to OpenAI APIs. For that to work correctly, we need to customize both the `auth` and `verify` arguments in (synchronous) requests, which isn't possible with the current client library.

This pull request introduces a fairly general mechanism to pass arbitrary extra keyword arguments in requests. Since synchronous and asynchronous requests use different libraries under the hood (requests vs aiohttp), they have separate sets of arguments. For the project I'm working on we'd do something like:

```python
openai.request_extra_kwargs = {
  'auth': ...,
  'verify': ...,
}
```

An alternative to this is to provide the same API to customize `auth` and `verify` for both synchronous and asynchronou requests. However, the API of requests and aiohttp are quite different, so I'd like to propose this simpler alternative first.

This is similar to #562, but is more general and uses module-level variables - the idea is that a certain user will use the same set of extra arguments for all OpenAI requests, in much the same way as they may customize `openai.api_base` for all their OpenAI requests.

This fixes #561.

Thanks!