### PR TITLE
fix(types): add "developer" role to support O-series models

### DIFF
--- a/src/openai/types/chat/chat_completion_role.py
+++ b/src/openai/types/chat/chat_completion_role.py
@@ -4,4 +4,4 @@ from typing_extensions import Literal, TypeAlias
 
 __all__ = ["ChatCompletionRole"]
 
-ChatCompletionRole: TypeAlias = Literal["system", "user", "assistant", "tool", "function"]
+ChatCompletionRole: TypeAlias = Literal["system", "user", "assistant", "tool", "function", "developer"]


### PR DESCRIPTION
The OpenAI API now supports a "developer" role specifically for O-series models, but this role was missing in the type definitions. This update adds the "developer" role to ChatCompletionRole type alias to prevent IDE warnings while maintaining compatibility with the actual API behavior.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
