### PR TITLE
Fix Azure Client /openai/deployments route override to be used more w…

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -58,8 +58,8 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
     ) -> httpx.Request:
         if options.url in _deployments_endpoints and is_mapping(options.json_data):
             model = options.json_data.get("model")
-            if model is not None and not "/deployments" in str(self.base_url):
-                options.url = f"/deployments/{model}{options.url}"
+            if model is not None and not "/openai/deployments" in str(self.base_url):
+                options.url = f"/openai/deployments/{model}{options.url}"
 
         return super()._build_request(options, retries_taken=retries_taken)
 
@@ -195,7 +195,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
             if azure_deployment is not None:
                 base_url = f"{azure_endpoint}/openai/deployments/{azure_deployment}"
             else:
-                base_url = f"{azure_endpoint}/openai"
+                base_url = f"{azure_endpoint}"
         else:
             if azure_endpoint is not None:
                 raise ValueError("base_url and azure_endpoint are mutually exclusive")


### PR DESCRIPTION
…idely

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links

Hello, there seems to be a problem with the openai python client regarding the AzureOpenAI client. 

While the Python client operates seamlessly with most endpoints, such as `chat/completions` (as detailed in the API reference: https://platform.openai.com/docs/api-reference/chat/create), I've identified a discrepancy when it comes to training-related routes.

It appears that the AzureOpenAI Client incorrectly appends /openai to the request URLs for training operations. This modification results in erroneous routes that my Azure deployment does not recognize, as it does not support URLs containing the openai segment.

The routes that get affected are:
- https://platform.openai.com/docs/api-reference/fine-tuning/create
- https://platform.openai.com/docs/api-reference/fine-tuning/list-events
- https://platform.openai.com/docs/api-reference/fine-tuning/list
- https://platform.openai.com/docs/api-reference/files/create
- etc

My fix resolves these issues. Would like someone to take a look.

Thanks