### PR TITLE
Add Request Header Exlude Option For Debug logging

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -436,7 +436,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         options: FinalRequestOptions,
     ) -> httpx.Request:
         if log.isEnabledFor(logging.DEBUG):
-            log.debug("Request options: %s", model_dump(options, exclude_unset=True))
+            log.debug("Request options: %s", model_dump(options, exclude_unset=True, exclude_headers=True))
 
         kwargs: dict[str, Any] = {}
 

--- a/src/openai/_compat.py
+++ b/src/openai/_compat.py
@@ -135,15 +135,21 @@ def model_dump(
     *,
     exclude_unset: bool = False,
     exclude_defaults: bool = False,
+    exclude_headers: bool = False,
 ) -> dict[str, Any]:
+    exclude = {}
+    if exclude_headers:
+        exclude={"headers"} 
     if PYDANTIC_V2:
         return model.model_dump(
+            exclude=exclude,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
         )
     return cast(
         "dict[str, Any]",
         model.dict(  # pyright: ignore[reportDeprecated, reportUnnecessaryCast]
+            exclude=exclude,
             exclude_unset=exclude_unset,
             exclude_defaults=exclude_defaults,
         ),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

fix this issue
https://github.com/openai/openai-python/issues/1082
https://github.com/openai/openai-python/issues/1196

Sample code to reproduce

```
$ export OPENAI_LOG=debug
```

```
from openai import OpenAI
import os

client = OpenAI()
response = client.chat.completions.with_raw_response.create(
    messages=[{
        "role": "user",
        "content": "Say this is a test",
    }],
    model="gpt-3.5-turbo",
    extra_headers={"Authorization": f'Bearer {os.environ.get("OPENAI_API_KEY")}'},
)
print(response)
```

```
poetry run python openai_lib/sample3.py
[2024-03-13 19:23:39 - httpx:80 - DEBUG] load_ssl_context verify=True cert=None trust_env=True http2=False
[2024-03-13 19:23:39 - httpx:146 - DEBUG] load_verify_locations cafile='/Users/keisuke.taniguchi/Library/Caches/pypoetry/virtualenvs/openai-lib-wrcub86L-py3.11/lib/python3.11/site-packages/certifi/cacert.pem'
[2024-03-13 19:23:39 - openai._base_client:435 - DEBUG] Request options: {'method': 'post', 'url': '/chat/completions', 'headers': {'Authorization': 'Bearer <api-key>', 'X-Stainless-Raw-Response': 'true'}, 'files': None, 'json_data': {'messages': [{'role': 'user', 'content': 'Say this is a test'}], 'model': 'gpt-3.5-turbo'}}
[2024-03-13 19:23:39 - httpx:1026 - INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
[2024-03-13 19:23:39 - openai._base_client:887 - DEBUG] HTTP Request: POST https://api.openai.com/v1/chat/completions "200 OK"
<APIResponse [200 OK] type=<class 'openai.types.chat.chat_completion.ChatCompletion'>>
```

## Additional context & links
https://github.com/openai/openai-python/blob/main/src/openai/_models.py#L398
https://github.com/openai/openai-python/blob/main/tests/test_models.py#L510
