### PR TITLE
Refactor APIStatusError Import for Better Readability

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -399,7 +399,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         *,
         body: object,
         response: httpx.Response,
-    ) -> _exceptions.APIStatusError:
+    ) -> APIStatusError:
         raise NotImplementedError()
 
     def _remaining_retries(


### PR DESCRIPTION
Change the import statement for APIStatusError from using a relative path with '_exceptions' to a direct import, enhancing code readability and consistency.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links