### PR TITLE
Fix the issue where the task was being scheduled in stopped loop

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1364,9 +1364,13 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
         if self.is_closed:
             return
 
+        # TODO(someday): support non asyncio runtimes here
         try:
-            # TODO(someday): support non asyncio runtimes here
-            asyncio.get_running_loop().create_task(self.aclose())
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                loop.create_task(self.aclose())
+            else:
+                loop.run_until_complete(self.aclose())
         except Exception:
             pass
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Properly call httpx AsyncClient aclose method.

## Additional context & links

As of now, there is an issue when using AsyncOpenAI in AWS Lambdas because the event loop is closed and after that the `aclose()` coroutine is scheduled. 
By checking if the loop is running before actually scheduling the coroutine, the issue is resolved.