### PR TITLE
fix: when api_key is None, the request should not contain 'Authorizat…

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -170,7 +170,9 @@ class OpenAI(SyncAPIClient):
     @override
     def auth_headers(self) -> dict[str, str]:
         api_key = self.api_key
-        return {"Authorization": f"Bearer {api_key}"}
+        if api_key :
+            return {"Authorization": f"Bearer {api_key}"}
+        return {}
 
     @property
     @override
@@ -401,7 +403,9 @@ class AsyncOpenAI(AsyncAPIClient):
     @override
     def auth_headers(self) -> dict[str, str]:
         api_key = self.api_key
-        return {"Authorization": f"Bearer {api_key}"}
+        if api_key :
+            return {"Authorization": f"Bearer {api_key}"}
+        return {}
 
     @property
     @override


### PR DESCRIPTION
…ion': f 'Bearer {api_key}'. #961

fix: https://github.com/openai/openai-python/issues/961

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
