### PR TITLE
support oci auth

### DIFF
--- a/examples/oci_client.py
+++ b/examples/oci_client.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env -S rye run python
+
+from openai import OciOpenAI, OciSessionAuth
+
+client = OciOpenAI(
+    service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+    auth=OciSessionAuth(profile_name="<profile name>"),
+    compartment_id="<compartment ocid>",
+)
+
+completion = client.chat.completions.create(
+    model="<model name>",
+    messages=[
+        {
+            "role": "user",
+            "content": "How do I output all files in a directory using Python?",
+        },
+    ],
+)
+print(completion.model_dump_json())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev-dependencies = [
     "rich>=13.7.1",
     "inline-snapshot >=0.7.0",
     "azure-identity >=1.14.1",
+    "oci >= 2.150.0",
     "types-tqdm > 4",
     "types-pyaudio > 0",
     "trio >=0.22.2",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -40,12 +40,15 @@ black==24.10.0
 certifi==2023.7.22
     # via httpcore
     # via httpx
+    # via oci
     # via requests
 cffi==1.16.0
     # via cryptography
     # via sounddevice
 charset-normalizer==3.3.2
     # via requests
+circuitbreaker==2.1.3
+    # via oci
 click==8.1.7
     # via black
     # via inline-snapshot
@@ -54,7 +57,9 @@ colorlog==6.7.0
 cryptography==42.0.7
     # via azure-identity
     # via msal
+    # via oci
     # via pyjwt
+    # via pyopenssl
 dirty-equals==0.6.0
 distlib==0.3.7
     # via virtualenv
@@ -119,6 +124,7 @@ numpy==2.0.2
     # via openai
     # via pandas
     # via pandas-stubs
+oci==2.154.3
 outcome==1.3.0.post0
     # via trio
 packaging==23.2
@@ -151,6 +157,8 @@ pygments==2.18.0
     # via rich
 pyjwt==2.8.0
     # via msal
+pyopenssl==24.3.0
+    # via oci
 pyright==1.1.399
 pytest==8.3.3
     # via pytest-asyncio
@@ -158,10 +166,12 @@ pytest==8.3.3
 pytest-asyncio==0.24.0
 pytest-xdist==3.7.0
 python-dateutil==2.8.2
+    # via oci
     # via pandas
     # via time-machine
 pytz==2023.3.post1
     # via dirty-equals
+    # via oci
     # via pandas
 requests==2.31.0
     # via azure-core

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -86,6 +86,14 @@ if not _t.TYPE_CHECKING:
     from ._utils._resources_proxy import resources as resources
 
 from .lib import azure as _azure, pydantic_function_tool as pydantic_function_tool
+from .lib.oci import (
+    OciOpenAI as OciOpenAI,
+    AsyncOciOpenAI as AsyncOciOpenAI,
+    OciSessionAuth as OciSessionAuth,
+    OciUserPrincipleAuth as OciUserPrincipleAuth,
+    OciInstancePrincipleAuth as OciInstancePrincipleAuth,
+    OciResourcePrincipleAuth as OciResourcePrincipleAuth,
+)
 from .version import VERSION as VERSION
 from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI
 from .lib._old_api import *

--- a/src/openai/lib/oci.py
+++ b/src/openai/lib/oci.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Generator
+from typing_extensions import override
+
+import oci
+import httpx
+import requests
+from oci.config import DEFAULT_PROFILE, DEFAULT_LOCATION
+
+from .._client import (
+    NOT_GIVEN,
+    DEFAULT_MAX_RETRIES,
+    OpenAI,
+    Timeout,
+    NotGiven,
+    AsyncOpenAI,
+)
+from .._base_client import DefaultHttpxClient, DefaultAsyncHttpxClient
+
+OciAuthSigner = type[oci.signer.AbstractBaseSigner]
+
+
+class OciOpenAI(OpenAI):
+    """
+    A custom OpenAI client implementation for Oracle Cloud Infrastructure (OCI) Generative AI service.
+
+    This class extends the OpenAI client to work with OCI's Generative AI service endpoints,
+    handling authentication and request signing specific to OCI.
+
+    Attributes:
+        service_endpoint (str): The OCI service endpoint URL
+        auth (httpx.Auth): Authentication handler for OCI
+        compartment_id (str): OCI compartment ID for resource isolation
+        timeout (float | Timeout | None | NotGiven): Request timeout configuration
+        max_retries (int): Maximum number of retry attempts for failed requests
+        default_headers (Mapping[str, str] | None): Default HTTP headers
+        default_query (Mapping[str, object] | None): Default query parameters
+    """
+
+    def __init__(
+        self,
+        *,
+        service_endpoint: str,
+        auth: httpx.Auth,
+        compartment_id: str,
+        timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        default_headers: Mapping[str, str] | None = None,
+        default_query: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            api_key="<NOTUSED>",
+            base_url=f"{service_endpoint}/20231130/actions/v1",
+            timeout=timeout,
+            max_retries=max_retries,
+            default_headers=default_headers,
+            default_query=default_query,
+            http_client=DefaultHttpxClient(
+                auth=auth,
+                headers={
+                    "CompartmentId": compartment_id,
+                },
+            ),
+        )
+
+
+class AsyncOciOpenAI(AsyncOpenAI):
+    """
+    An async custom OpenAI client implementation for Oracle Cloud Infrastructure (OCI) Generative AI service.
+
+    This class extends the AsyncOpenAI client to work with OCI's Generative AI service endpoints,
+    handling authentication and request signing specific to OCI with async/await support.
+
+    Attributes:
+        service_endpoint (str): The OCI service endpoint URL
+        auth (httpx.Auth): Authentication handler for OCI
+        compartment_id (str): OCI compartment ID for resource isolation
+        timeout (float | Timeout | None | NotGiven): Request timeout configuration
+        max_retries (int): Maximum number of retry attempts for failed requests
+        default_headers (Mapping[str, str] | None): Default HTTP headers
+        default_query (Mapping[str, object] | None): Default query parameters
+    """
+
+    def __init__(
+        self,
+        *,
+        service_endpoint: str,
+        auth: httpx.Auth,
+        compartment_id: str,
+        timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        default_headers: Mapping[str, str] | None = None,
+        default_query: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__(
+            api_key="<NOTUSED>",
+            base_url=f"{service_endpoint}/20231130/actions/v1",
+            timeout=timeout,
+            max_retries=max_retries,
+            default_headers=default_headers,
+            default_query=default_query,
+            http_client=DefaultAsyncHttpxClient(
+                auth=auth,
+                headers={
+                    "CompartmentId": compartment_id,
+                },
+            ),
+        )
+
+
+class HttpxOciAuth(httpx.Auth):
+    """
+    Custom HTTPX authentication class that implements OCI request signing.
+
+    This class handles the authentication flow for HTTPX requests by signing them
+    using the OCI Signer, which adds the necessary authentication headers for OCI API calls.
+
+    Attributes:
+        signer (oci.signer.Signer): The OCI signer instance used for request signing
+    """
+
+    def __init__(self, signer: OciAuthSigner):
+        self.signer = signer
+
+    @override
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        req = requests.Request(
+            method=request.method,
+            url=str(request.url),
+            headers=dict(request.headers),
+            data=request.content,
+        )
+        prepared_request = req.prepare()
+
+        # Sign the request using the OCI Signer
+        self.signer.do_request_sign(prepared_request)  # type: ignore
+
+        # Update the original HTTPX request with the signed headers
+        request.headers.update(prepared_request.headers)
+
+        yield request
+
+
+class OciSessionAuth(HttpxOciAuth):
+    """
+    OCI authentication implementation using session-based authentication.
+
+    This class implements OCI authentication using a session token and private key
+    loaded from the OCI configuration file. It's suitable for interactive user sessions.
+
+    Attributes:
+        signer (oci.auth.signers.SecurityTokenSigner): OCI signer using session token
+    """
+
+    def __init__(self, config_file: str = DEFAULT_LOCATION, profile_name: str = DEFAULT_PROFILE):
+        config = oci.config.from_file(config_file, profile_name)
+        token = self._load_token(config)
+        private_key = oci.signer.load_private_key_from_file(config["key_file"])  # type: ignore
+        self.signer = oci.auth.signers.SecurityTokenSigner(token, private_key)
+
+    def _load_token(self, config: Mapping[str, Any]) -> str:
+        token_file = config["security_token_file"]
+        with open(token_file, "r") as f:
+            return f.read().strip()
+
+
+class OciResourcePrincipleAuth(HttpxOciAuth):
+    """
+    OCI authentication implementation using Resource Principal authentication.
+
+    This class implements OCI authentication using Resource Principal credentials,
+    which is suitable for services running within OCI that need to access other OCI services.
+    """
+
+    def __init__(self):
+        self.signer = oci.auth.signers.get_resource_principals_signer()  # type: ignore
+
+
+class OciInstancePrincipleAuth(HttpxOciAuth):
+    """
+    OCI authentication implementation using Instance Principal authentication.
+
+    This class implements OCI authentication using Instance Principal credentials,
+    which is suitable for compute instances that need to access OCI services.
+    """
+
+    def __init__(self, **kwargs: Mapping[str, Any]):
+        self.signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner(**kwargs)
+
+
+class OciUserPrincipleAuth(HttpxOciAuth):
+    """
+    OCI authentication implementation using user principle authentication.
+
+        This class implements OCI authentication using API Key credentials loaded from
+    the OCI configuration file. It's suitable for programmatic access to OCI services.
+
+    Attributes:
+        signer (oci.signer.Signer): OCI signer configured with API key credentials
+    """
+
+    def __init__(self, config_file: str = DEFAULT_LOCATION, profile_name: str = DEFAULT_PROFILE):
+        config = oci.config.from_file(config_file, profile_name)
+        oci.config.validate_config(config)  # type: ignore
+
+        self.signer = oci.signer.Signer(
+            tenancy=config["tenancy"],
+            user=config["user"],
+            fingerprint=config["fingerprint"],
+            private_key_file_location=config.get("key_file"),
+            pass_phrase=oci.config.get_config_value_or_default(config, "pass_phrase"),  # type: ignore
+            private_key_content=config.get("key_content"),
+        )


### PR DESCRIPTION
Add OCI client to support OCI authenticator(not by API key)

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Add OciOpenAI and AsyncOciOpenAI client and OCI authentication helper
- example to use OciOpenAI client and authentication helper

## Additional context & links
https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm