### PR TITLE
Fix typo in docstring of _types.NotGiven

### DIFF
--- a/src/openai/_types.py
+++ b/src/openai/_types.py
@@ -279,8 +279,8 @@ class NotGiven:
     ```py
     def get(timeout: Union[int, NotGiven, None] = NotGiven()) -> Response: ...
 
-    get(timout=1) # 1s timeout
-    get(timout=None) # No timeout
+    get(timeout=1) # 1s timeout
+    get(timeout=None) # No timeout
     get() # Default timeout behavior, which may not be statically known at the method definition.
     ```
     """


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

(Same as title)

## Additional context & links

N/A