### PR TITLE
Expanded constructor of client/env var support for AOAI

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -97,7 +97,7 @@ api_key: str | None = _os.environ.get("OPENAI_API_KEY")
 
 organization: str | None = _os.environ.get("OPENAI_ORG_ID")
 
-base_url: str | None = None
+base_url: str | None = _os.environ.get("OPENAI_API_BASE")
 
 timeout: float | Timeout | None = DEFAULT_TIMEOUT
 
@@ -109,6 +109,8 @@ default_query: _t.Mapping[str, object] | None = None
 
 http_client: _httpx.Client | None = None
 
+api_version: str | None = _os.environ.get("OPENAI_API_VERSION")
+api_type: str | None = _os.environ.get("OPENAI_API_TYPE")
 
 class _ModuleClient(OpenAI):
     # Note: we have to use type: ignores here as overriding class members
@@ -211,6 +213,8 @@ def _load_client() -> OpenAI:  # type: ignore[reportUnusedFunction]
     if _client is None:
         _client = _ModuleClient(
             api_key=api_key,
+            api_version=api_version,
+            api_type=api_type,
             organization=organization,
             base_url=base_url,
             timeout=timeout,


### PR DESCRIPTION
Starting point for discussion of enhancing the client constructor to support Azure OpenAI endpoint.

- (Re)introduced three new environment variables (OPENAI_API_BASE, OPENAI_API_VERSION, OPENAI_API_TYPE)
- Added `api_version` and `api_type` parameters to client constructor. Default to `None` and `"openai"` respectively
- Added the ability to provide a callable for `api_key` that returns a tuple of header name + value (base support for token based auth)
- If `api_type` is `"azure"` and `api_key` is a `str`, use the Azure `api-key` header name for providing the API key.

For the different credential types, I don't know if the openapi that is used to generated the library includes the security schemes and how having multiple schemes would affect the client constructor. 

For the api version, if we can align the APIs across OpenAI and Azure OpenAI to both take the same format of api version query parameter (and have that generated as a client constructor parameter), it would reduce the deltas between the APIs even further.
