### PR TITLE
fix: ignore errors in isinstance() calls on LazyProxy subclasses

### DIFF
--- a/src/openai/_utils/_proxy.py
+++ b/src/openai/_utils/_proxy.py
@@ -46,7 +46,10 @@ class LazyProxy(Generic[T], ABC):
     @property  # type: ignore
     @override
     def __class__(self) -> type:  # pyright: ignore
-        proxied = self.__get_proxied__()
+        try:
+            proxied = self.__get_proxied__()
+        except Exception:
+            return type(self)
         if issubclass(type(proxied), LazyProxy):
             return type(proxied)
         return proxied.__class__

--- a/tests/test_utils/test_proxy.py
+++ b/tests/test_utils/test_proxy.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing_extensions import override
 
 from openai._utils import LazyProxy
+from openai._extras._common import MissingDependencyError
 
 
 class RecursiveLazyProxy(LazyProxy[Any]):
@@ -21,3 +22,14 @@ def test_recursive_proxy() -> None:
     assert dir(proxy) == []
     assert type(proxy).__name__ == "RecursiveLazyProxy"
     assert type(operator.attrgetter("name.foo.bar.baz")(proxy)).__name__ == "RecursiveLazyProxy"
+
+
+def test_is_instance_with_missing_dependency_error() -> None:
+    class MissingDepsProxy(LazyProxy[Any]):
+        @override
+        def __load__(self) -> Any:
+            raise MissingDependencyError("Mocking missing dependency")
+
+    proxy = MissingDepsProxy()
+    assert not isinstance(proxy, dict)
+    assert isinstance(proxy, LazyProxy)


### PR DESCRIPTION
Fix #2056

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links

I assume this might need to be upstreamed in Stainless then?
