### PR TITLE
fix(parsing): don't default to an empty array

### DIFF
--- a/src/openai/lib/_parsing/_completions.py
+++ b/src/openai/lib/_parsing/_completions.py
@@ -111,7 +111,7 @@ def parse_chat_completion(
                             response_format=response_format,
                             message=message,
                         ),
-                        "tool_calls": tool_calls,
+                        "tool_calls": tool_calls if tool_calls else None,
                     },
                 },
             )

--- a/tests/lib/chat/test_completions.py
+++ b/tests/lib/chat/test_completions.py
@@ -65,7 +65,7 @@ recommend checking a reliable weather website or app like the Weather Channel or
                 parsed=None,
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],
@@ -132,7 +132,7 @@ ParsedChatCompletion[Location](
                 parsed=Location(city='San Francisco', temperature=65.0, units='f'),
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],
@@ -201,7 +201,7 @@ ParsedChatCompletion[Location](
                 parsed=Location(city='San Francisco', temperature=65.0, units='f'),
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],
@@ -272,7 +272,7 @@ ParsedChoice[ColorDetection](
         parsed=ColorDetection(color=<Color.RED: 'red'>, hex_color_code='#FF0000'),
         refusal=None,
         role='assistant',
-        tool_calls=[]
+        tool_calls=None
     )
 )
 """
@@ -321,7 +321,7 @@ def test_parse_pydantic_model_multiple_choices(
             parsed=Location(city='San Francisco', temperature=64.0, units='f'),
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     ),
     ParsedChoice[Location](
@@ -335,7 +335,7 @@ def test_parse_pydantic_model_multiple_choices(
             parsed=Location(city='San Francisco', temperature=65.0, units='f'),
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     ),
     ParsedChoice[Location](
@@ -349,7 +349,7 @@ def test_parse_pydantic_model_multiple_choices(
             parsed=Location(city='San Francisco', temperature=63.0, units='f'),
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -399,7 +399,7 @@ ParsedChatCompletion[CalendarEvent](
                 parsed=CalendarEvent(name='Science Fair', date='Friday', participants=['Alice', 'Bob']),
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],
@@ -571,7 +571,7 @@ def test_parse_pydantic_model_refusal(client: OpenAI, respx_mock: MockRouter, mo
             parsed=None,
             refusal="I'm very sorry, but I can't assist with that.",
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -855,7 +855,7 @@ ParsedChatCompletion[Location](
                 parsed=Location(city='San Francisco', temperature=58.0, units='f'),
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],
@@ -930,7 +930,7 @@ ParsedChatCompletion[Location](
                 parsed=Location(city='San Francisco', temperature=65.0, units='f'),
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],

--- a/tests/lib/chat/test_completions_streaming.py
+++ b/tests/lib/chat/test_completions_streaming.py
@@ -70,7 +70,7 @@ recommend checking a reliable weather website or a weather app.",
             parsed=None,
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -147,7 +147,7 @@ ParsedChatCompletion[Location](
                 parsed=Location(city='San Francisco', temperature=61.0, units='f'),
                 refusal=None,
                 role='assistant',
-                tool_calls=[]
+                tool_calls=None
             )
         )
     ],
@@ -324,7 +324,7 @@ def test_parse_pydantic_model_multiple_choices(
             parsed=Location(city='San Francisco', temperature=65.0, units='f'),
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     ),
     ParsedChoice[Location](
@@ -338,7 +338,7 @@ def test_parse_pydantic_model_multiple_choices(
             parsed=Location(city='San Francisco', temperature=61.0, units='f'),
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     ),
     ParsedChoice[Location](
@@ -352,7 +352,7 @@ def test_parse_pydantic_model_multiple_choices(
             parsed=Location(city='San Francisco', temperature=59.0, units='f'),
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -427,7 +427,7 @@ RefusalDoneEvent(refusal="I'm sorry, I can't assist with that request.", type='r
             parsed=None,
             refusal="I'm sorry, I can't assist with that request.",
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -501,7 +501,7 @@ def test_content_logprobs_events(client: OpenAI, respx_mock: MockRouter, monkeyp
             parsed=None,
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -612,7 +612,7 @@ def test_refusal_logprobs_events(client: OpenAI, respx_mock: MockRouter, monkeyp
             parsed=None,
             refusal="I'm very sorry, but I can't assist with that.",
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -925,7 +925,7 @@ def test_non_pydantic_response_format(client: OpenAI, respx_mock: MockRouter, mo
             parsed=None,
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]
@@ -1040,7 +1040,7 @@ recommend checking a reliable weather website or a weather app.",
             parsed=None,
             refusal=None,
             role='assistant',
-            tool_calls=[]
+            tool_calls=None
         )
     )
 ]


### PR DESCRIPTION
The previous behaviour breaks passing messages back in.

See #2061.