### PR TITLE
fix(errors): properly assign APIError.body

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -48,6 +48,7 @@ class APIError(OpenAIError):
         super().__init__(message)
         self.request = request
         self.message = message
+        self.body = body
 
         if is_dict(body):
             self.code = cast(Any, body.get("code"))


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Simply assign the body from the parameter to the class variable.

Based on the comment in the code:
```
    ""The API response body.

    If the API responded with a valid JSON structure then this property will be the
    decoded result.

    If it isn't a valid JSON structure then this will be the raw response.

    If there was no response associated with this error then it will be `None`.
    """
```

## Additional context & links

closes https://github.com/openai/openai-python/issues/948
