### PR TITLE
fix(parsing): handle whitespace only strings

### DIFF
--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -434,7 +434,8 @@ class ChatCompletionStreamState(Generic[ResponseFormatT]):
                 choice_snapshot.message.content
                 and not choice_snapshot.message.refusal
                 and is_given(self._rich_response_format)
-                and choice_snapshot.message.content.strip() # Add filter to ensure no parsing errors
+                # partial parsing fails on white-space
+                and choice_snapshot.message.content.strip()
             ):
                 choice_snapshot.message.parsed = from_json(
                     bytes(choice_snapshot.message.content, "utf-8"),

--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -434,6 +434,7 @@ class ChatCompletionStreamState(Generic[ResponseFormatT]):
                 choice_snapshot.message.content
                 and not choice_snapshot.message.refusal
                 and is_given(self._rich_response_format)
+                and choice_snapshot.message.content.strip() # Add filter to ensure no parsing errors
             ):
                 choice_snapshot.message.parsed = from_json(
                     bytes(choice_snapshot.message.content, "utf-8"),


### PR DESCRIPTION
…ng `from_json`

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- add filter logic to ensure chunk streaming work properly.

## Additional context & links
- I notice that in some case, when messages stack around 2 - 3 conversation turn, it will throw 'EOF error parsing', so I launch quick check on client lib, and found that, in some use case, server will send empty string with '\n', so it make jiter parsing function error.