### PR TITLE
Add defaults for `type` fields in types.beta.realtime and support open `str` type for session.model

### DIFF
--- a/src/openai/types/beta/realtime/conversation_created_event.py
+++ b/src/openai/types/beta/realtime/conversation_created_event.py
@@ -23,5 +23,5 @@ class ConversationCreatedEvent(BaseModel):
     event_id: str
     """The unique ID of the server event."""
 
-    type: Literal["conversation.created"]
+    type: Literal["conversation.created"] = "conversation.created"
     """The event type, must be `conversation.created`."""

--- a/src/openai/types/beta/realtime/conversation_item_create_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_create_event.py
@@ -13,7 +13,7 @@ class ConversationItemCreateEvent(BaseModel):
     item: ConversationItem
     """The item to add to the conversation."""
 
-    type: Literal["conversation.item.create"]
+    type: Literal["conversation.item.create"] = "conversation.item.create"
     """The event type, must be `conversation.item.create`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/conversation_item_created_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_created_event.py
@@ -16,7 +16,7 @@ class ConversationItemCreatedEvent(BaseModel):
     item: ConversationItem
     """The item to add to the conversation."""
 
-    type: Literal["conversation.item.created"]
+    type: Literal["conversation.item.created"] = "conversation.item.created"
     """The event type, must be `conversation.item.created`."""
 
     previous_item_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/conversation_item_delete_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_delete_event.py
@@ -12,7 +12,7 @@ class ConversationItemDeleteEvent(BaseModel):
     item_id: str
     """The ID of the item to delete."""
 
-    type: Literal["conversation.item.delete"]
+    type: Literal["conversation.item.delete"] = "conversation.item.delete"
     """The event type, must be `conversation.item.delete`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/conversation_item_deleted_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_deleted_event.py
@@ -14,5 +14,5 @@ class ConversationItemDeletedEvent(BaseModel):
     item_id: str
     """The ID of the item that was deleted."""
 
-    type: Literal["conversation.item.deleted"]
+    type: Literal["conversation.item.deleted"] = "conversation.item.deleted"
     """The event type, must be `conversation.item.deleted`."""

--- a/src/openai/types/beta/realtime/conversation_item_input_audio_transcription_completed_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_input_audio_transcription_completed_event.py
@@ -33,7 +33,7 @@ class UsageTranscriptTextUsageTokens(BaseModel):
     total_tokens: int
     """Total number of tokens used (input + output)."""
 
-    type: Literal["tokens"]
+    type: Literal["tokens"] = "tokens"
     """The type of the usage object. Always `tokens` for this variant."""
 
     input_token_details: Optional[UsageTranscriptTextUsageTokensInputTokenDetails] = None
@@ -44,7 +44,7 @@ class UsageTranscriptTextUsageDuration(BaseModel):
     seconds: float
     """Duration of the input audio in seconds."""
 
-    type: Literal["duration"]
+    type: Literal["duration"] = "duration"
     """The type of the usage object. Always `duration` for this variant."""
 
 
@@ -75,7 +75,7 @@ class ConversationItemInputAudioTranscriptionCompletedEvent(BaseModel):
     transcript: str
     """The transcribed text."""
 
-    type: Literal["conversation.item.input_audio_transcription.completed"]
+    type: Literal["conversation.item.input_audio_transcription.completed"] = "conversation.item.input_audio_transcription.completed"
     """
     The event type, must be `conversation.item.input_audio_transcription.completed`.
     """

--- a/src/openai/types/beta/realtime/conversation_item_input_audio_transcription_delta_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_input_audio_transcription_delta_event.py
@@ -26,7 +26,7 @@ class ConversationItemInputAudioTranscriptionDeltaEvent(BaseModel):
     item_id: str
     """The ID of the item."""
 
-    type: Literal["conversation.item.input_audio_transcription.delta"]
+    type: Literal["conversation.item.input_audio_transcription.delta"] = "conversation.item.input_audio_transcription.delta"
     """The event type, must be `conversation.item.input_audio_transcription.delta`."""
 
     content_index: Optional[int] = None

