### PR TITLE
fix message attachment typing

### DIFF
--- a/src/openai/types/beta/threads/message_create_params.py
+++ b/src/openai/types/beta/threads/message_create_params.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from typing import List, Iterable, Optional
+from typing import Union, Iterable, Optional
 from typing_extensions import Literal, Required, TypedDict
+
+from ....types.beta import FileSearchToolParam, CodeInterpreterToolParam
 
 __all__ = ["MessageCreateParams", "Attachment"]
 
@@ -32,9 +34,10 @@ class MessageCreateParams(TypedDict, total=False):
     a maxium of 512 characters long.
     """
 
+AttachmentToolParam = Union[CodeInterpreterToolParam, FileSearchToolParam]
 
 class Attachment(TypedDict, total=False):
     file_id: str
     """The ID of the file to attach to the message."""
 
-    tools: List[Literal["file_search", "code_interpreter"]]
+    tools: Iterable[AttachmentToolParam]


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Message attachments typing is wrong and can confuse developers.
## Additional context & links
