### PR TITLE
feat: model as first parameter in body for proxy routing efficiency

### DIFF
--- a/src/openai/resources/audio/speech.py
+++ b/src/openai/resources/audio/speech.py
@@ -100,8 +100,8 @@ class Speech(SyncAPIResource):
             "/audio/speech",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                     "voice": voice,
                     "instructions": instructions,
                     "response_format": response_format,
@@ -191,8 +191,8 @@ class AsyncSpeech(AsyncAPIResource):
             "/audio/speech",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                     "voice": voice,
                     "instructions": instructions,
                     "response_format": response_format,

--- a/src/openai/resources/audio/transcriptions.py
+++ b/src/openai/resources/audio/transcriptions.py
@@ -313,8 +313,8 @@ class Transcriptions(SyncAPIResource):
     ) -> str | Transcription | TranscriptionVerbose | Stream[TranscriptionStreamEvent]:
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "file": file,
-                "model": model,
                 "chunking_strategy": chunking_strategy,
                 "include": include,
                 "language": language,
@@ -692,8 +692,8 @@ class AsyncTranscriptions(AsyncAPIResource):
     ) -> Transcription | TranscriptionVerbose | str | AsyncStream[TranscriptionStreamEvent]:
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "file": file,
-                "model": model,
                 "chunking_strategy": chunking_strategy,
                 "include": include,
                 "language": language,

--- a/src/openai/resources/audio/translations.py
+++ b/src/openai/resources/audio/translations.py
@@ -146,8 +146,8 @@ class Translations(SyncAPIResource):
         """
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "file": file,
-                "model": model,
                 "prompt": prompt,
                 "response_format": response_format,
                 "temperature": temperature,
@@ -289,8 +289,8 @@ class AsyncTranslations(AsyncAPIResource):
         """
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "file": file,
-                "model": model,
                 "prompt": prompt,
                 "response_format": response_format,
                 "temperature": temperature,