--- a/src/openai/types/beta/realtime/conversation_item_input_audio_transcription_failed_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_input_audio_transcription_failed_event.py
@@ -35,5 +35,5 @@ class ConversationItemInputAudioTranscriptionFailedEvent(BaseModel):
     item_id: str
     """The ID of the user message item."""
 
-    type: Literal["conversation.item.input_audio_transcription.failed"]
+    type: Literal["conversation.item.input_audio_transcription.failed"] = "conversation.item.input_audio_transcription.failed"
     """The event type, must be `conversation.item.input_audio_transcription.failed`."""

--- a/src/openai/types/beta/realtime/conversation_item_retrieve_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_retrieve_event.py
@@ -12,7 +12,7 @@ class ConversationItemRetrieveEvent(BaseModel):
     item_id: str
     """The ID of the item to retrieve."""
 
-    type: Literal["conversation.item.retrieve"]
+    type: Literal["conversation.item.retrieve"] = "conversation.item.retrieve"
     """The event type, must be `conversation.item.retrieve`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/conversation_item_truncate_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_truncate_event.py
@@ -25,7 +25,7 @@ class ConversationItemTruncateEvent(BaseModel):
     Only assistant message items can be truncated.
     """
 
-    type: Literal["conversation.item.truncate"]
+    type: Literal["conversation.item.truncate"] = "conversation.item.truncate"
     """The event type, must be `conversation.item.truncate`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/conversation_item_truncated_event.py
+++ b/src/openai/types/beta/realtime/conversation_item_truncated_event.py
@@ -20,5 +20,5 @@ class ConversationItemTruncatedEvent(BaseModel):
     item_id: str
     """The ID of the assistant message item that was truncated."""
 
-    type: Literal["conversation.item.truncated"]
+    type: Literal["conversation.item.truncated"] = "conversation.item.truncated"
     """The event type, must be `conversation.item.truncated`."""

--- a/src/openai/types/beta/realtime/error_event.py
+++ b/src/openai/types/beta/realtime/error_event.py
@@ -32,5 +32,5 @@ class ErrorEvent(BaseModel):
     event_id: str
     """The unique ID of the server event."""
 
-    type: Literal["error"]
+    type: Literal["error"] = "error"
     """The event type, must be `error`."""

--- a/src/openai/types/beta/realtime/input_audio_buffer_append_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_append_event.py
@@ -16,7 +16,7 @@ class InputAudioBufferAppendEvent(BaseModel):
     session configuration.
     """
 
-    type: Literal["input_audio_buffer.append"]
+    type: Literal["input_audio_buffer.append"] = "input_audio_buffer.append"
     """The event type, must be `input_audio_buffer.append`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/input_audio_buffer_clear_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_clear_event.py
@@ -9,7 +9,7 @@ __all__ = ["InputAudioBufferClearEvent"]
 
 
 class InputAudioBufferClearEvent(BaseModel):
-    type: Literal["input_audio_buffer.clear"]
+    type: Literal["input_audio_buffer.clear"] = "input_audio_buffer.clear"
     """The event type, must be `input_audio_buffer.clear`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/input_audio_buffer_cleared_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_cleared_event.py
@@ -11,5 +11,5 @@ class InputAudioBufferClearedEvent(BaseModel):
     event_id: str
     """The unique ID of the server event."""
 
-    type: Literal["input_audio_buffer.cleared"]
+    type: Literal["input_audio_buffer.cleared"] = "input_audio_buffer.cleared"
     """The event type, must be `input_audio_buffer.cleared`."""

--- a/src/openai/types/beta/realtime/input_audio_buffer_commit_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_commit_event.py
@@ -9,7 +9,7 @@ __all__ = ["InputAudioBufferCommitEvent"]
 
 
 class InputAudioBufferCommitEvent(BaseModel):
