### PR TITLE
feat(client): raise helpful error message for response_format misuse

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,2 +1,2 @@
 configured_endpoints: 68
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/openai-c36d30a94622922f83d56a025cdf0095ff7cb18a5138838c698c8443f21fb3a8.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/openai-4097c2f86beb3f3bb021775cd1dfa240e960caf842aeefc2e08da4dc0851ea79.yml

--- a/src/openai/resources/beta/chat/completions.py
+++ b/src/openai/resources/beta/chat/completions.py
@@ -78,13 +78,16 @@ class Completions(SyncAPIResource):
         from pydantic import BaseModel
         from openai import OpenAI
 
+
         class Step(BaseModel):
             explanation: str
             output: str
 
+
         class MathResponse(BaseModel):
             steps: List[Step]
             final_answer: str
+
 
         client = OpenAI()
         completion = client.beta.chat.completions.parse(
@@ -184,12 +187,12 @@ class Completions(SyncAPIResource):
 
         ```py
         with client.beta.chat.completions.stream(
-            model='gpt-4o-2024-08-06',
+            model="gpt-4o-2024-08-06",
             messages=[...],
         ) as stream:
             for event in stream:
-                if event.type == 'content.delta':
-                    print(event.content, flush=True, end='')
+                if event.type == "content.delta":
+                    print(event.content, flush=True, end="")
         ```
 
         When the context manager is entered, a `ChatCompletionStream` instance is returned which, like `.create(stream=True)` is an iterator. The full list of events that are yielded by the iterator are outlined in [these docs](https://github.com/openai/openai-python/blob/main/helpers.md#chat-completions-events).
@@ -287,13 +290,16 @@ class AsyncCompletions(AsyncAPIResource):
         from pydantic import BaseModel
         from openai import AsyncOpenAI
 
+
         class Step(BaseModel):
             explanation: str
             output: str
 
+
         class MathResponse(BaseModel):
             steps: List[Step]
             final_answer: str
+
 
         client = AsyncOpenAI()
         completion = await client.beta.chat.completions.parse(
@@ -393,12 +399,12 @@ class AsyncCompletions(AsyncAPIResource):
 
         ```py
         async with client.beta.chat.completions.stream(
-            model='gpt-4o-2024-08-06',
+            model="gpt-4o-2024-08-06",
             messages=[...],
         ) as stream:
             async for event in stream:
-                if event.type == 'content.delta':
-                    print(event.content, flush=True, end='')
+                if event.type == "content.delta":
+                    print(event.content, flush=True, end="")
         ```
 
         When the context manager is entered, an `AsyncChatCompletionStream` instance is returned which, like `.create(stream=True)` is an async iterator. The full list of events that are yielded by the iterator are outlined in [these docs](https://github.com/openai/openai-python/blob/main/helpers.md#chat-completions-events).

--- a/src/openai/resources/chat/completions.py
+++ b/src/openai/resources/chat/completions.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Dict, List, Union, Iterable, Optional, overload
 from typing_extensions import Literal
 
 import httpx
+import pydantic
 
 from ... import _legacy_response
 from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
@@ -647,6 +649,7 @@ class Completions(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ChatCompletion | Stream[ChatCompletionChunk]:
+        validate_response_format(response_format)
         return self._post(
             "/chat/completions",
             body=maybe_transform(
@@ -1302,6 +1305,7 @@ class AsyncCompletions(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ChatCompletion | AsyncStream[ChatCompletionChunk]:
+        validate_response_format(response_format)
         return await self._post(
             "/chat/completions",
             body=await async_maybe_transform(
@@ -1374,4 +1378,11 @@ class AsyncCompletionsWithStreamingResponse:
 
         self.create = async_to_streamed_response_wrapper(
             completions.create,
+        )
+
+
+def validate_response_format(response_format: object) -> None:
+    if inspect.isclass(response_format) and issubclass(response_format, pydantic.BaseModel):
+        raise TypeError(
+            "You tried to pass a `BaseModel` class to `chat.completions.create()`; You must use `beta.chat.completions.parse()` instead"
         )


### PR DESCRIPTION
Should help prevent users from accidentally trying to use `chat.completions.create()` instead of `beta.chat.completions.parse()` for structured outputs auto parsing.