### PR TITLE
Enable custom auth for OpenAI clients (prototype)

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -84,7 +84,7 @@ if not _t.TYPE_CHECKING:
 
 from .lib import azure as _azure, pydantic_function_tool as pydantic_function_tool
 from .version import VERSION as VERSION
-from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI
+from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI, AzureAuth as AzureAuth
 from .lib._old_api import *
 from .lib.streaming import (
     AssistantEventHandler as AssistantEventHandler,

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -819,6 +819,7 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx.Client | None = None,
+        auth: httpx.Auth | None = None,
         custom_headers: Mapping[str, str] | None = None,
         custom_query: Mapping[str, object] | None = None,
         _strict_response_validation: bool,
@@ -856,6 +857,12 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             # cast to a valid type because mypy doesn't understand our type narrowing
             timeout=cast(Timeout, timeout),
         )
+        self._custom_auth = auth
+
+    @property
+    @override
+    def custom_auth(self) -> httpx.Auth | None:
+        return self._custom_auth
 
     def is_closed(self) -> bool:
         return self._client.is_closed
@@ -1343,6 +1350,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         max_retries: int = DEFAULT_MAX_RETRIES,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx.AsyncClient | None = None,
+        auth: httpx.Auth | None = None,
         custom_headers: Mapping[str, str] | None = None,
         custom_query: Mapping[str, object] | None = None,
     ) -> None:
@@ -1379,7 +1387,13 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             # cast to a valid type because mypy doesn't understand our type narrowing
             timeout=cast(Timeout, timeout),
         )
+        self._custom_auth = auth
 
+    @property
+    @override
+    def custom_auth(self) -> httpx.Auth | None:
+        return self._custom_auth
+    
     def is_closed(self) -> bool:
         return self._client.is_closed
 

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -103,6 +103,7 @@ class OpenAI(SyncAPIClient):
         # We provide a `DefaultHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
         # See the [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
         http_client: httpx.Client | None = None,
+        auth: httpx.Auth | None = None,
         # Enable or disable schema validation for data returned by the API.
         # When enabled an error APIResponseValidationError is raised
         # if the API responds with invalid data for the expected schema.
@@ -149,6 +150,7 @@ class OpenAI(SyncAPIClient):
             max_retries=max_retries,
             timeout=timeout,
             http_client=http_client,
+            auth = auth,
             custom_headers=default_headers,
             custom_query=default_query,
             _strict_response_validation=_strict_response_validation,
@@ -292,6 +294,7 @@ class OpenAI(SyncAPIClient):
         base_url: str | httpx.URL | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx.Client | None = None,
+        auth: httpx.Auth | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
         default_headers: Mapping[str, str] | None = None,
         set_default_headers: Mapping[str, str] | None = None,
@@ -329,6 +332,7 @@ class OpenAI(SyncAPIClient):
             base_url=base_url or self.base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
+            auth=auth or self.custom_auth,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,
             default_headers=headers,
             default_query=params,
@@ -404,6 +408,7 @@ class AsyncOpenAI(AsyncAPIClient):
         # We provide a `DefaultAsyncHttpxClient` class that you can pass to retain the default values we use for `limits`, `timeout` & `follow_redirects`.
         # See the [httpx documentation](https://www.python-httpx.org/api/#asyncclient) for more details.
         http_client: httpx.AsyncClient | None = None,
+        auth: httpx.Auth | None = None,
         # Enable or disable schema validation for data returned by the API.
         # When enabled an error APIResponseValidationError is raised
         # if the API responds with invalid data for the expected schema.
@@ -450,6 +455,7 @@ class AsyncOpenAI(AsyncAPIClient):
             max_retries=max_retries,
             timeout=timeout,
             http_client=http_client,
+            auth=auth,
             custom_headers=default_headers,
             custom_query=default_query,
             _strict_response_validation=_strict_response_validation,
@@ -593,6 +599,7 @@ class AsyncOpenAI(AsyncAPIClient):
         base_url: str | httpx.URL | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx.AsyncClient | None = None,
+        auth: httpx.Auth | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
         default_headers: Mapping[str, str] | None = None,
         set_default_headers: Mapping[str, str] | None = None,
@@ -630,6 +637,7 @@ class AsyncOpenAI(AsyncAPIClient):
             base_url=base_url or self.base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
+            auth=auth or self.custom_auth,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,
             default_headers=headers,
             default_query=params,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Added the ability to pass in a custom httpx.Auth instance to the OpenAI/AsyncOpenAI client.

## Additional context & links

Could be a basis to resolve #1611 

## Example usage:

```python
from openai import OpenAI, AzureAuth

import azure.identity

# may change in the future
# https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning
api_version = "2023-07-01-preview"

# gets the API Key from environment variable AZURE_OPENAI_API_KEY
client = OpenAI(
    # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal#create-a-resource
    base_url="https://contoso.com/openai/deployments/gpt-4",
    api_key = "dummy",  # Azure OpenAI does not use API keys, but this is required by the OpenAI client
    auth = AzureAuth(
        azure.identity.DefaultAzureCredential(exclude_interactive_browser_credential=False)
    ),
    default_query={"api-version": api_version}, # api-versions will be dropped in the future
)

completion = client.chat.completions.create(
    model="gpt-4",  # e.g. gpt-35-instant
    messages=[
        {
            "role": "user",
            "content": "How do I output all files in a directory using Python?",
        },
    ],
)
print(completion.to_json())
```
