### PR TITLE
fix(cli/migrate): change grit binaries prefix

### DIFF
--- a/src/openai/cli/_tools/migrate.py
+++ b/src/openai/cli/_tools/migrate.py
@@ -92,8 +92,8 @@ def install() -> Path:
     install_dir = dir_name / ".install"
     target_dir = install_dir / "bin"
 
-    target_path = target_dir / "marzano"
-    temp_file = target_dir / "marzano.tmp"
+    target_path = target_dir / "grit"
+    temp_file = target_dir / "grit.tmp"
 
     if target_path.exists():
         _debug(f"{target_path} already exists")
@@ -110,7 +110,7 @@ def install() -> Path:
     arch = _get_arch()
     _debug(f"Using architecture {arch}")
 
-    file_name = f"marzano-{arch}-{platform}"
+    file_name = f"grit-{arch}-{platform}"
     download_url = f"https://github.com/getgrit/gritql/releases/latest/download/{file_name}.tar.gz"
 
     sys.stdout.write(f"Downloading Grit CLI from {download_url}\n")


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixing `openai migrate` by updating renamed binaries.
Closes #1838

## Additional context & links
On Oct25, [gritql main CLI name was changed](https://github.com/getgrit/gritql/pull/564), introducing #1838.
Upon inspection of [the relevant commit](https://github.com/getgrit/gritql/pull/564/commits/b183b4ac64a6f6cbd4ba5e7a73af8301c2156fdc), it consisted of a renaming of the prefix or their binaries.
This PR renames the prefix according to their change.