### PR TITLE
Support both string and integer types for duration in TranslationVerbose

### DIFF
--- a/src/openai/types/audio/translation_verbose.py
+++ b/src/openai/types/audio/translation_verbose.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from ..._models import BaseModel
 from .transcription_segment import TranscriptionSegment
@@ -9,7 +9,7 @@ __all__ = ["TranslationVerbose"]
 
 
 class TranslationVerbose(BaseModel):
-    duration: str
+    duration: Union[str, int]
     """The duration of the input audio."""
 
     language: str
@@ -20,3 +20,7 @@ class TranslationVerbose(BaseModel):
 
     segments: Optional[List[TranscriptionSegment]] = None
     """Segments of the translated text and their corresponding details."""
+
+    def __post_init__(self):
+        if isinstance(self.duration, int):
+            self.duration = str(self.duration)


### PR DESCRIPTION
This update enhances the `TranslationVerbose` model by supporting both string and integer types for the `duration` field:  

- **Changed**: Updated the `duration` field type to `Union[str, int]` to allow both formats.  
- **Added**: A `__post_init__` method to ensure consistent handling of integer durations by converting them to strings internally.  

This change addresses potential usability issues where the duration might be provided as an integer but was previously expected as a string.  

**Impact**: Improves flexibility and usability for the `TranslationVerbose` model.  

- [x] I understand that this repository is auto-generated and my pull request may not be merged  

### Changes Being Requested  
Support for both string and integer values in the `duration` field of the `TranslationVerbose` model.  

### Additional Context & Links  
- Relevant issue: #1814.  
This change ensures better compatibility and reduces confusion when `duration` is supplied as an integer.