### PR TITLE
fix(images.edit): update `size` type annotation to match documentation

### DIFF
--- a/src/openai/resources/images.py
+++ b/src/openai/resources/images.py
@@ -124,7 +124,9 @@ class Images(SyncAPIResource):
         n: Optional[int] | NotGiven = NOT_GIVEN,
         quality: Optional[Literal["standard", "low", "medium", "high", "auto"]] | NotGiven = NOT_GIVEN,
         response_format: Optional[Literal["url", "b64_json"]] | NotGiven = NOT_GIVEN,
-        size: Optional[Literal["256x256", "512x512", "1024x1024"]] | NotGiven = NOT_GIVEN,
+        size: Optional[
+            Literal["auto", "1024x1024", "1536x1024", "1024x1536", "256x256", "512x512"]
+        ] | NotGiven = NOT_GIVEN,
         user: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -434,7 +436,9 @@ class AsyncImages(AsyncAPIResource):
         n: Optional[int] | NotGiven = NOT_GIVEN,
         quality: Optional[Literal["standard", "low", "medium", "high", "auto"]] | NotGiven = NOT_GIVEN,
         response_format: Optional[Literal["url", "b64_json"]] | NotGiven = NOT_GIVEN,
-        size: Optional[Literal["256x256", "512x512", "1024x1024"]] | NotGiven = NOT_GIVEN,
+        size: Optional[
+            Literal["auto", "1024x1024", "1536x1024", "1024x1536", "256x256", "512x512"]
+        ] | NotGiven = NOT_GIVEN,
         user: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.

--- a/src/openai/types/image_edit_params.py
+++ b/src/openai/types/image_edit_params.py
@@ -61,7 +61,7 @@ class ImageEditParams(TypedDict, total=False):
     `gpt-image-1` will always return base64-encoded images.
     """
 
-    size: Optional[Literal["256x256", "512x512", "1024x1024"]]
+    size: Optional[Literal["auto", "1024x1024", "1536x1024", "1024x1536", "256x256", "512x512"]]
     """The size of the generated images.
 
     Must be one of `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), or


### PR DESCRIPTION
Updates the type annotation of the `size` parameter in the `images.edit` method to match the official documentation.

Currently, the annotation is missing the valid options "1536x1024", "1024x1536", and "auto". As a result, IDEs and type checkers incorrectly flag valid resolutions as errors, causing unnecessary developer pain and triggering existential crises for perfectionists everywhere. 😅

This fix only affects type annotations and does not change runtime behavior.