### PR TITLE
fix(client/async): correctly retry in all cases

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1591,7 +1591,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         except Exception as err:
             log.debug("Encountered Exception", exc_info=True)
 
-            if retries_taken > 0:
+            if remaining_retries > 0:
                 return await self._retry_request(
                     input_options,
                     cast_to,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

I know this is auto generated, thus this PR may serve as a hint to fix the upstream code-generator bug.

### Reproduction

```
import logging
from openai import OpenAI, AsyncOpenAI
import openai

logging.basicConfig(level=logging.DEBUG,
                    format='%(asctime)s - %(levelname)s - %(filename)s:%(funcName)s:%(lineno)d - %(message)s',
                    datefmt='%Y-%m-%d %H:%M:%S')

# look at log and it DOES retry
client = OpenAI(api_key='dummy', base_url='https://localhost:1111') # deliberate not exist domain
client.chat.completions.create(messages=[], model='my-model')

# this is buggy and the log show NO retry
client = AsyncOpenAI(api_key='dummy', base_url='https://localhost:1111') # deliberate not exist domain
await client.chat.completions.create(messages=[], model='my-model')
```

### Analysis

You can look at AsyncOpenAI vs OpenAI to see why this line of code is wrong. Or, look at a dozen line above this line to see how other errors are handled to see why this is wrong.