### PR TITLE
Speech create args: voice and format can be 'str' and 'Literal'

### DIFF
--- a/src/openai/resources/audio/speech.py
+++ b/src/openai/resources/audio/speech.py
@@ -32,8 +32,8 @@ class Speech(SyncAPIResource):
         *,
         input: str,
         model: Union[str, Literal["tts-1", "tts-1-hd"]],
-        voice: Literal["alloy", "echo", "fable", "onyx", "nova", "shimmer"],
-        response_format: Literal["mp3", "opus", "aac", "flac"] | NotGiven = NOT_GIVEN,
+        voice: Union[str, Literal["alloy", "echo", "fable", "onyx", "nova", "shimmer"]],
+        response_format: Union[str, Literal["mp3", "opus", "aac", "flac"]] | NotGiven = NOT_GIVEN,
         speed: float | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.


### PR DESCRIPTION
When we use this function, we can get 'voice' and other args as 'str' method args. This commit fix this problem

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
