### PR TITLE
Image create request timeout

### DIFF
--- a/openai/api_resources/image.py
+++ b/openai/api_resources/image.py
@@ -1,5 +1,5 @@
 # WARNING: This interface is considered experimental and may changed in the future without warning.
-from typing import Any, List
+from typing import Any, List, Optional, Union, Tuple
 
 import openai
 from openai import api_requestor, error, util
@@ -24,6 +24,7 @@ class Image(APIResource):
         api_type=None,
         api_version=None,
         organization=None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
         **params,
     ):
         requestor = api_requestor.APIRequestor(
@@ -37,7 +38,8 @@ class Image(APIResource):
         api_type, api_version = cls._get_api_type_and_version(api_type, api_version)
 
         response, _, api_key = requestor.request(
-            "post", cls._get_url("generations", azure_action="submit", api_type=api_type, api_version=api_version), params
+            "post", cls._get_url("generations", azure_action="submit", api_type=api_type, api_version=api_version),
+            params, request_timeout=request_timeout
         )
 
         if api_type in (util.ApiType.AZURE, util.ApiType.AZURE_AD):
@@ -60,6 +62,7 @@ class Image(APIResource):
         api_type=None,
         api_version=None,
         organization=None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
         **params,
     ):
 
@@ -74,7 +77,8 @@ class Image(APIResource):
         api_type, api_version = cls._get_api_type_and_version(api_type, api_version)
 
         response, _, api_key = await requestor.arequest(
-            "post", cls._get_url("generations", azure_action="submit", api_type=api_type, api_version=api_version), params
+            "post", cls._get_url("generations", azure_action="submit", api_type=api_type, api_version=api_version),
+            params, request_timeout=request_timeout
         )
 
         if api_type in (util.ApiType.AZURE, util.ApiType.AZURE_AD):


### PR DESCRIPTION
### Description:
It's currently not possible to pass `request_timeout` to `Image.create`, which prevents setting request timeouts. 

### Reference:
@raiyanyahya has raised this as a concern in #221 

According to [requests#Timeouts](https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts)
> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely.

However, this library has set the default as [600 seconds](https://github.com/openai/openai-python/blob/e389823ba013a24b4c32ce38fa0bd87e6bccae94/openai/api_requestor.py#L37), which is not practical for many use cases.


### User impact: 
Occasionally the Image.create API call can stall for 600s, which could be a long time to a user to wait before retrying. By allowing the user to set a reasonable request_timeout, we can retry sooner.

### Usage:

Example usage:

    import openai
    prompt="A picture of a soda can"
    n=1
    size="512x512"
    # Timeout in seconds
    request_timeout=30
    openai.Image.create(prompt=prompt, n=n, size=size, request_timeout=request_timeout)

Example connect/read timeout usage:

```
connect_timeout = 3.0 # Timeout to establish connection
read_timeout = 30.0 # Timeout to receive response
request_timeout = (connect_timeout, read_timeout)
openai.Image.create(prompt=prompt, n=n, size=size, request_timeout=request_timeout)
```

Example async usage: 

    import asyncio
    # ...
    asyncio.run(openai.Image.acreate(prompt=prompt, n=n, size=size, request_timeout=request_timeout))

