### PR TITLE
[Bug] Breaking httpx version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 { name = "OpenAI", email = "support@openai.com" },
 ]
 dependencies = [
-    "httpx>=0.23.0, <=0.28.0",
+    "httpx>=0.23.0, <0.28.0",
     "pydantic>=1.9.0, <3",
     "typing-extensions>=4.11, <5",
     "anyio>=3.5.0, <5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 { name = "OpenAI", email = "support@openai.com" },
 ]
 dependencies = [
-    "httpx>=0.23.0, <1",
+    "httpx>=0.23.0, <0.28.0",
     "pydantic>=1.9.0, <3",
     "typing-extensions>=4.11, <5",
     "anyio>=3.5.0, <5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 { name = "OpenAI", email = "support@openai.com" },
 ]
 dependencies = [
-    "httpx>=0.23.0, <0.28.0",
+    "httpx>=0.23.0, <=0.28.0",
     "pydantic>=1.9.0, <3",
     "typing-extensions>=4.11, <5",
     "anyio>=3.5.0, <5",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Update version pin for `httpx` library which is breaking OpenAI api usage

## Additional context & links
```
File "/usr/src/app/agent_executor.py", line 15, in initialise_agent_executor
     llm = ChatOpenAI(
           ^^^^^^^^^^^
   File "/usr/local/lib/python3.12/site-packages/langchain_core/load/serializable.py", line 125, in __init__
     super().__init__(*args, **kwargs)
   File "/usr/local/lib/python3.12/site-packages/pydantic/main.py", line 193, in __init__
     self.__pydantic_validator__.validate_python(data, self_instance=self)
   File "/usr/local/lib/python3.12/site-packages/langchain_openai/chat_models/base.py", line 551, in validate_environment
     self.root_client = openai.OpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/local/lib/python3.12/site-packages/openai/_client.py", line 123, in __init__
     super().__init__(
   File "/usr/local/lib/python3.12/site-packages/openai/_base_client.py", line 856, in __init__
     self._client = http_client or SyncHttpxClientWrapper(
                                   ^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/local/lib/python3.12/site-packages/openai/_base_client.py", line 754, in __init__
     super().__init__(**kwargs)
```