--- a/src/openai/resources/beta/assistants.py
+++ b/src/openai/resources/beta/assistants.py
@@ -156,7 +156,7 @@ class Assistants(SyncAPIResource):
             "/assistants",
             body=maybe_transform(
                 {
-                    "model": model,
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "description": description,
                     "instructions": instructions,
                     "metadata": metadata,
@@ -360,10 +360,10 @@ class Assistants(SyncAPIResource):
             f"/assistants/{assistant_id}",
             body=maybe_transform(
                 {
+                    "model": model, # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "description": description,
                     "instructions": instructions,
                     "metadata": metadata,
-                    "model": model,
                     "name": name,
                     "reasoning_effort": reasoning_effort,
                     "response_format": response_format,
@@ -605,7 +605,7 @@ class AsyncAssistants(AsyncAPIResource):
             "/assistants",
             body=await async_maybe_transform(
                 {
-                    "model": model,
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "description": description,
                     "instructions": instructions,
                     "metadata": metadata,
@@ -809,10 +809,10 @@ class AsyncAssistants(AsyncAPIResource):
             f"/assistants/{assistant_id}",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "description": description,
                     "instructions": instructions,
                     "metadata": metadata,
-                    "model": model,
                     "name": name,
                     "reasoning_effort": reasoning_effort,
                     "response_format": response_format,

--- a/src/openai/resources/beta/chat/completions.py
+++ b/src/openai/resources/beta/chat/completions.py
@@ -159,8 +159,8 @@ class Completions(SyncAPIResource):
             "/chat/completions",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "messages": messages,
-                    "model": model,
                     "audio": audio,
                     "frequency_penalty": frequency_penalty,
                     "function_call": function_call,
@@ -438,8 +438,8 @@ class AsyncCompletions(AsyncAPIResource):
             "/chat/completions",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "messages": messages,
-                    "model": model,
                     "audio": audio,
                     "frequency_penalty": frequency_penalty,
                     "function_call": function_call,

--- a/src/openai/resources/beta/realtime/sessions.py
+++ b/src/openai/resources/beta/realtime/sessions.py
@@ -179,6 +179,7 @@ class Sessions(SyncAPIResource):
             "/realtime/sessions",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "client_secret": client_secret,
                     "input_audio_format": input_audio_format,
                     "input_audio_noise_reduction": input_audio_noise_reduction,
@@ -186,7 +187,6 @@ class Sessions(SyncAPIResource):
                     "instructions": instructions,
                     "max_response_output_tokens": max_response_output_tokens,
                     "modalities": modalities,
-                    "model": model,
                     "output_audio_format": output_audio_format,
                     "speed": speed,
                     "temperature": temperature,
@@ -364,6 +364,7 @@ class AsyncSessions(AsyncAPIResource):
             "/realtime/sessions",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "client_secret": client_secret,
                     "input_audio_format": input_audio_format,
                     "input_audio_noise_reduction": input_audio_noise_reduction,
@@ -371,7 +372,6 @@ class AsyncSessions(AsyncAPIResource):
                     "instructions": instructions,
                     "max_response_output_tokens": max_response_output_tokens,
                     "modalities": modalities,
-                    "model": model,
                     "output_audio_format": output_audio_format,
                     "speed": speed,
                     "temperature": temperature,

--- a/src/openai/resources/beta/threads/runs/runs.py
+++ b/src/openai/resources/beta/threads/runs/runs.py
@@ -573,6 +573,7 @@ class Runs(SyncAPIResource):
             f"/threads/{thread_id}/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "additional_instructions": additional_instructions,
                     "additional_messages": additional_messages,
@@ -580,7 +581,6 @@ class Runs(SyncAPIResource):
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "parallel_tool_calls": parallel_tool_calls,
                     "reasoning_effort": reasoning_effort,
                     "response_format": response_format,
@@ -976,6 +976,7 @@ class Runs(SyncAPIResource):
             f"/threads/{thread_id}/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "additional_instructions": additional_instructions,
                     "additional_messages": additional_messages,
@@ -983,7 +984,6 @@ class Runs(SyncAPIResource):
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "response_format": response_format,
                     "temperature": temperature,
                     "tool_choice": tool_choice,
@@ -1163,6 +1163,7 @@ class Runs(SyncAPIResource):
             f"/threads/{thread_id}/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "additional_instructions": additional_instructions,
                     "additional_messages": additional_messages,
@@ -1170,7 +1171,6 @@ class Runs(SyncAPIResource):
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "response_format": response_format,
                     "temperature": temperature,
                     "tool_choice": tool_choice,
@@ -2007,6 +2007,7 @@ class AsyncRuns(AsyncAPIResource):
             f"/threads/{thread_id}/runs",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "additional_instructions": additional_instructions,
                     "additional_messages": additional_messages,
@@ -2014,7 +2015,6 @@ class AsyncRuns(AsyncAPIResource):
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "parallel_tool_calls": parallel_tool_calls,
                     "reasoning_effort": reasoning_effort,
                     "response_format": response_format,
@@ -2409,6 +2409,7 @@ class AsyncRuns(AsyncAPIResource):
             f"/threads/{thread_id}/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "additional_instructions": additional_instructions,
                     "additional_messages": additional_messages,
@@ -2416,7 +2417,6 @@ class AsyncRuns(AsyncAPIResource):
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "response_format": response_format,
                     "temperature": temperature,
                     "tool_choice": tool_choice,
@@ -2596,6 +2596,7 @@ class AsyncRuns(AsyncAPIResource):
             f"/threads/{thread_id}/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "additional_instructions": additional_instructions,
                     "additional_messages": additional_messages,
@@ -2603,7 +2604,6 @@ class AsyncRuns(AsyncAPIResource):
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "response_format": response_format,
                     "temperature": temperature,
                     "tool_choice": tool_choice,

--- a/src/openai/resources/beta/threads/threads.py
+++ b/src/openai/resources/beta/threads/threads.py
@@ -707,12 +707,12 @@ class Threads(SyncAPIResource):
             "/threads/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "instructions": instructions,
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "parallel_tool_calls": parallel_tool_calls,
                     "response_format": response_format,
                     "stream": stream,
@@ -888,12 +888,12 @@ class Threads(SyncAPIResource):
             "/threads/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "instructions": instructions,
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "parallel_tool_calls": parallel_tool_calls,
                     "response_format": response_format,
                     "temperature": temperature,
@@ -1565,12 +1565,12 @@ class AsyncThreads(AsyncAPIResource):
             "/threads/runs",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "instructions": instructions,
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "parallel_tool_calls": parallel_tool_calls,
                     "response_format": response_format,
                     "stream": stream,
@@ -1750,12 +1750,12 @@ class AsyncThreads(AsyncAPIResource):
             "/threads/runs",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "assistant_id": assistant_id,
                     "instructions": instructions,
                     "max_completion_tokens": max_completion_tokens,
                     "max_prompt_tokens": max_prompt_tokens,
                     "metadata": metadata,
-                    "model": model,
                     "parallel_tool_calls": parallel_tool_calls,
                     "response_format": response_format,
                     "temperature": temperature,

--- a/src/openai/resources/chat/completions/completions.py
+++ b/src/openai/resources/chat/completions/completions.py
@@ -926,8 +926,8 @@ class Completions(SyncAPIResource):
             "/chat/completions",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "messages": messages,
-                    "model": model,
                     "audio": audio,
                     "frequency_penalty": frequency_penalty,
                     "function_call": function_call,
@@ -2029,8 +2029,8 @@ class AsyncCompletions(AsyncAPIResource):
             "/chat/completions",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "messages": messages,
-                    "model": model,
                     "audio": audio,
                     "frequency_penalty": frequency_penalty,
                     "function_call": function_call,

--- a/src/openai/resources/completions.py
+++ b/src/openai/resources/completions.py
@@ -542,7 +542,7 @@ class Completions(SyncAPIResource):
             "/completions",
             body=maybe_transform(
                 {
-                    "model": model,
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "prompt": prompt,
                     "best_of": best_of,
                     "echo": echo,
@@ -1092,7 +1092,7 @@ class AsyncCompletions(AsyncAPIResource):
             "/completions",
             body=await async_maybe_transform(
                 {
-                    "model": model,
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "prompt": prompt,
                     "best_of": best_of,
                     "echo": echo,

--- a/src/openai/resources/embeddings.py
+++ b/src/openai/resources/embeddings.py
@@ -98,8 +98,8 @@ class Embeddings(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         params = {
+            "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
             "input": input,
-            "model": model,
             "user": user,
             "dimensions": dimensions,
             "encoding_format": encoding_format,
@@ -214,8 +214,8 @@ class AsyncEmbeddings(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         params = {
+            "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
             "input": input,
-            "model": model,
             "user": user,
             "dimensions": dimensions,
             "encoding_format": encoding_format,

--- a/src/openai/resources/fine_tuning/jobs/jobs.py
+++ b/src/openai/resources/fine_tuning/jobs/jobs.py
@@ -157,7 +157,7 @@ class Jobs(SyncAPIResource):
             "/fine_tuning/jobs",
             body=maybe_transform(
                 {
-                    "model": model,
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "training_file": training_file,
                     "hyperparameters": hyperparameters,
                     "integrations": integrations,
@@ -535,7 +535,7 @@ class AsyncJobs(AsyncAPIResource):
             "/fine_tuning/jobs",
             body=await async_maybe_transform(
                 {
-                    "model": model,
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "training_file": training_file,
                     "hyperparameters": hyperparameters,
                     "integrations": integrations,

--- a/src/openai/resources/images.py
+++ b/src/openai/resources/images.py
@@ -91,8 +91,8 @@ class Images(SyncAPIResource):
         """
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "image": image,
-                "model": model,
                 "n": n,
                 "response_format": response_format,
                 "size": size,
@@ -198,11 +198,11 @@ class Images(SyncAPIResource):
         """
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "image": image,
                 "prompt": prompt,
                 "background": background,
                 "mask": mask,
-                "model": model,
                 "n": n,
                 "quality": quality,
                 "response_format": response_format,
@@ -323,9 +323,9 @@ class Images(SyncAPIResource):
             "/images/generations",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "prompt": prompt,
                     "background": background,
-                    "model": model,
                     "moderation": moderation,
                     "n": n,
                     "output_compression": output_compression,
@@ -415,8 +415,8 @@ class AsyncImages(AsyncAPIResource):
         """
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "image": image,
-                "model": model,
                 "n": n,
                 "response_format": response_format,
                 "size": size,
@@ -522,11 +522,11 @@ class AsyncImages(AsyncAPIResource):
         """
         body = deepcopy_minimal(
             {
+                "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                 "image": image,
                 "prompt": prompt,
                 "background": background,
                 "mask": mask,
-                "model": model,
                 "n": n,
                 "quality": quality,
                 "response_format": response_format,
@@ -647,9 +647,9 @@ class AsyncImages(AsyncAPIResource):
             "/images/generations",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "prompt": prompt,
                     "background": background,
-                    "model": model,
                     "moderation": moderation,
                     "n": n,
                     "output_compression": output_compression,

--- a/src/openai/resources/moderations.py
+++ b/src/openai/resources/moderations.py
@@ -79,8 +79,8 @@ class Moderations(SyncAPIResource):
             "/moderations",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                 },
                 moderation_create_params.ModerationCreateParams,
             ),
@@ -149,8 +149,8 @@ class AsyncModerations(AsyncAPIResource):
             "/moderations",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                 },
                 moderation_create_params.ModerationCreateParams,
             ),

--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -691,8 +691,8 @@ class Responses(SyncAPIResource):
             "/responses",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                     "background": background,
                     "include": include,
                     "instructions": instructions,
@@ -802,8 +802,8 @@ class Responses(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ResponseStreamManager[TextFormatT]:
         new_response_args = {
+            "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
             "input": input,
-            "model": model,
             "include": include,
             "instructions": instructions,
             "max_output_tokens": max_output_tokens,
@@ -943,8 +943,8 @@ class Responses(SyncAPIResource):
             "/responses",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                     "include": include,
                     "instructions": instructions,
                     "max_output_tokens": max_output_tokens,
@@ -1899,8 +1899,8 @@ class AsyncResponses(AsyncAPIResource):
             "/responses",
             body=await async_maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                     "background": background,
                     "include": include,
                     "instructions": instructions,
@@ -2010,8 +2010,8 @@ class AsyncResponses(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> AsyncResponseStreamManager[TextFormatT]:
         new_response_args = {
+            "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
             "input": input,
-            "model": model,
             "include": include,
             "instructions": instructions,
             "max_output_tokens": max_output_tokens,
@@ -2155,8 +2155,8 @@ class AsyncResponses(AsyncAPIResource):
             "/responses",
             body=maybe_transform(
                 {
+                    "model": model,  # Always set model as the first field in the payload. In some proxies, this is used for routing. We don't want to read all messages specifically big ones for routing.
                     "input": input,
-                    "model": model,
                     "include": include,
                     "instructions": instructions,
                     "max_output_tokens": max_output_tokens,


### PR DESCRIPTION
I would like that the generator could produce code with the "model" field as the first parameter only.

Proxies such as open-router (or custom proxies) use the "model" field as a routing parameter. We don't need to read the entire payload for routing, we can readily exit the read when we find the "model" field. 

The important thing is that the "model" field should be before the "prompt" or "inputs" as those can be very large.