### PR TITLE
docs: clarify async client cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,26 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-Functionality between the synchronous and asynchronous clients is otherwise identical.
+Functionality between the synchronous and asynchronous clients is otherwise mostly identical.
+
+### Async Garbage Collection
+
+When opening multiple `AsyncOpenAI` clients, it is recommended to use `with` blocks to handle
+resource management instead of relying on traditional garbage collection. Failing to do this
+may result in leaked connections and degraded performance over time since the async event loop
+can be cleaned up before the `AsyncOpenAI` client has a chance to clean up its resources.
+
+```
+async def callModel(prompt) -> None:
+   async with getAsyncVLLMClient(api_key=os.environ.get("OPENAI_API_KEY")) as client:
+      response = await client.responses.create(
+          model="gpt-4o", input=prompt
+      )
+
+prompts = [...]
+for prompt in prompts:
+   asyncio.run(callModel(prompt))
+```
 
 ## Streaming responses
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

When using multiple AsyncOpenAI clients to send records to a local vLLM server, we ran into an issue with garbage collection after switching from the sync client to the async client. We started seeing a bunch of errors like:

```
Traceback (most recent call last):\n  File \"/usr/local/lib/python3.9/dist-packages/httpx/_client.py\", line 1985, in aclose\n    await self._transport.aclose()\n  File \"/usr/local/lib/python3.9/dist-packages/httpx/_transports/default.py\", line 406, in aclose\n    await self._pool.aclose()\n  File \"/usr/local/lib/python3.9/dist-packages/httpcore/_async/connection_pool.py\", line 353, in aclose\n    await self._close_connections(closing_connections)\n  File \"/usr/local/lib/python3.9/dist-packages/httpcore/_async/connection_pool.py\", line 345, in _close_connections\n    await connection.aclose()\n  File \"/usr/local/lib/python3.9/dist-packages/httpcore/_async/connection.py\", line 173, in aclose\n    await self._connection.aclose()\n  File \"/usr/local/lib/python3.9/dist-packages/httpcore/_async/http11.py\", line 258, in aclose\n    await self._network_stream.aclose()\n  File \"/usr/local/lib/python3.9/dist-packages/httpcore/_backends/anyio.py\", line 53, in aclose\n    await self._stream.aclose()\n  File \"/usr/local/lib/python3.9/dist-packages/anyio/_backends/_asyncio.py\", line 1314, in aclose\n    self._transport.close()\n  File \"/usr/lib/python3.9/asyncio/selector_events.py\", line 698, in close\n    self._loop.call_soon(self._call_connection_lost, None)\n  File \"/usr/lib/python3.9/asyncio/base_events.py\", line 751, in call_soon\n    self._check_closed()\n  File \"/usr/lib/python3.9/asyncio/base_events.py\", line 515, in _check_closed\n    raise RuntimeError('Event loop is closed')\nRuntimeError: Event loop is closed\n
```

which indicated that the event loop was being closed before we could close the client. Concurrently, we saw degraded performance. When we switched to `with` blocks for resource management, the problem went away (PR - https://github.com/apache/beam/pull/35053/files). I seems like relying on normal garbage collection calling https://github.com/openai/openai-python/blob/f588695f77aad9279a355f5f483d8debf92b46ed/src/openai/_base_client.py#L1318C21-L1318C37 can cause a meaningful performance issue because the event loop can be destroyed before the client cleanup finishes.

Its not clear to me if the slowness was caused by:
1) Overhead associated with trying to call a closed event loop
2) Actually failing to close the connections

Regardless, it would be nice to doc this since switching clients did not work without some minor changes.