-    type: Literal["input_audio_buffer.commit"]
+    type: Literal["input_audio_buffer.commit"] = "input_audio_buffer.commit"
     """The event type, must be `input_audio_buffer.commit`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/input_audio_buffer_committed_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_committed_event.py
@@ -15,7 +15,7 @@ class InputAudioBufferCommittedEvent(BaseModel):
     item_id: str
     """The ID of the user message item that will be created."""
 
-    type: Literal["input_audio_buffer.committed"]
+    type: Literal["input_audio_buffer.committed"] = "input_audio_buffer.committed"
     """The event type, must be `input_audio_buffer.committed`."""
 
     previous_item_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/input_audio_buffer_speech_started_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_speech_started_event.py
@@ -22,5 +22,5 @@ class InputAudioBufferSpeechStartedEvent(BaseModel):
     item_id: str
     """The ID of the user message item that will be created when speech stops."""
 
-    type: Literal["input_audio_buffer.speech_started"]
+    type: Literal["input_audio_buffer.speech_started"] = "input_audio_buffer.speech_started"
     """The event type, must be `input_audio_buffer.speech_started`."""

--- a/src/openai/types/beta/realtime/input_audio_buffer_speech_stopped_event.py
+++ b/src/openai/types/beta/realtime/input_audio_buffer_speech_stopped_event.py
@@ -21,5 +21,5 @@ class InputAudioBufferSpeechStoppedEvent(BaseModel):
     item_id: str
     """The ID of the user message item that will be created."""
 
-    type: Literal["input_audio_buffer.speech_stopped"]
+    type: Literal["input_audio_buffer.speech_stopped"] = "input_audio_buffer.speech_stopped"
     """The event type, must be `input_audio_buffer.speech_stopped`."""

--- a/src/openai/types/beta/realtime/rate_limits_updated_event.py
+++ b/src/openai/types/beta/realtime/rate_limits_updated_event.py
@@ -29,5 +29,5 @@ class RateLimitsUpdatedEvent(BaseModel):
     rate_limits: List[RateLimit]
     """List of rate limit information."""
 
-    type: Literal["rate_limits.updated"]
+    type: Literal["rate_limits.updated"] = "rate_limits.updated"
     """The event type, must be `rate_limits.updated`."""

--- a/src/openai/types/beta/realtime/realtime_client_event.py
+++ b/src/openai/types/beta/realtime/realtime_client_event.py
@@ -21,7 +21,7 @@ __all__ = ["RealtimeClientEvent", "OutputAudioBufferClear"]
 
 
 class OutputAudioBufferClear(BaseModel):
-    type: Literal["output_audio_buffer.clear"]
+    type: Literal["output_audio_buffer.clear"] = "output_audio_buffer.clear"
     """The event type, must be `output_audio_buffer.clear`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/realtime_server_event.py
+++ b/src/openai/types/beta/realtime/realtime_server_event.py
@@ -55,7 +55,7 @@ class ConversationItemRetrieved(BaseModel):
     item: ConversationItem
     """The item to add to the conversation."""
 
-    type: Literal["conversation.item.retrieved"]
+    type: Literal["conversation.item.retrieved"] = "conversation.item.retrieved"
     """The event type, must be `conversation.item.retrieved`."""
 
 
@@ -66,7 +66,7 @@ class OutputAudioBufferStarted(BaseModel):
     response_id: str
     """The unique ID of the response that produced the audio."""
 
-    type: Literal["output_audio_buffer.started"]
+    type: Literal["output_audio_buffer.started"] = "output_audio_buffer.started"
     """The event type, must be `output_audio_buffer.started`."""
 
 
@@ -77,7 +77,7 @@ class OutputAudioBufferStopped(BaseModel):
     response_id: str
     """The unique ID of the response that produced the audio."""
 
-    type: Literal["output_audio_buffer.stopped"]
+    type: Literal["output_audio_buffer.stopped"] = "output_audio_buffer.stopped"
     """The event type, must be `output_audio_buffer.stopped`."""
 
 
