### PR TITLE
Refactor condition to leverage truthiness for message.content in parsing

### DIFF
--- a/src/openai/lib/_parsing/_completions.py
+++ b/src/openai/lib/_parsing/_completions.py
@@ -157,7 +157,7 @@ def maybe_parse_content(
     response_format: type[ResponseFormatT] | ResponseFormatParam | NotGiven,
     message: ChatCompletionMessage | ParsedChatCompletionMessage[object],
 ) -> ResponseFormatT | None:
-    if has_rich_response_format(response_format) and message.content is not None and not message.refusal:
+    if has_rich_response_format(response_format) and message.content and not message.refusal:
         return _parse_content(response_format, message.content)
 
     return None


### PR DESCRIPTION
Fixing https://github.com/openai/openai-python/issues/1763 where parsing often fails when content is empty string instead of None.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
