### PR TITLE
Prevent user setting empty string as api key

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -92,9 +92,9 @@ class OpenAI(SyncAPIClient):
         - `api_key` from `OPENAI_API_KEY`
         - `organization` from `OPENAI_ORG_ID`
         """
-        if api_key is None:
+        if not api_key:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None:
+        if not api_key:
             raise OpenAIError(
                 "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
             )
@@ -290,9 +290,9 @@ class AsyncOpenAI(AsyncAPIClient):
         - `api_key` from `OPENAI_API_KEY`
         - `organization` from `OPENAI_ORG_ID`
         """
-        if api_key is None:
+        if not api_key:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None:
+        if not api_key:
             raise OpenAIError(
                 "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
             )


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Instead of only checking for api_key is `None`, also prevent user from passing in an empty str as api_key. This will cause in a `Protocol Error "Bearer "` message which is rather confusing to users.