### PR TITLE
docs(readme): fix broken azure_ad notebook link

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ In addition to the options provided in the base `OpenAI` client, the following o
 - `azure_ad_token`
 - `azure_ad_token_provider`
 
-An example of using the client with Azure Active Directory can be found [here](https://github.com/openai/openai-python/blob/v1/examples/azure_ad.py).
+An example of using the client with Azure Active Directory can be found [here](https://github.com/openai/openai-python/blob/main/examples/azure_ad.py).
 
 ## Versioning
 


### PR DESCRIPTION
The notebook link in the main README pointed an old directory.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
