### PR TITLE
Allow Unicode characters to be displayed in the printed OpenAIObject

### DIFF
--- a/openai/openai_object.py
+++ b/openai/openai_object.py
@@ -278,7 +278,7 @@ class OpenAIObject(dict):
 
     def __str__(self):
         obj = self.to_dict_recursive()
-        return json.dumps(obj, indent=2)
+        return json.dumps(obj, indent=2, ensure_ascii=False)
 
     def to_dict(self):
         return dict(self)


### PR DESCRIPTION
If OpenAIObject contains Unicode characters (cyrillic letters or emojis for example), they are printed as Unicode codes.  
Before:
```python
{
  ...
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "\u041f\u0440\u0438\u0432\u0456\u0442! \ud83d\udc4b \u042f \u0440\u0430\u0434\u0438\u0439 \u0442\u043e\u0431\u0456 \u0434\u043e\u043f\u043e\u043c\u043e\u0433\u0442\u0438! \ud83d\ude0a \u0427\u0438\u043c \u044f \u043c\u043e\u0436\u0443 \u0442\u043e\u0431\u0456 \u0434\u043e\u043f\u043e\u043c\u043e\u0433\u0442\u0438 \u0441\u044c\u043e\u0433\u043e\u0434\u043d\u0456? \ud83e\udd14\ud83d\udd0d"
      },
      "finish_reason": "stop"
    }
  ],
  ...
}
```
This makes it more difficult to experiment while exploring the API as well as logging the responses in production. The solution is to set `ensure_ascii` to `False`
After:
```python
{
...
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Привіт! 👋 Я радий тобі допомогти! 😊 Чим я можу тобі допомогти сьогодні? 🤔🔍"
      },
      "finish_reason": "stop"
    }
  ],
...
}
```