### PR TITLE
fix(cli/audio): handle non-json response format

### DIFF
--- a/src/openai/cli/_api/audio.py
+++ b/src/openai/cli/_api/audio.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any, Optional, cast
 from argparse import ArgumentParser
 
@@ -7,6 +8,7 @@ from .._utils import get_client, print_model
 from ..._types import NOT_GIVEN
 from .._models import BaseModel
 from .._progress import BufferReader
+from ...types.audio import Transcription
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
@@ -65,30 +67,42 @@ class CLIAudio:
         with open(args.file, "rb") as file_reader:
             buffer_reader = BufferReader(file_reader.read(), desc="Upload progress")
 
-        model = get_client().audio.transcriptions.create(
-            file=(args.file, buffer_reader),
-            model=args.model,
-            language=args.language or NOT_GIVEN,
-            temperature=args.temperature or NOT_GIVEN,
-            prompt=args.prompt or NOT_GIVEN,
-            # casts required because the API is typed for enums
-            # but we don't want to validate that here for forwards-compat
-            response_format=cast(Any, args.response_format),
+        model = cast(
+            "Transcription | str",
+            get_client().audio.transcriptions.create(
+                file=(args.file, buffer_reader),
+                model=args.model,
+                language=args.language or NOT_GIVEN,
+                temperature=args.temperature or NOT_GIVEN,
+                prompt=args.prompt or NOT_GIVEN,
+                # casts required because the API is typed for enums
+                # but we don't want to validate that here for forwards-compat
+                response_format=cast(Any, args.response_format),
+            ),
         )
-        print_model(model)
+        if isinstance(model, str):
+            sys.stdout.write(model + "\n")
+        else:
+            print_model(model)
 
     @staticmethod
     def translate(args: CLITranslationArgs) -> None:
         with open(args.file, "rb") as file_reader:
             buffer_reader = BufferReader(file_reader.read(), desc="Upload progress")
 
-        model = get_client().audio.translations.create(
-            file=(args.file, buffer_reader),
-            model=args.model,
-            temperature=args.temperature or NOT_GIVEN,
-            prompt=args.prompt or NOT_GIVEN,
-            # casts required because the API is typed for enums
-            # but we don't want to validate that here for forwards-compat
-            response_format=cast(Any, args.response_format),
+        model = cast(
+            "Transcription | str",
+            get_client().audio.translations.create(
+                file=(args.file, buffer_reader),
+                model=args.model,
+                temperature=args.temperature or NOT_GIVEN,
+                prompt=args.prompt or NOT_GIVEN,
+                # casts required because the API is typed for enums
+                # but we don't want to validate that here for forwards-compat
+                response_format=cast(Any, args.response_format),
+            ),
         )
-        print_model(model)
+        if isinstance(model, str):
+            sys.stdout.write(model + "\n")
+        else:
+            print_model(model)

--- a/src/openai/cli/_utils.py
+++ b/src/openai/cli/_utils.py
@@ -33,7 +33,10 @@ def organization_info() -> str:
 
 
 def print_model(model: BaseModel) -> None:
-    sys.stdout.write(model_json(model, indent=2) + "\n")
+    if isinstance(model, BaseModel):
+        sys.stdout.write(model_json(model, indent=2) + "\n")
+    elif isinstance(model, str):
+        sys.stdout.write(model)
 
 
 def can_use_http2() -> bool:

--- a/src/openai/cli/_utils.py
+++ b/src/openai/cli/_utils.py
@@ -33,10 +33,7 @@ def organization_info() -> str:
 
 
 def print_model(model: BaseModel) -> None:
-    if isinstance(model, BaseModel):
-        sys.stdout.write(model_json(model, indent=2) + "\n")
-    elif isinstance(model, str):
-        sys.stdout.write(model)
+    sys.stdout.write(model_json(model, indent=2) + "\n")
 
 
 def can_use_http2() -> bool:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Modified the ``print_model` function in `openai/cli/_utils.py` to handle string responses appropriately.
- Added a type check in `print_model` to print the response directly if it is a string, avoiding the `model_dump_json` call.

## Additional context & links
Fixes #1035