### PR TITLE
fix(json schema): support recursive BaseModels in Pydantic v1

### DIFF
--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -62,6 +62,11 @@ def _ensure_strict_json_schema(
         for def_name, def_schema in defs.items():
             _ensure_strict_json_schema(def_schema, path=(*path, "$defs", def_name))
 
+    definitions = json_schema.get("definitions")
+    if is_dict(definitions):
+        for definition_name, definition_schema in definitions.items():
+            _ensure_strict_json_schema(definition_schema, path=(*path, "definitions", definition_name))
+
     return json_schema
 
 

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -130,6 +130,7 @@ def test_most_types() -> None:
                             "type": "object",
                             "properties": {"column_name": {"title": "Column Name", "type": "string"}},
                             "required": ["column_name"],
+                            "additionalProperties": False,
                         },
                         "Condition": {
                             "title": "Condition",
@@ -147,6 +148,7 @@ def test_most_types() -> None:
                                 },
                             },
                             "required": ["column", "operator", "value"],
+                            "additionalProperties": False,
                         },
                         "OrderBy": {
                             "title": "OrderBy",


### PR DESCRIPTION
Pydantic 2 introduced `$defs` and removed `definitions`. The latter is not handled during json parsing in "Structured Outputs" mode, so `additionalProperties: False` is not set and the request fails with pydantic<2 with nested objects in the schema, as they are not getting the flag set.

Added `definitions` in `_ensure_strict_json_schema` to correctly parse the schema with pydantic<2 and not fail on requests with nested objects.

Steps to reproduce the error:
openai==1.40.1
pydantic==1.10.12

```
from pydantic import BaseModel
from openai import OpenAI

client = OpenAI(api_key=OPENAI_API_KEY)

class Step(BaseModel):
    explanation: str
    output: str

class MathReasoning(BaseModel):
    final_answer: str
    step: list[Step]

completion = client.beta.chat.completions.parse(
    model="gpt-4o-2024-08-06",
    messages=[
        {"role": "system", "content": "You are a helpful math tutor. Guide the user through the solution step by step."},
        {"role": "user", "content": "how can I solve 8x + 7 = -23"}
    ],
    response_format=MathReasoning,
)

math_reasoning = completion.choices[0].message.parsed
```