### PR TITLE
fix(client) await httpx async responses

### DIFF
--- a/src/openai/_legacy_response.py
+++ b/src/openai/_legacy_response.py
@@ -372,16 +372,16 @@ class HttpxBinaryResponseContent:
         return await self.response.aread()
 
     async def aiter_bytes(self, chunk_size: int | None = None) -> AsyncIterator[bytes]:
-        return self.response.aiter_bytes(chunk_size)
+        return await self.response.aiter_bytes(chunk_size)
 
     async def aiter_text(self, chunk_size: int | None = None) -> AsyncIterator[str]:
-        return self.response.aiter_text(chunk_size)
+        return await self.response.aiter_text(chunk_size)
 
     async def aiter_lines(self) -> AsyncIterator[str]:
-        return self.response.aiter_lines()
+        return await self.response.aiter_lines()
 
     async def aiter_raw(self, chunk_size: int | None = None) -> AsyncIterator[bytes]:
-        return self.response.aiter_raw(chunk_size)
+        return await self.response.aiter_raw(chunk_size)
 
     @deprecated(
         "Due to a bug, this method doesn't actually stream the response content, `.with_streaming_response.method()` should be used instead"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Fix async responses not awaiting httpx async functions

## Additional context & links
I got the same issue as [issue with async responses](https://github.com/openai/openai-python/issues/1062)

Check  [httpx async functions](https://github.com/encode/httpx/blob/master/httpx/_models.py#L973)
