### PR TITLE
Correctly set Accept header to text/event-stream for completion streaming

### DIFF
--- a/src/openai/resources/chat/completions.py
+++ b/src/openai/resources/chat/completions.py
@@ -812,6 +812,7 @@ class Completions(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ChatCompletion | Stream[ChatCompletionChunk]:
         validate_response_format(response_format)
+        extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})} if stream else extra_headers
         return self._post(
             "/chat/completions",
             body=maybe_transform(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Previously, the standard Accept header was set to application/json unconditionally.
However, streaming response returns content-type: text/event-stream following
the specification of server-sent-events.

This correctly sets the Accept header to it accordingly in order to comply with the
standard. The exact same problem exists in other SDKS (e.g. https://github.com/openai/openai-go/pull/94)

## Additional context & links

* https://github.com/openai/openai-node/issues/375
* https://github.com/openai/openai-node/pull/1145
* https://github.com/openai/openai-go/pull/94

___

Context: I am an Envoy Proxy community member and from a network proxy perspective, the discrepancy from the web standard is not a good thing. Hope this brings an attention to the problem as the fix is clearly a single line!

