### PR TITLE
Dict conversion for category scores from moderation

### DIFF
--- a/src/openai/types/moderation.py
+++ b/src/openai/types/moderation.py
@@ -105,6 +105,24 @@ class CategoryScores(BaseModel):
     violence_graphic: float = FieldInfo(alias="violence/graphic")
     """The score for the category 'violence/graphic'."""
 
+    def to_dict(self):
+        return {
+            "harassment": self.harassment,
+            "harassment/threatening": self.harassment_threatening,
+            "hate": self.hate,
+            "hate/threatening": self.hate_threatening,
+            "self-harm": self.self_minus_harm,
+            "self-harm/instructions": self.self_minus_harm_instructions,
+            "self-harm/intent": self.self_minus_harm_intent,
+            "sexual": self.sexual,
+            "sexual/minors": self.sexual_minors,
+            "violence": self.violence,
+            "violence/graphic": self.violence_graphic,
+        }
+
+    def __dict__(self):
+        return self.to_dict()
+
 
 class Moderation(BaseModel):
     categories: Categories


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
There are a lot of scenarios when you want to work with the response from the Moderations endpoint as a dictionary. Previously in the openAI library you could retrieve the categories and their scores as key-value pairs as a python dictionary. However, now, the categories are contained within the CategoryScores model and you have to manually convert it into a dict.
I'm just introducing `__dict__` here to make this easier.

## Additional context & links
