### PR TITLE
fix: considering default_headers for realtime headers

### DIFF
--- a/src/openai/_utils/_sync.py
+++ b/src/openai/_utils/_sync.py
@@ -50,6 +50,7 @@ def asyncify(function: Callable[T_ParamSpec, T_Retval]) -> Callable[T_ParamSpec,
         # blocking code
         return result
 
+
     result = asyncify(blocking_function)(arg1, arg2, kwarg1=value1)
     ```
 

--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -96,7 +96,7 @@ class Realtime(SyncAPIResource):
         return RealtimeConnectionManager(
             client=self._client,
             extra_query=extra_query,
-            extra_headers=extra_headers,
+            extra_headers=extra_headers or self._client.default_headers,
             websocket_connection_options=websocket_connection_options,
             model=model,
         )
@@ -148,7 +148,7 @@ class AsyncRealtime(AsyncAPIResource):
         return AsyncRealtimeConnectionManager(
             client=self._client,
             extra_query=extra_query,
-            extra_headers=extra_headers,
+            extra_headers=extra_headers or self._client.default_headers,
             websocket_connection_options=websocket_connection_options,
             model=model,
         )

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -153,7 +153,6 @@ async def test_client_token_provider_refresh_async(respx_mock: MockRouter) -> No
 
 
 class TestAzureLogging:
-
     @pytest.fixture(autouse=True)
     def logger_with_filter(self) -> logging.Logger:
         logger = logging.getLogger("openai")
@@ -165,9 +164,7 @@ class TestAzureLogging:
     def test_azure_api_key_redacted(self, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture) -> None:
         respx_mock.post(
             "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions?api-version=2024-06-01"
-        ).mock(
-            return_value=httpx.Response(200, json={"model": "gpt-4"})
-        )
+        ).mock(return_value=httpx.Response(200, json={"model": "gpt-4"}))
 
         client = AzureOpenAI(
             api_version="2024-06-01",
@@ -182,14 +179,11 @@ class TestAzureLogging:
             if is_dict(record.args) and record.args.get("headers") and is_dict(record.args["headers"]):
                 assert record.args["headers"]["api-key"] == "<redacted>"
 
-
     @pytest.mark.respx()
     def test_azure_bearer_token_redacted(self, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture) -> None:
         respx_mock.post(
             "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions?api-version=2024-06-01"
-        ).mock(
-            return_value=httpx.Response(200, json={"model": "gpt-4"})
-        )
+        ).mock(return_value=httpx.Response(200, json={"model": "gpt-4"}))
 
         client = AzureOpenAI(
             api_version="2024-06-01",
@@ -204,15 +198,12 @@ class TestAzureLogging:
             if is_dict(record.args) and record.args.get("headers") and is_dict(record.args["headers"]):
                 assert record.args["headers"]["Authorization"] == "<redacted>"
 
-
     @pytest.mark.asyncio
     @pytest.mark.respx()
     async def test_azure_api_key_redacted_async(self, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture) -> None:
         respx_mock.post(
             "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions?api-version=2024-06-01"
-        ).mock(
-            return_value=httpx.Response(200, json={"model": "gpt-4"})
-        )
+        ).mock(return_value=httpx.Response(200, json={"model": "gpt-4"}))
 
         client = AsyncAzureOpenAI(
             api_version="2024-06-01",
@@ -227,15 +218,14 @@ class TestAzureLogging:
             if is_dict(record.args) and record.args.get("headers") and is_dict(record.args["headers"]):
                 assert record.args["headers"]["api-key"] == "<redacted>"
 
-
     @pytest.mark.asyncio
     @pytest.mark.respx()
-    async def test_azure_bearer_token_redacted_async(self, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture) -> None:
+    async def test_azure_bearer_token_redacted_async(
+        self, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture
+    ) -> None:
         respx_mock.post(
             "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions?api-version=2024-06-01"
-        ).mock(
-            return_value=httpx.Response(200, json={"model": "gpt-4"})
-        )
+        ).mock(return_value=httpx.Response(200, json={"model": "gpt-4"}))
 
         client = AsyncAzureOpenAI(
             api_version="2024-06-01",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Added logic to pick default_headers for extra_headers in case of realtime endpoints. 

Useful when openai client is being used as a proxy via default_headers

## Additional context & links
Fixes: #1975 
