### PR TITLE
[Bug Fix]Return None when stream is True, proposed fix

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -226,6 +226,8 @@ class SSEDecoder:
             sse = self.decode(line)
             if sse is not None:
                 yield sse
+            else:
+                yield self.decode(sse)
 
     async def aiter(self, iterator: AsyncIterator[str]) -> AsyncIterator[ServerSentEvent]:
         """Given an async iterator that yields lines, iterate over it & yield every event encountered"""
@@ -234,6 +236,8 @@ class SSEDecoder:
             sse = self.decode(line)
             if sse is not None:
                 yield sse
+            else:
+                yield self.decode(sse)
 
     def decode(self, line: str) -> ServerSentEvent | None:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501


### PR DESCRIPTION
Receive None response when stream==True
found a tricky design in _streaming.SSEDecoder.decode that returns None with input. Decode for second time could fix this issue.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fix a bug when setting stream as True

## Additional context & links