@@ -88,7 +88,7 @@ class OutputAudioBufferCleared(BaseModel):
     response_id: str
     """The unique ID of the response that produced the audio."""
 
-    type: Literal["output_audio_buffer.cleared"]
+    type: Literal["output_audio_buffer.cleared"] = "output_audio_buffer.cleared"
     """The event type, must be `output_audio_buffer.cleared`."""
 
 

--- a/src/openai/types/beta/realtime/response_audio_delta_event.py
+++ b/src/openai/types/beta/realtime/response_audio_delta_event.py
@@ -26,5 +26,5 @@ class ResponseAudioDeltaEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.audio.delta"]
+    type: Literal["response.audio.delta"] = "response.audio.delta"
     """The event type, must be `response.audio.delta`."""

--- a/src/openai/types/beta/realtime/response_audio_done_event.py
+++ b/src/openai/types/beta/realtime/response_audio_done_event.py
@@ -23,5 +23,5 @@ class ResponseAudioDoneEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.audio.done"]
+    type: Literal["response.audio.done"] = "response.audio.done"
     """The event type, must be `response.audio.done`."""

--- a/src/openai/types/beta/realtime/response_audio_transcript_delta_event.py
+++ b/src/openai/types/beta/realtime/response_audio_transcript_delta_event.py
@@ -26,5 +26,5 @@ class ResponseAudioTranscriptDeltaEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.audio_transcript.delta"]
+    type: Literal["response.audio_transcript.delta"] = "response.audio_transcript.delta"
     """The event type, must be `response.audio_transcript.delta`."""

--- a/src/openai/types/beta/realtime/response_audio_transcript_done_event.py
+++ b/src/openai/types/beta/realtime/response_audio_transcript_done_event.py
@@ -26,5 +26,5 @@ class ResponseAudioTranscriptDoneEvent(BaseModel):
     transcript: str
     """The final transcript of the audio."""
 
-    type: Literal["response.audio_transcript.done"]
+    type: Literal["response.audio_transcript.done"] = "response.audio_transcript.done"
     """The event type, must be `response.audio_transcript.done`."""

--- a/src/openai/types/beta/realtime/response_cancel_event.py
+++ b/src/openai/types/beta/realtime/response_cancel_event.py
@@ -9,7 +9,7 @@ __all__ = ["ResponseCancelEvent"]
 
 
 class ResponseCancelEvent(BaseModel):
-    type: Literal["response.cancel"]
+    type: Literal["response.cancel"] = "response.cancel"
     """The event type, must be `response.cancel`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/response_content_part_added_event.py
+++ b/src/openai/types/beta/realtime/response_content_part_added_event.py
@@ -41,5 +41,5 @@ class ResponseContentPartAddedEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.content_part.added"]
+    type: Literal["response.content_part.added"] = "response.content_part.added"
     """The event type, must be `response.content_part.added`."""

--- a/src/openai/types/beta/realtime/response_content_part_done_event.py
+++ b/src/openai/types/beta/realtime/response_content_part_done_event.py
@@ -41,5 +41,5 @@ class ResponseContentPartDoneEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.content_part.done"]
+    type: Literal["response.content_part.done"] = "response.content_part.done"
     """The event type, must be `response.content_part.done`."""

--- a/src/openai/types/beta/realtime/response_create_event.py
+++ b/src/openai/types/beta/realtime/response_create_event.py
@@ -115,7 +115,7 @@ class Response(BaseModel):
 
 
 class ResponseCreateEvent(BaseModel):
-    type: Literal["response.create"]
+    type: Literal["response.create"] = "response.create"
     """The event type, must be `response.create`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/response_create_event_param.py
+++ b/src/openai/types/beta/realtime/response_create_event_param.py
@@ -24,7 +24,7 @@ class ResponseTool(TypedDict, total=False):
     parameters: object
     """Parameters of the function in JSON Schema."""
 
