### PR TITLE
Fix NotGiven encoding_format bug in Embeddings

### DIFF
--- a/src/openai/resources/embeddings.py
+++ b/src/openai/resources/embeddings.py
@@ -35,7 +35,7 @@ class Embeddings(SyncAPIResource):
         *,
         input: Union[str, List[str], List[int], List[List[int]]],
         model: Union[str, Literal["text-embedding-ada-002"]],
-        encoding_format: Literal["float", "base64"] | NotGiven = NOT_GIVEN,
+        encoding_format: Literal["float", "base64"] | NotGiven = "float",
         user: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.


### PR DESCRIPTION
Add 'float' as default according to documentation.

Hi, I found a bug in the API connection for getting embedding.
The documentation says [`encoding_format string Optional Defaults to float`](https://platform.openai.com/docs/api-reference/embeddings/create?lang=python#embeddings-create-encoding_format), but it doesn't set to default in implementation. [link](https://github.com/openai/openai-python/blob/01d3b37305b28a45d0d9adfbc23c958bf924fe05/src/openai/resources/embeddings.py#L38)

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
