### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ If you need to access undocumented endpoints, params, or response properties, th
 #### Undocumented endpoints
 
 To make requests to undocumented endpoints, you can make requests using `client.get`, `client.post`, and other
-http verbs. Options on the client will be respected (such as retries) will be respected when making this
+http verbs. Options on the client (such as retries) will be respected when making this
 request.
 
 ```py


### PR DESCRIPTION
"will be respected" was repeated twice before and after parentheses Noticed the same typo was made from a commited change from the anthropic-sdk-python repo (commit 1ef083b)

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