-    type: Literal["function"]
+    type: Literal["function"] = "function"
     """The type of the tool, i.e. `function`."""
 
 

--- a/src/openai/types/beta/realtime/response_created_event.py
+++ b/src/openai/types/beta/realtime/response_created_event.py
@@ -15,5 +15,5 @@ class ResponseCreatedEvent(BaseModel):
     response: RealtimeResponse
     """The response resource."""
 
-    type: Literal["response.created"]
+    type: Literal["response.created"] = "response.created"
     """The event type, must be `response.created`."""

--- a/src/openai/types/beta/realtime/response_done_event.py
+++ b/src/openai/types/beta/realtime/response_done_event.py
@@ -15,5 +15,5 @@ class ResponseDoneEvent(BaseModel):
     response: RealtimeResponse
     """The response resource."""
 
-    type: Literal["response.done"]
+    type: Literal["response.done"] = "response.done"
     """The event type, must be `response.done`."""

--- a/src/openai/types/beta/realtime/response_function_call_arguments_delta_event.py
+++ b/src/openai/types/beta/realtime/response_function_call_arguments_delta_event.py
@@ -26,5 +26,5 @@ class ResponseFunctionCallArgumentsDeltaEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.function_call_arguments.delta"]
+    type: Literal["response.function_call_arguments.delta"] = "response.function_call_arguments.delta"
     """The event type, must be `response.function_call_arguments.delta`."""

--- a/src/openai/types/beta/realtime/response_function_call_arguments_done_event.py
+++ b/src/openai/types/beta/realtime/response_function_call_arguments_done_event.py
@@ -26,5 +26,5 @@ class ResponseFunctionCallArgumentsDoneEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.function_call_arguments.done"]
+    type: Literal["response.function_call_arguments.done"] = "response.function_call_arguments.done"
     """The event type, must be `response.function_call_arguments.done`."""

--- a/src/openai/types/beta/realtime/response_output_item_added_event.py
+++ b/src/openai/types/beta/realtime/response_output_item_added_event.py
@@ -21,5 +21,5 @@ class ResponseOutputItemAddedEvent(BaseModel):
     response_id: str
     """The ID of the Response to which the item belongs."""
 
-    type: Literal["response.output_item.added"]
+    type: Literal["response.output_item.added"] = "response.output_item.added"
     """The event type, must be `response.output_item.added`."""

--- a/src/openai/types/beta/realtime/response_output_item_done_event.py
+++ b/src/openai/types/beta/realtime/response_output_item_done_event.py
@@ -21,5 +21,5 @@ class ResponseOutputItemDoneEvent(BaseModel):
     response_id: str
     """The ID of the Response to which the item belongs."""
 
-    type: Literal["response.output_item.done"]
+    type: Literal["response.output_item.done"] = "response.output_item.done"
     """The event type, must be `response.output_item.done`."""

--- a/src/openai/types/beta/realtime/response_text_delta_event.py
+++ b/src/openai/types/beta/realtime/response_text_delta_event.py
@@ -26,5 +26,5 @@ class ResponseTextDeltaEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.text.delta"]
+    type: Literal["response.text.delta"] = "response.text.delta"
     """The event type, must be `response.text.delta`."""

--- a/src/openai/types/beta/realtime/response_text_done_event.py
+++ b/src/openai/types/beta/realtime/response_text_done_event.py
@@ -26,5 +26,5 @@ class ResponseTextDoneEvent(BaseModel):
     text: str
     """The final text content."""
 
-    type: Literal["response.text.done"]
+    type: Literal["response.text.done"] = "response.text.done"
     """The event type, must be `response.text.done`."""

--- a/src/openai/types/beta/realtime/session_create_params.py
+++ b/src/openai/types/beta/realtime/session_create_params.py
@@ -222,7 +222,7 @@ class Tool(TypedDict, total=False):
     parameters: object
     """Parameters of the function in JSON Schema."""
 
