### PR TITLE
fix(client/async): replace asyncify with asyncio.to_thread (#1827)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ filterwarnings = [
 # there are a couple of flags that are still disabled by
 # default in strict mode as they are experimental and niche.
 typeCheckingMode = "strict"
-pythonVersion = "3.7"
+pythonVersion = "3.9.18"
 
 exclude = [
     "_dev",

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -62,7 +62,7 @@ from ._types import (
     HttpxRequestFiles,
     ModelBuilderProtocol,
 )
-from ._utils import is_dict, is_list, asyncify, is_given, lru_cache, is_mapping
+from ._utils import is_dict, is_list, is_given, lru_cache, is_mapping
 from ._compat import model_copy, model_dump
 from ._models import GenericModel, FinalRequestOptions, validate_type, construct_type
 from ._response import (
@@ -1549,7 +1549,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         if self._platform is None:
             # `get_platform` can make blocking IO calls so we
             # execute it earlier while we are in an async context
-            self._platform = await asyncify(get_platform)()
+            self._platform = await asyncio.to_thread(get_platform)
 
         # create a copy of the options we were given so that if the
         # options are mutated later & we then retry, the retries are


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
This Pull Request addresses an issue where AnyIO worker threads do not terminate properly when using `asyncify(get_platform)` in an asynchronous context. This can cause tests to hang, especially when using pytest, due to non-daemon worker threads remaining alive.

**Changes Made**:
- Replaced `asyncify(get_platform)` with `asyncio.to_thread(get_platform)` in the `_request` method. This ensures that worker threads terminate correctly after completing their tasks, preventing the hanging issue in asynchronous environments.
- Updated the `pythonVersion` setting in `pyright` from `3.7` to `3.9.18` to match the current Python version and to support `asyncio.to_thread`, which is available from Python 3.9 onwards. This change allows linters to recognize `asyncio.to_thread` and pass linting checks.

## Additional context & links
#1827 