### PR TITLE
fix is_given() that thinks None is a tool

### DIFF
--- a/src/openai/_utils/_utils.py
+++ b/src/openai/_utils/_utils.py
@@ -124,8 +124,9 @@ def _extract_items(
 
 
 def is_given(obj: NotGivenOr[_T]) -> TypeGuard[_T]:
+    if obj is None or obj == []:
+        return False  # is_given() Misinterprets None as a Tool issue #2138
     return not isinstance(obj, NotGiven)
-
 
 # Type safe methods for narrowing types with TypeVars.
 # The default narrowing for isinstance(obj, dict) is dict[unknown, unknown],


### PR DESCRIPTION
issue #2138

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
**Current Implementation:**
```python
def is_given(obj: NotGivenOr[_T]) -> TypeGuard[_T]:
    return not isinstance(obj, NotGiven)
```
This function does not explicitly handle `None`, causing incorrect behavior when `tools=None`.

### Expected Behavior
If `tools` is `None`, `is_given(tools)` should return `False`, preventing the loop execution.

### Steps to Reproduce
1. Use `openai-python` in an environment where `tools=None` is passed to `validate_input_tools()`.
2. Observe the TypeError at line `for tool in tools:`.

### Workaround
A modified version of `is_given()` resolves the issue:

```python
def is_given(obj: NotGivenOr[_T]) -> TypeGuard[_T]:
    if obj is None or obj == []:
        return False
    return not isinstance(obj, NotGiven)
```

This correctly prevents the function from proceeding when `tools=None`.
