### PR TITLE
honor retry-after-ms for azure clients

### DIFF
--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -114,7 +114,7 @@ def test_no_retry_after_header(client: Client, headers: httpx.Headers) -> None:
     "client,headers",
     [
         (sync_client, {"retry-after-ms": "invalid"}),
-        (sync_client, {"retry-after-ms": "invalid"}),
+        (async_client, {"retry-after-ms": "invalid"}),
     ],
 )
 def test_invalid_retry_after_header(client: Client, headers: httpx.Headers) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Related feature request: https://github.com/openai/openai-python/issues/957

@rattrayalex Coming back from the holidays and I see we're getting requests to support retry-after-ms on the Azure side. If it's easier / less work for you, I added the retry-after-ms logic to the Azure clients only in this PR. This assumes that it is okay to override the the internal calculate retry timeout method, but let me know if you have a different recommendation. Thanks so much!


## Additional context & links
