### PR TITLE
fix use 'message' in APIError on non-specific Azure Server Error

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -400,8 +400,8 @@ class APIRequestor:
 
     def handle_error_response(self, rbody, rcode, resp, rheaders, stream_error=False):
         try:
-            error_data = resp["error"]
-        except (KeyError, TypeError):
+            error_data = resp["error"] if resp.get("error") else resp
+        except TypeError:
             raise error.APIError(
                 "Invalid response object from API: %r (HTTP response code "
                 "was %d)" % (rbody, rcode),


### PR DESCRIPTION
Fixes #609

Azure OpenAI intermittently returns a message payload on generic server errors, which is not technically an "invalid response object" just one that currently isn't handled. All access to `error_data` is through `.get`, so as long as the catch on TypeError (i.e. string) is present, the subsequent logic will make a best attempt at categorizing the error