### PR TITLE
Add https:// prefix to azure_endpoint when missing

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -225,6 +225,10 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
             if azure_endpoint is not None:
                 raise ValueError("base_url and azure_endpoint are mutually exclusive")
 
+        # if base url does not start with https, we should add it
+        if not base_url.startswith("https://"):
+            base_url = f"https://{base_url}"
+
         if api_key is None:
             # define a sentinel value to avoid any typing issues
             api_key = API_KEY_SENTINEL
@@ -498,6 +502,10 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
         else:
             if azure_endpoint is not None:
                 raise ValueError("base_url and azure_endpoint are mutually exclusive")
+
+        # if base url does not start with https, we should add it
+        if not base_url.startswith("https://"):
+            base_url = f"https://{base_url}"
 
         if api_key is None:
             # define a sentinel value to avoid any typing issues


### PR DESCRIPTION
Add `https://` prefix to azure_endpoint when missing to avoid faulty URL construction where `azure_endpoint` is repeated twice

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Please either apply this change to add `https://` prefix to `azure_endpoint` or throw exception when it is missing. Otherwise the https client will create a weird URL like
```
<azure-ai-service-name>.cognitiveservices.azure.com/openai/<azure-ai-service-name>.cognitiveservices.azure.com/openai/deployments/<deployment-name>/chat/completions
```

Since host is not correctly parsed and set on the base URL.
## Additional context & links
