### PR TITLE
Update pyproject.toml for better Colab support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ dependencies = [
     "typing-extensions>=4.5, <5",
     "anyio>=3.5.0, <4",
     "distro>=1.7.0, <2",
-    "tqdm > 4"
+    "tqdm > 4",
+    "cohere>=4.34, <5", 
+    "tiktoken>=0.5.1, <1"
 ]
 requires-python = ">= 3.7.1"
 classifiers = [


### PR DESCRIPTION
![image](https://github.com/openai/openai-python/assets/5193877/9c2dd7f4-6fc5-4c0f-aa61-aec3491d5edd)

[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/11rc0Z7m-Z0a82OlMInhutZQQE5IBw_ck?usp=sharing)

I'm speculating that `openai` is used a lot on Google Colab.

## Changes being requested

Install `cohere` and `tiktoken` for better Google Colab support.

Currently, you can't just

```python
%pip install openai
```

you have to

```python
%pip install openai cohere tiktoken
```