### PR TITLE
Add the default base url configuration

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -309,7 +309,7 @@ class AsyncOpenAI(AsyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
         if base_url is None:
-            base_url = "https://api.openai.com/v1"  # default value
+            base_url = f"https://api.openai.com/v1"  # default value
 
         super().__init__(
             version=__version__,

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -307,7 +307,9 @@ class AsyncOpenAI(AsyncAPIClient):
         self.organization = organization
 
         if base_url is None:
-            base_url = f"https://api.openai.com/v1"
+            base_url = os.environ.get("OPENAI_BASE_URL")
+        if base_url is None:
+            base_url = "https://api.openai.com/v1"  # default value
 
         super().__init__(
             version=__version__,


### PR DESCRIPTION
We'll always set the base_url, and we want to add this option so that we don't have to set the base_url ourselves each time we're in the project