### PR TITLE
BUG FIX: Pydantic conversion logic for structured outputs is broken for models containing dictionaries

### DIFF
--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -47,12 +47,17 @@ def _ensure_strict_json_schema(
             _ensure_strict_json_schema(definition_schema, path=(*path, "definitions", definition_name), root=root)
 
     typ = json_schema.get("type")
-    if typ == "object" and "additionalProperties" not in json_schema:
+    properties = json_schema.get("properties")
+    if (
+        typ == "object" and
+        "additionalProperties" not in json_schema and
+        is_dict(properties) and
+        len(properties) > 0
+    ):
         json_schema["additionalProperties"] = False
 
     # object types
     # { 'type': 'object', 'properties': { 'a':  {...} } }
-    properties = json_schema.get("properties")
     if is_dict(properties):
         json_schema["required"] = [prop for prop in properties.keys()]
         json_schema["properties"] = {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

There's a bug in OpenAI's python client logic for translating pydantic models with dictionaries into structured outputs JSON schema definitions: **dictionaries are always required to be empty in the resulting JSON schema, rendering the dictionary outputs significantly less useful since the LLM is never allowed to populate them**

This PR fixes the issue and introduces test coverage.

## Additional context & links

Fixes #2004