### PR TITLE
Log the remaining retries info at `info` log level

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1060,9 +1060,9 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
     ) -> None:
         remaining_retries = max_retries - retries_taken
         if remaining_retries == 1:
-            log.debug("1 retry left")
+            log.info("1 retry left")
         else:
-            log.debug("%i retries left", remaining_retries)
+            log.info("%i retries left", remaining_retries)
 
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
         log.info("Retrying request to %s in %f seconds", options.url, timeout)
@@ -1607,9 +1607,9 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
     ) -> None:
         remaining_retries = max_retries - retries_taken
         if remaining_retries == 1:
-            log.debug("1 retry left")
+            log.info("1 retry left")
         else:
-            log.debug("%i retries left", remaining_retries)
+            log.info("%i retries left", remaining_retries)
 
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
         log.info("Retrying request to %s in %f seconds", options.url, timeout)


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

I've made some changes to log the remaining requests count at the `info` level so developers don't have to set their log level to `debug` and see unnecessary fluff for this simple piece of information. Specifically, changes were made to logs in `SyncAPIClient._sleep_for_retry` and `AsyncAPIClient._sleep_for_retry`.

I've tested this locally with `examples/demo.py` with `OPENAI_LOG` set to `info` and seems to work fine.

<img width="1313" height="465" alt="image" src="https://github.com/user-attachments/assets/070d8a7c-b3f4-462b-9295-8a6b8a7b78bd" />

## Additional context & links

This fixes #2404 

**Note:** I am not sure if this was meant to be generated or hand-edited, please let me know if I can do anything about it.