### PR TITLE
Mark requirements for testing Python versions 3.7-3.11 using tox, prepare for testing Python 3.12

### DIFF
--- a/openai/tests/asyncio/test_endpoints.py
+++ b/openai/tests/asyncio/test_endpoints.py
@@ -11,6 +11,7 @@ pytestmark = [pytest.mark.asyncio]
 
 
 # FILE TESTS
+@pytest.mark.integration
 async def test_file_upload():
     result = await openai.File.acreate(
         file=io.StringIO(
@@ -25,7 +26,8 @@ async def test_file_upload():
     assert result.status == "uploaded"
 
 
-# COMPLETION TESTS
+# COMPLETION TEST
+@pytest.mark.integration
 async def test_completions():
     result = await openai.Completion.acreate(
         prompt="This was a test", n=5, engine="ada"
@@ -33,6 +35,7 @@ async def test_completions():
     assert len(result.choices) == 5
 
 
+@pytest.mark.integration
 async def test_completions_multiple_prompts():
     result = await openai.Completion.acreate(
         prompt=["This was a test", "This was another test"], n=5, engine="ada"
@@ -40,12 +43,14 @@ async def test_completions_multiple_prompts():
     assert len(result.choices) == 10
 
 
+@pytest.mark.integration
 async def test_completions_model():
     result = await openai.Completion.acreate(prompt="This was a test", n=5, model="ada")
     assert len(result.choices) == 5
     assert result.model.startswith("ada")
 
 
+@pytest.mark.integration
 async def test_timeout_raises_error():
     # A query that should take awhile to return
     with pytest.raises(error.Timeout):
@@ -58,6 +63,7 @@ async def test_timeout_raises_error():
         )
 
 
+@pytest.mark.integration
 async def test_timeout_does_not_error():
     # A query that should be fast
     await openai.Completion.acreate(
@@ -67,6 +73,7 @@ async def test_timeout_does_not_error():
     )
 
 
+@pytest.mark.integration
 async def test_completions_stream_finishes_global_session():
     async with ClientSession() as session:
         openai.aiosession.set(session)
@@ -80,6 +87,7 @@ async def test_completions_stream_finishes_global_session():
         assert len(parts) > 1
 
 
+@pytest.mark.integration
 async def test_completions_stream_finishes_local_session():
     # A query that should be fast
     parts = []

--- a/openai/tests/test_api_requestor.py
+++ b/openai/tests/test_api_requestor.py
@@ -8,6 +8,7 @@ from openai import Model
 from openai.api_requestor import APIRequestor
 
 
+@pytest.mark.integration
 @pytest.mark.requestor
 def test_requestor_sets_request_id(mocker: MockerFixture) -> None:
     # Fake out 'requests' and confirm that the X-Request-Id header is set.
@@ -69,6 +70,7 @@ def test_requestor_azure_ad_headers() -> None:
     assert headers["Authorization"] == "Bearer test_key"
 
 
+@pytest.mark.integration
 @pytest.mark.requestor
 def test_requestor_cycle_sessions(mocker: MockerFixture) -> None:
     # HACK: we need to purge the _thread_context to not interfere

--- a/openai/tests/test_endpoints.py
+++ b/openai/tests/test_endpoints.py
@@ -9,6 +9,7 @@ from openai import error
 
 
 # FILE TESTS
+@pytest.mark.integration
 def test_file_upload():
     result = openai.File.create(
         file=io.StringIO(
@@ -24,6 +25,7 @@ def test_file_upload():
 
 
 # CHAT COMPLETION TESTS
+@pytest.mark.integration
 def test_chat_completions():
     result = openai.ChatCompletion.create(
         model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello!"}]
@@ -31,6 +33,7 @@ def test_chat_completions():
     assert len(result.choices) == 1
 
 
+@pytest.mark.integration
 def test_chat_completions_multiple():
     result = openai.ChatCompletion.create(
         model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello!"}], n=5
@@ -38,6 +41,7 @@ def test_chat_completions_multiple():
     assert len(result.choices) == 5
 
 
+@pytest.mark.integration
 def test_chat_completions_streaming():
     result = None
     events = openai.ChatCompletion.create(
@@ -50,11 +54,13 @@ def test_chat_completions_streaming():
 
 
 # COMPLETION TESTS
+@pytest.mark.integration
 def test_completions():
     result = openai.Completion.create(prompt="This was a test", n=5, engine="ada")
     assert len(result.choices) == 5
 
 
+@pytest.mark.integration
 def test_completions_multiple_prompts():
     result = openai.Completion.create(
         prompt=["This was a test", "This was another test"], n=5, engine="ada"
@@ -62,12 +68,14 @@ def test_completions_multiple_prompts():
     assert len(result.choices) == 10
 
 
+@pytest.mark.integration
 def test_completions_model():
     result = openai.Completion.create(prompt="This was a test", n=5, model="ada")
     assert len(result.choices) == 5
     assert result.model.startswith("ada")
 
 
+@pytest.mark.integration
 def test_timeout_raises_error():
     # A query that should take awhile to return
     with pytest.raises(error.Timeout):
@@ -80,6 +88,7 @@ def test_timeout_raises_error():
         )
 
 
+@pytest.mark.integration
 def test_timeout_does_not_error():
     # A query that should be fast
     openai.Completion.create(
@@ -89,6 +98,7 @@ def test_timeout_does_not_error():
     )
 
 
+@pytest.mark.integration
 def test_user_session():
      with requests.Session() as session:
         openai.requestssession = session
@@ -100,6 +110,7 @@ def test_user_session():
         assert completion
 
 
+@pytest.mark.integration
 def test_user_session_factory():
     def factory():
         session = requests.Session()

--- a/openai/tests/test_file_cli.py
+++ b/openai/tests/test_file_cli.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 import subprocess
 import time
 from tempfile import NamedTemporaryFile
@@ -6,6 +7,7 @@ from tempfile import NamedTemporaryFile
 STILL_PROCESSING = "File is still processing. Check back later."
 
 
+@pytest.mark.integration
 def test_file_cli() -> None:
     contents = json.dumps({"prompt": "1 + 3 =", "completion": "4"}) + "\n"
     with NamedTemporaryFile(suffix=".jsonl", mode="wb") as train_file:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 markers =
     url: mark a test as part of the url composition tests.
     requestor: mark test as part of the api_requestor tests.
+    integration: requires valid API keys

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,12 +10,16 @@ url = https://github.com/openai/openai-python
 license_files = LICENSE
 classifiers =
   Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   License :: OSI Approved :: MIT License
   Operating System :: OS Independent
 
 [options]
 packages = find:
-python_requires = >=3.7.1
+python_requires = >=3.8.0
 zip_safe = True
 include_package_data = True
 install_requires =
@@ -63,3 +67,16 @@ console_scripts =
 exclude =
   tests
   tests.*
+
+[tox:tox]
+min_version = 4.0
+env_list =
+    py38
+    py39
+    py310
+    py311
+    py312
+
+[testenv]
+commands = pytest -v -m "not integration" openai/tests 
+extras = dev


### PR DESCRIPTION
This PR adds a tox configuration file to automate testing of Python versions 3.8-3.11 with this package.

Since some of the tests require valid API keys, I've added another marker for pytest called `integration` which will skip those tests in Tox. 

This PR also highlights the following issues:
- the aiohttp dependency makes this package incompatible with Python 3.12 until aiohttp 3.9 is released
- although 3.7 is specified as a supported version, it isn't supported because urllib3 > v2 (used by aiohttp) requires the newer version of openssl than the one bundled with Python 3.7 so Python 3.7 gives a runtime error