### PR TITLE
feat: add images/edits to azure endpoints list

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -25,6 +25,7 @@ _deployments_endpoints = set(
         "/audio/translations",
         "/audio/speech",
         "/images/generations",
+        "/images/edits",
     ]
 )
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Add images/generations to azure endpoints list.

## Additional context & links
With the new `gpt-image-1` being available on Azure OpenAI `/images/edits` endpoints is now a thing.