-    type: Literal["function"]
+    type: Literal["function"] = "function"
     """The type of the tool, i.e. `function`."""
 
 

--- a/src/openai/types/beta/realtime/session_created_event.py
+++ b/src/openai/types/beta/realtime/session_created_event.py
@@ -15,5 +15,5 @@ class SessionCreatedEvent(BaseModel):
     session: Session
     """Realtime session object configuration."""
 
-    type: Literal["session.created"]
+    type: Literal["session.created"] = "session.created"
     """The event type, must be `session.created`."""

--- a/src/openai/types/beta/realtime/session_update_event.py
+++ b/src/openai/types/beta/realtime/session_update_event.py
@@ -309,7 +309,7 @@ class SessionUpdateEvent(BaseModel):
     session: Session
     """Realtime session object configuration."""
 
-    type: Literal["session.update"]
+    type: Literal["session.update"] = "session.update"
     """The event type, must be `session.update`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/session_update_event.py
+++ b/src/openai/types/beta/realtime/session_update_event.py
@@ -223,7 +223,8 @@ class Session(BaseModel):
     To disable audio, set this to ["text"].
     """
 
-    model: Optional[
+    model: Union[
+        str,
         Literal[
             "gpt-4o-realtime-preview",
             "gpt-4o-realtime-preview-2024-10-01",
@@ -231,7 +232,8 @@ class Session(BaseModel):
             "gpt-4o-realtime-preview-2025-06-03",
             "gpt-4o-mini-realtime-preview",
             "gpt-4o-mini-realtime-preview-2024-12-17",
-        ]
+        ],
+        None
     ] = None
     """The Realtime model used for this session."""
 

--- a/src/openai/types/beta/realtime/session_update_event_param.py
+++ b/src/openai/types/beta/realtime/session_update_event_param.py
@@ -85,7 +85,7 @@ class SessionTool(TypedDict, total=False):
     parameters: object
     """Parameters of the function in JSON Schema."""
 
-    type: Literal["function"]
+    type: Literal["function"] = "function"
     """The type of the tool, i.e. `function`."""
 
 

--- a/src/openai/types/beta/realtime/session_updated_event.py
+++ b/src/openai/types/beta/realtime/session_updated_event.py
@@ -15,5 +15,5 @@ class SessionUpdatedEvent(BaseModel):
     session: Session
     """Realtime session object configuration."""
 
-    type: Literal["session.updated"]
+    type: Literal["session.updated"] = "session.updated"
     """The event type, must be `session.updated`."""

--- a/src/openai/types/beta/realtime/transcription_session_update.py
+++ b/src/openai/types/beta/realtime/transcription_session_update.py
@@ -178,7 +178,7 @@ class TranscriptionSessionUpdate(BaseModel):
     session: Session
     """Realtime transcription session object configuration."""
 
-    type: Literal["transcription_session.update"]
+    type: Literal["transcription_session.update"] = "transcription_session.update"
     """The event type, must be `transcription_session.update`."""
 
     event_id: Optional[str] = None

--- a/src/openai/types/beta/realtime/transcription_session_updated_event.py
+++ b/src/openai/types/beta/realtime/transcription_session_updated_event.py
@@ -20,5 +20,5 @@ class TranscriptionSessionUpdatedEvent(BaseModel):
     not present when a session is updated via the WebSocket API.
     """
 
-    type: Literal["transcription_session.updated"]
+    type: Literal["transcription_session.updated"] = "transcription_session.updated"
     """The event type, must be `transcription_session.updated`."""


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- ### Add defaults for `type` fields in types.beta.realtime

This makes it simpler and cleaner to programmatically construct events for more complex client flows - the type is redundant with class name in practice.

- ### Add `str` fallback for SessionUpdateEvent.session.model field

This makes it more flexible to use different client and server versions as things evolve over time. And it's consistent with how `voice` field is handled.

## Additional context & links
