### PR TITLE
fix(cli/audio): file format detection failing for whisper

### DIFF
--- a/src/openai/cli/_api/audio.py
+++ b/src/openai/cli/_api/audio.py
@@ -66,7 +66,7 @@ class CLIAudio:
             buffer_reader = BufferReader(file_reader.read(), desc="Upload progress")
 
         model = get_client().audio.transcriptions.create(
-            file=buffer_reader,
+            file=(args.file, buffer_reader),
             model=args.model,
             language=args.language or NOT_GIVEN,
             temperature=args.temperature or NOT_GIVEN,
@@ -83,7 +83,7 @@ class CLIAudio:
             buffer_reader = BufferReader(file_reader.read(), desc="Upload progress")
 
         model = get_client().audio.translations.create(
-            file=buffer_reader,
+            file=(args.file, buffer_reader),
             model=args.model,
             temperature=args.temperature or NOT_GIVEN,
             prompt=args.prompt or NOT_GIVEN,


### PR DESCRIPTION
Fix for #333 

# My initial problem
My case is using `openai api audio.transcriptions.create -f audio.mp3`. Without the fix the returned value is `Error: Error code: 400 - {'error': {'message': "Unrecognized file format. Supported formats: ['flac', 'm4a', 'mp3', 'mp4', 'mpeg', 'mpga', 'oga', 'ogg', 'wav', 'webm']", 'type': 'invalid_request_error', 'param': None, 'code': None}}`.


# What the cause was
The issue was that using BufferReader to read from the audio file was not keeping the `name` attribute so the file detection code on the server side was failing.

# Quality
My fix is a viable workaround but a more invasive fix would be better. I found numerous other posts with this kind of issue for a while :
- https://community.openai.com/t/has-the-whisper-error-been-solved/433315
- https://community.openai.com/t/whisper-api-cannot-read-files-correctly/93420/54
- https://community.openai.com/t/whisper-api-completely-wrong-for-mp4/289256/6
- https://community.openai.com/t/openai-whisper-send-bytes-python-instead-of-filename/84786/3
- https://community.openai.com/t/whisperai-api-not-recognizing-valid-file-formats/145208
- https://community.openai.com/t/whisper-api-cannot-read-files-correctly/93420/51

 so I think this quick non invasive fix would be a good idea.

Edit: confirmed this fix is still relevant for 1.2.0. I'm on linux using python 3.9.0 for this test.