### PR TITLE
fix(typo): change bytes to usage_bytes (following original response api)

### DIFF
--- a/src/openai/types/beta/vector_store.py
+++ b/src/openai/types/beta/vector_store.py
@@ -40,7 +40,7 @@ class VectorStore(BaseModel):
     id: str
     """The identifier, which can be referenced in API endpoints."""
 
-    bytes: int
+    usage_bytes: int
     """The byte size of the vector store."""
 
     created_at: int


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
i think there is typo, so i change `bytes` to `usage_bytes`

## Additional context & links
original response from api there is `usage_bytes` not `bytes`:
<img width="812" alt="Screenshot 2024-04-21 at 8 02 20 AM" src="https://github.com/openai/openai-python/assets/25049562/23d5541f-af17-4230-8515-40c7a048fddd">


response from library:
<img width="973" alt="Screenshot 2024-04-21 at 8 00 47 AM" src="https://github.com/openai/openai-python/assets/25049562/9188cb95-f132-4a76-bb19-88d8b3f38919">
