### PR TITLE
fix(embeddings): raise error message on missing data

### DIFF
--- a/src/openai/resources/embeddings.py
+++ b/src/openai/resources/embeddings.py
@@ -112,6 +112,9 @@ class Embeddings(SyncAPIResource):
                 # don't modify the response object if a user explicitly asked for a format
                 return obj
 
+            if not obj.data:
+                raise ValueError("No embedding data received")
+
             for embedding in obj.data:
                 data = cast(object, embedding.embedding)
                 if not isinstance(data, str):
@@ -227,6 +230,9 @@ class AsyncEmbeddings(AsyncAPIResource):
             if is_given(encoding_format):
                 # don't modify the response object if a user explicitly asked for a format
                 return obj
+
+            if not obj.data:
+                raise ValueError("No embedding data received")
 
             for embedding in obj.data:
                 data = cast(object, embedding.embedding)


### PR DESCRIPTION
I had a setup where my embedding model didn't reply properly and had a really hard time figuring out where
"NoneType object is not iterable" comes from.
With this error message, it should be easier to find the problem.

Possibly this is a bad place to create this exception, so please hint me into the right direction. I just
debugged my problem down to this place.

- [X] I understand that this repository is auto-generated and my pull request may not be merged

