### PR TITLE
chore(streaming): silence pydantic model_dump warnings

### DIFF
--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -906,11 +906,11 @@ def accumulate_run_step(
             merged = accumulate_delta(
                 cast(
                     "dict[object, object]",
-                    snapshot.model_dump(exclude_unset=True),
+                    snapshot.model_dump(exclude_unset=True, warnings=False),
                 ),
                 cast(
                     "dict[object, object]",
-                    data.delta.model_dump(exclude_unset=True),
+                    data.delta.model_dump(exclude_unset=True, warnings=False),
                 ),
             )
             run_step_snapshots[snapshot.id] = cast(RunStep, construct_type(type_=RunStep, value=merged))
@@ -948,7 +948,7 @@ def accumulate_event(
                         construct_type(
                             # mypy doesn't allow Content for some reason
                             type_=cast(Any, MessageContent),
-                            value=content_delta.model_dump(exclude_unset=True),
+                            value=content_delta.model_dump(exclude_unset=True, warnings=False),
                         ),
                     ),
                 )
@@ -957,11 +957,11 @@ def accumulate_event(
                 merged = accumulate_delta(
                     cast(
                         "dict[object, object]",
-                        block.model_dump(exclude_unset=True),
+                        block.model_dump(exclude_unset=True, warnings=False),
                     ),
                     cast(
                         "dict[object, object]",
-                        content_delta.model_dump(exclude_unset=True),
+                        content_delta.model_dump(exclude_unset=True, warnings=False),
                     ),
                 )
                 current_message_snapshot.content[content_delta.index] = cast(


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Disable warnings emitted from AssistantEventHandler. Warnings arise from differences in the Azure API and end up not being that helpful, nor configurable by the user.

## Additional context & links
