### PR TITLE
stream param to Speech and AsyncSpeech

### DIFF
--- a/src/openai/resources/audio/speech.py
+++ b/src/openai/resources/audio/speech.py
@@ -12,7 +12,10 @@ from ..._utils import maybe_transform
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import to_raw_response_wrapper, async_to_raw_response_wrapper
 from ...types.audio import speech_create_params
-from ..._base_client import HttpxBinaryResponseContent, make_request_options
+from ..._base_client import HttpxBinaryResponseContent, make_request_options, Stream, AsyncStream
+
+#NOTE: this would probably be nice as some kind of Audio or SpeechCompletion Chunk, but those don't exist in the lib, this works now
+from ...types.chat.chat_completion_chunk import ChatCompletionChunk
 
 if TYPE_CHECKING:
     from ..._client import OpenAI, AsyncOpenAI
@@ -42,7 +45,7 @@ class Speech(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         stream: bool = False
-    ) -> HttpxBinaryResponseContent:
+    ) -> HttpxBinaryResponseContent | Stream[ChatCompletionChunk]:
         """
         Generates audio from the input text.
 
@@ -85,7 +88,8 @@ class Speech(SyncAPIResource):
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
             cast_to=HttpxBinaryResponseContent,
-            stream=stream
+            stream=stream,
+            stream_cls=Stream[ChatCompletionChunk]
         )
 
 
@@ -111,7 +115,7 @@ class AsyncSpeech(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
         stream: bool = False
-    ) -> HttpxBinaryResponseContent:
+    ) -> HttpxBinaryResponseContent | AsyncStream[ChatCompletionChunk]:
         """
         Generates audio from the input text.
 
@@ -154,7 +158,8 @@ class AsyncSpeech(AsyncAPIResource):
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
             cast_to=HttpxBinaryResponseContent,
-            stream=stream
+            stream=stream,
+            stream_cls=AsyncStream[ChatCompletionChunk]
         )
 
 

--- a/src/openai/resources/audio/speech.py
+++ b/src/openai/resources/audio/speech.py
@@ -41,6 +41,7 @@ class Speech(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+        stream: bool = False
     ) -> HttpxBinaryResponseContent:
         """
         Generates audio from the input text.
@@ -84,6 +85,7 @@ class Speech(SyncAPIResource):
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
             cast_to=HttpxBinaryResponseContent,
+            stream=stream
         )
 
 
@@ -108,6 +110,7 @@ class AsyncSpeech(AsyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+        stream: bool = False
     ) -> HttpxBinaryResponseContent:
         """
         Generates audio from the input text.
@@ -151,6 +154,7 @@ class AsyncSpeech(AsyncAPIResource):
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
             cast_to=HttpxBinaryResponseContent,
+            stream=stream
         )
 
 


### PR DESCRIPTION
help.openai says, in https://help.openai.com/en/articles/8555505-tts-api#h_f2f424c6cb

> Is it possible to stream audio?
> Yes! By setting stream=True, you can chunk the returned audio file.

However, the API reference does not have such a param in https://platform.openai.com/docs/api-reference/audio/createSpeech

The guide again says, in https://platform.openai.com/docs/guides/text-to-speech:

> The Speech API provides support for real time audio streaming using [chunk transfer encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding). This means that the audio is able to be played before the full file has been generated and made accessible. 

However, the code there seems like it reads the content in full, before responding over http?

```python
  # Convert the binary response content to a byte stream
  byte_stream = io.BytesIO(response.content)
```

I tried to experiment, and indeed it seemed that that version did not stream.

I modified the speech part of the client lib to pass the `stream: bool` onwards, and I think this way it actually works, my playback starts so soon. I did not verify this (yet) with proper debugging.

This should be considered a draft, because apparently the `stream=True` param for the `speech.create` changes the return type from `HttpxBinaryResponseContent` to `AsyncStream`. I did not fix the type infos etc.
