### PR TITLE
fix(types): make id optional in ResponseFunctionToolCallParam

### DIFF
--- a/src/openai/types/responses/response_function_tool_call_param.py
+++ b/src/openai/types/responses/response_function_tool_call_param.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Literal, Required, TypedDict
+from typing_extensions import Literal, Required, TypedDict, Optional
 
 __all__ = ["ResponseFunctionToolCallParam"]
 
@@ -20,7 +20,7 @@ class ResponseFunctionToolCallParam(TypedDict, total=False):
     type: Required[Literal["function_call"]]
     """The type of the function tool call. Always `function_call`."""
 
-    id: str
+    id: Optional[str]
     """The unique ID of the function tool call."""
 
     status: Literal["in_progress", "completed", "incomplete"]


### PR DESCRIPTION
This pull request addresses [Issue #2205](https://github.com/openai/openai-python/issues/2205) by updating the `ResponseFunctionToolCallParam` type. Previously, the `id` field was defined as a required string, but this change makes it optional, aligning the type definition with the actual usage scenarios.

**Changes Introduced:**  
- Updated `src/openai/types/responses/response_function_tool_call_param.py` to change the `id` field from `str` to `Optional[str]`.

**Rationale:**  
The GitHub issue details confirm that making id optional aligns with the API spec. Users have successfully tested the functionality without supplying an id, which further validates this change. This update improves the type accuracy and usability of the library.







