### PR TITLE
Use Type ChatCompletionRole for ChatCompletionMessage.role

### DIFF
--- a/src/openai/types/chat/chat_completion_message.py
+++ b/src/openai/types/chat/chat_completion_message.py
@@ -1,10 +1,10 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List, Optional
-from typing_extensions import Literal
 
 from ..._models import BaseModel
 from .chat_completion_message_tool_call import ChatCompletionMessageToolCall
+from .chat_completion_role import ChatCompletionRole
 
 __all__ = ["ChatCompletionMessage", "FunctionCall"]
 
@@ -26,7 +26,7 @@ class ChatCompletionMessage(BaseModel):
     content: Optional[str] = None
     """The contents of the message."""
 
-    role: Literal["assistant"]
+    role: ChatCompletionRole
     """The role of the author of this message."""
 
     function_call: Optional[FunctionCall] = None


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

It appears that the `role` attribute of `ChatCompletionMessage` is incorrectly using the type `Literal["assistant"]` instead of `ChatCompletionRole`. Messages sent to, and received from, the Chat Completions API can indeed accept all values defined in `ChatCompletionRole`, and not just `"assistant"`.

## Additional context & links

[Chat Completions API](https://platform.openai.com/docs/guides/text-generation/chat-completions-api) documentation showing an example with messages of various roles (i.e. assistant, user, system).