### PR TITLE
fix timeout issue with a pause on retry

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -890,6 +890,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:  # thrown on 4xx and 5xx status code
             if retries > 0 and self._should_retry(err.response):
+                time.sleep(10)
                 err.response.close()
                 return self._retry_request(
                     options,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
When running embedding models in azure to create vector indexes there is a timeout even with ADA set to 240 TPM. Simply adding a 10s sleep (only on retry attempts) fixes this.

Thank you so much for all your amazing work!

## Additional context & links
