### PR TITLE
Update api_requestor.py

### DIFF
--- a/openai/api_requestor.py
+++ b/openai/api_requestor.py
@@ -34,7 +34,7 @@ from openai.openai_response import OpenAIResponse
 from openai.util import ApiType
 
 TIMEOUT_SECS = 600
-MAX_SESSION_LIFETIME_SECS = 180
+MAX_SESSION_LIFETIME_SECS = 777
 MAX_CONNECTION_RETRIES = 2
 
 # Has one attribute per thread, 'session'.


### PR DESCRIPTION
replaced the MAX_SESSION_LIFETIME_SECS from 180 seconds to 777 seconds.

addressed issue number #616.
simply increased MAX_SESSION_LIFETIME_SECS to 777 seconds.

code(before committing changes)- https://github.com/openai/openai-python/blob/e389823ba013a24b4c32ce38fa0bd87e6bccae94/openai/api_requestor.py#L590C2-L590C2


contact me- ansumanswain25@gmail.com
connect with me- https://www.linkedin.com/in/ansuman-swain-704122228