### PR TITLE
docs(readme): improve custom `base_url` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,7 +567,7 @@ from openai import OpenAI, DefaultHttpxClient
 
 client = OpenAI(
     # Or use the `OPENAI_BASE_URL` env var
-    base_url="http://my.test.server.example.com:8083",
+    base_url="http://my.test.server.example.com:8083/v1",
     http_client=DefaultHttpxClient(
         proxies="http://my.test.proxy.example.com",
         transport=httpx.HTTPTransport(local_address="0.0.0.0"),


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

OPENAI_BASE_URL defaults to https://api.openai.com/v1, so if you add a replacement and forget to append the /v1, it will result in 404s. Let's give an example that ends in v1

## Additional context & links

https://github.com/openai/openai-python/blob/b2f58cba092cfb3083dc31de429fa19d89f739dc/src/openai/_client.py#L118C1-L121C52