### PR TITLE
Update permissions to make it less restrictive

### DIFF
--- a/src/openai/cli/_tools/migrate.py
+++ b/src/openai/cli/_tools/migrate.py
@@ -148,7 +148,7 @@ def install() -> Path:
 
     shutil.rmtree(unpacked_dir)
     os.remove(temp_file)
-    os.chmod(target_path, 0o755)
+    os.chmod(target_path, 0o700)
 
     sys.stdout.flush()
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #1618 

Extracting files from a malicious tar archive without validating that the destination file path is within the destination directory can cause files outside the destination directory to be overwritten, due to the possible presence of directory traversal elements (..) in archive paths.

Alert: Overly permissive file permissions

Current Issue: The current file permission is set to 0o755, which allows the owner to read, write, and execute the file, while the group and others can read and execute it.
Recommended Fix: Change the file permission to 0o700, which allows only the owner to read, write, and execute the file, thereby restricting access to others.
Code to change:

# Original code
```
os.chmod(target_path, 0o755)
```

# Recommended fix
```
os.chmod(target_path, 0o700)
```
This change ensures that the file permissions are restricted, enhancing security by preventing unauthorized users from accessing the file.

## Additional context & links
