### PR TITLE
feat(responses): add ComputerCallOutput to response input parameters

### DIFF
--- a/src/openai/types/responses/__init__.py
+++ b/src/openai/types/responses/__init__.py
@@ -32,6 +32,7 @@ from .tool_choice_options import ToolChoiceOptions as ToolChoiceOptions
 from .response_error_event import ResponseErrorEvent as ResponseErrorEvent
 from .response_input_image import ResponseInputImage as ResponseInputImage
 from .response_input_param import ResponseInputParam as ResponseInputParam
+from .response_input_param import ComputerCallOutput as ComputerCallOutput
 from .response_output_item import ResponseOutputItem as ResponseOutputItem
 from .response_output_text import ResponseOutputText as ResponseOutputText
 from .response_text_config import ResponseTextConfig as ResponseTextConfig


### PR DESCRIPTION
This PR introduces an alias import for `ComputerCallOutput` in the `__init__.py` file of the `openai.types.responses` module by importing it from `response_input_param`:

```python
from .response_input_param import ComputerCallOutput as ComputerCallOutput
```

**Note:**  
The duplicate definition of `ComputerCallOutput` in `src/openai/types/responses/response_input_item_param.py` has **not** been removed and remains unchanged. This change simply provides a unified and accessible entry point via the package's `__init__.py`. Future cleanups may address the redundancy directly if needed.

## Additional Context & Links
- [x] I understand that this repository is auto-generated and my pull request may not be merged.

Feel free to review the changes and provide any feedback.