### PR TITLE
#2355 adding cached_token_details to realtime_response_usage

### DIFF
--- a/src/openai/types/beta/realtime/realtime_response_usage.py
+++ b/src/openai/types/beta/realtime/realtime_response_usage.py
@@ -6,6 +6,13 @@ from ...._models import BaseModel
 
 __all__ = ["RealtimeResponseUsage", "InputTokenDetails", "OutputTokenDetails"]
 
+class CachedTokenDetails(BaseModel):
+    """Details about the cached tokens used in the response."""
+    text_tokens: Optional[int] = None
+    """The number of cached text tokens."""
+
+    audio_tokens: Optional[int] = None
+    """The number of cached audio tokens."""
 
 class InputTokenDetails(BaseModel):
     audio_tokens: Optional[int] = None
@@ -16,6 +23,9 @@ class InputTokenDetails(BaseModel):
 
     text_tokens: Optional[int] = None
     """The number of text tokens used in the Response."""
+    
+    cached_tokens_details: Optional[CachedTokenDetails] = None
+    """A detailed breakdown of the cached tokens."""
 
 
 class OutputTokenDetails(BaseModel):


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ Yes] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
#2355 adding cached_token_details to realtime_response_usage - created a separate class for cached_token_details and added it as an optional attribute in input_token_details

## Additional context & links
Response done API usage - https://platform.openai.com/docs/api-reference/realtime-server-events/response/done to verify the field and structure in the API response
