### PR TITLE
feat: expose vector_stores on client.beta

### DIFF
--- a/src/openai/resources/beta/beta.py
+++ b/src/openai/resources/beta/beta.py
@@ -30,6 +30,8 @@ from .realtime.realtime import (
     AsyncRealtimeWithStreamingResponse,
 )
 
+from ..vector_stores import VectorStores
+
 __all__ = ["Beta", "AsyncBeta"]
 
 
@@ -49,6 +51,11 @@ class Beta(SyncAPIResource):
     @cached_property
     def threads(self) -> Threads:
         return Threads(self._client)
+    
+    @cached_property
+    def vector_stores(self) -> VectorStores:
+        from ..vector_stores import VectorStores
+        return VectorStores(self._client)
 
     @cached_property
     def with_raw_response(self) -> BetaWithRawResponse:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Expose `vector_stores` under `client.beta` to enable Assistant file_search + vector_store_ids support.

## Additional context & links

Currently, OpenAI Python SDK 1.78.0 does not expose `client.beta.vector_stores`.  
This PR shows how to enable the missing entry point using:

```python
@cached_property
def vector_stores(self) -> VectorStores:
    from ..vector_stores import VectorStores
    return VectorStores(self._client)
```
See API reference: https://platform.openai.com/docs/assistants/tools/file-search
Related issue: [#<issue-number-if-you-opened-one>](https://github.com/openai/openai-python/issues/2347)