### PR TITLE
[azure] update authorization header with refreshed token during retry

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -287,8 +287,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
 
         azure_ad_token = self._get_azure_ad_token()
         if azure_ad_token is not None:
-            if headers.get("Authorization") is None:
-                headers["Authorization"] = f"Bearer {azure_ad_token}"
+            headers["Authorization"] = f"Bearer {azure_ad_token}"
         elif self.api_key is not API_KEY_SENTINEL:
             if headers.get("api-key") is None:
                 headers["api-key"] = self.api_key
@@ -530,8 +529,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
 
         azure_ad_token = await self._get_azure_ad_token()
         if azure_ad_token is not None:
-            if headers.get("Authorization") is None:
-                headers["Authorization"] = f"Bearer {azure_ad_token}"
+            headers["Authorization"] = f"Bearer {azure_ad_token}"
         elif self.api_key is not API_KEY_SENTINEL:
             if headers.get("api-key") is None:
                 headers["api-key"] = self.api_key

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -64,3 +64,42 @@ def test_client_copying_override_options(client: Client) -> None:
         api_version="2022-05-01",
     )
     assert copied._custom_query == {"api-version": "2022-05-01"}
+
+
+def test_client_token_provider_refresh_sync() -> None:
+    options = FinalRequestOptions.construct(
+        method="post",
+        url="/chat/completions",
+        json_data={"model": "my-deployment-model"},
+        headers={"Authorization": "Bearer expired"}
+    )
+
+    sync_client = AzureOpenAI(
+        api_version="2024-02-01",
+        azure_ad_token_provider=lambda: "valid",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+
+    sync_client._prepare_options(options)
+    token = options.headers["Authorization"]
+    assert token == "Bearer valid"
+
+
+@pytest.mark.asyncio
+async def test_client_token_provider_refresh_async() -> None:
+    options = FinalRequestOptions.construct(
+        method="post",
+        url="/chat/completions",
+        json_data={"model": "my-deployment-model"},
+        headers={"Authorization": "Bearer expired"}
+    )
+
+    async_client = AsyncAzureOpenAI(
+        api_version="2024-02-01",
+        azure_ad_token_provider=lambda: "valid",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+
+    await async_client._prepare_options(options)
+    token = options.headers["Authorization"]
+    assert token == "Bearer valid"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Upon a series of retry attempts, if the the token expires in the middle of it, the existing code is not updating the Authorization header with the refreshed token value.

## Additional context & links

Related issue: https://github.com/openai/openai-python/issues/1526