### PR TITLE
remove: Remove unnecessary judgment about debug log level

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -442,8 +442,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         self,
         options: FinalRequestOptions,
     ) -> httpx.Request:
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug("Request options: %s", model_dump(options, exclude_unset=True))
+        log.debug("Request options: %s", model_dump(options, exclude_unset=True))
 
         kwargs: dict[str, Any] = {}
 


### PR DESCRIPTION
Change-Id: I3fc59f63420e9e89441a116e0f7fbaec0eb032fc

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links

![image](https://github.com/openai/openai-python/assets/7046329/fcc5a65c-e2c2-4eb7-ac7b-3b7d17b531be)
In the Python official library, the `debug` method already has a level judgment, so there is no need to repeat the judgment

