### PR TITLE
docs(helpers): fix method name typo

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -508,7 +508,7 @@ The polling methods are:
 ```python
 client.beta.threads.create_and_run_poll(...)
 client.beta.threads.runs.create_and_poll(...)
-client.beta.threads.runs.submit_tool_ouptputs_and_poll(...)
+client.beta.threads.runs.submit_tool_outputs_and_poll(...)
 client.beta.vector_stores.files.upload_and_poll(...)
 client.beta.vector_stores.files.create_and_poll(...)
 client.beta.vector_stores.file_batches.create_and_poll(...)


### PR DESCRIPTION
There was a typo in thread's polling method name. Removed wrong extra letter in "..outputs.."

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
