### PR TITLE
fix(typo): 'guarentee' to 'guarantee'

### DIFF
--- a/src/openai/resources/chat/completions.py
+++ b/src/openai/resources/chat/completions.py
@@ -246,9 +246,9 @@ class Completions(SyncAPIResource):
                 utilize scale tier credits until they are exhausted.
               - If set to 'auto', and the Project is not Scale tier enabled, the request will
                 be processed using the default service tier with a lower uptime SLA and no
-                latency guarentee.
+                latency guarantee.
               - If set to 'default', the request will be processed using the default service
-                tier with a lower uptime SLA and no latency guarentee.
+                tier with a lower uptime SLA and no latency guarantee.
               - When not set, the default behavior is 'auto'.
 
               When this parameter is set, the response body will include the `service_tier`
@@ -504,9 +504,9 @@ class Completions(SyncAPIResource):
                 utilize scale tier credits until they are exhausted.
               - If set to 'auto', and the Project is not Scale tier enabled, the request will
                 be processed using the default service tier with a lower uptime SLA and no
-                latency guarentee.
+                latency guarantee.
               - If set to 'default', the request will be processed using the default service
-                tier with a lower uptime SLA and no latency guarentee.
+                tier with a lower uptime SLA and no latency guarantee.
               - When not set, the default behavior is 'auto'.
 
               When this parameter is set, the response body will include the `service_tier`
@@ -755,9 +755,9 @@ class Completions(SyncAPIResource):
                 utilize scale tier credits until they are exhausted.
               - If set to 'auto', and the Project is not Scale tier enabled, the request will
                 be processed using the default service tier with a lower uptime SLA and no
-                latency guarentee.
+                latency guarantee.
               - If set to 'default', the request will be processed using the default service
-                tier with a lower uptime SLA and no latency guarentee.
+                tier with a lower uptime SLA and no latency guarantee.
               - When not set, the default behavior is 'auto'.
 
               When this parameter is set, the response body will include the `service_tier`
@@ -1107,9 +1107,9 @@ class AsyncCompletions(AsyncAPIResource):
                 utilize scale tier credits until they are exhausted.
               - If set to 'auto', and the Project is not Scale tier enabled, the request will
                 be processed using the default service tier with a lower uptime SLA and no
-                latency guarentee.
+                latency guarantee.
               - If set to 'default', the request will be processed using the default service
-                tier with a lower uptime SLA and no latency guarentee.
+                tier with a lower uptime SLA and no latency guarantee.
               - When not set, the default behavior is 'auto'.
 
               When this parameter is set, the response body will include the `service_tier`
@@ -1365,9 +1365,9 @@ class AsyncCompletions(AsyncAPIResource):
                 utilize scale tier credits until they are exhausted.
               - If set to 'auto', and the Project is not Scale tier enabled, the request will
                 be processed using the default service tier with a lower uptime SLA and no
-                latency guarentee.
+                latency guarantee.
               - If set to 'default', the request will be processed using the default service
-                tier with a lower uptime SLA and no latency guarentee.
+                tier with a lower uptime SLA and no latency guarantee.
               - When not set, the default behavior is 'auto'.
 
               When this parameter is set, the response body will include the `service_tier`
@@ -1616,9 +1616,9 @@ class AsyncCompletions(AsyncAPIResource):
                 utilize scale tier credits until they are exhausted.
               - If set to 'auto', and the Project is not Scale tier enabled, the request will
                 be processed using the default service tier with a lower uptime SLA and no
-                latency guarentee.
+                latency guarantee.
               - If set to 'default', the request will be processed using the default service
-                tier with a lower uptime SLA and no latency guarentee.
+                tier with a lower uptime SLA and no latency guarantee.
               - When not set, the default behavior is 'auto'.
 
               When this parameter is set, the response body will include the `service_tier`

--- a/src/openai/types/chat/completion_create_params.py
+++ b/src/openai/types/chat/completion_create_params.py
@@ -216,9 +216,9 @@ class CompletionCreateParamsBase(TypedDict, total=False):
       utilize scale tier credits until they are exhausted.
     - If set to 'auto', and the Project is not Scale tier enabled, the request will
       be processed using the default service tier with a lower uptime SLA and no
-      latency guarentee.
+      latency guarantee.
     - If set to 'default', the request will be processed using the default service
-      tier with a lower uptime SLA and no latency guarentee.
+      tier with a lower uptime SLA and no latency guarantee.
     - When not set, the default behavior is 'auto'.
 
     When this parameter is set, the response body will include the `service_tier`


### PR DESCRIPTION
- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixed typo 'guarentee' to 'guarantee' on `completions.py` and `completion_create_params.py`

## Additional context & links
