### PR TITLE
fix: no chunk response in stream chat with HTTP default headers

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -562,7 +562,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
     @property
     def default_headers(self) -> dict[str, str | Omit]:
         return {
-            "Accept": "application/json",
+            "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
             "User-Agent": self.user_agent,
             **self.platform_headers(),


### PR DESCRIPTION
### Issue

no chunk response in the stream chat

### Steps to reproduce

environment:
```toml
python = "^3.12"
openai = "^1.6.1"
```

```python
client = OpenAI(
    base_url=OPENAI_API_BASE,
    api_key=OPENAI_API_KEY,
)
response = client.chat.completions.create(
    model="gpt-3.5-turbo-1106",
    messages=[{"role": "user", "content": "Hello Nerd"}],
    stream=True,
)
print("Resp: ", response)

for chunk in response:
    print("chunk: ", chunk)
```

It's supposed to print each chunk, but there's no chunk:
```text
Resp:  <openai.Stream object at 0x1023e42c0>
```
### Root cause analyze

With `stream=True`, we expect to use SSE response, but the current implementation uses default HTTP headers with `"Accept": "application/json"`. Of course, JSON makes no sense here.

Full header (try breakpoint at _base_client.py L873):
```
Headers({'host': 'XXXXXXXXXXX', 'accept-encoding': 'gzip, deflate', 'connection': 'keep-alive', 'accept': 'application/json', 'content-type': 'application/json', 'user-agent': 'OpenAI/Python 1.6.1', 'x-stainless-lang': 'python', 'x-stainless-package-version': '1.6.1', 'x-stainless-os': 'MacOS', 'x-stainless-arch': 'arm64', 'x-stainless-runtime': 'CPython', 'x-stainless-runtime-version': '3.12.1', 'authorization': '[secure]', 'x-stainless-async': 'false', 'content-length': '104'})
```

In this case, the server response is neither JSON nor SSE, it's a 1-line string.  
The following raw response can be retrieved by breakpoint at _streaming.py L53. It's using `self.response.iter_lines()` to parse the response, here it's `<generator object Response.iter_lines at 0x1039a2f20>`.   
To get the chunks inside, we try to print with `[chunk for chunk in self.response.iter_lines()]`:

```
'{"id":"chatcmpl-8ZWVfMh6N9JwFyUNreY7sl7ghxtNg","object":"chat.completion.chunk","created":1703477139,"model":"gpt-3.5-turbo-1106","choices":[{"delta":{"role":"assistant"},"index":0}],"content":"","functionCall":{},"lastOne":false} {"id":"chatcmpl-8ZWVfMh6N9JwFyUNreY7sl7ghxtNg","object":"chat.completion.chunk","created":1703477139,"model":"gpt-3.5-turbo-1106","choices":[{"delta":{"content":"Hello"},"index":0}],"content":"Hello","functionCall":{},"lastOne":false} {"id":"chatcmpl-8ZWVfMh6N9JwFyUNreY7sl7ghxtNg","object":"chat.completion.chunk","created":1703477139,"model":"gpt-3.5-turbo-1106","choices":[{"delta":{"content":"!"},"index":0}],"content":"Hello!","functionCall":{},"lastOne":false} {"id":"chatcmpl-8ZWVfMh6N9JwFyUNreY7sl7ghxtNg","object":"chat.completion.chunk","created":1703477139,"model":"gpt-3.5-turbo-1106","choices":[{"delta":{"content":" How"},"index":0}],"content":"Hello! How","functionCall":{},"lastOne":false} {"id":"chatcmpl-8ZWVfMh6N9JwFyUNreY7sl7ghxtNg","object":"chat.completion.chunk","crea...
```
