### PR TITLE
Fix the issue of no logprobs when calling non openai

### DIFF
--- a/src/openai/types/responses/response_text_delta_event.py
+++ b/src/openai/types/responses/response_text_delta_event.py
@@ -37,7 +37,7 @@ class ResponseTextDeltaEvent(BaseModel):
     item_id: str
     """The ID of the output item that the text delta was added to."""
 
-    logprobs: List[Logprob]
+    logprobs: List[Logprob] | None = None
     """The log probabilities of the tokens in the delta."""
 
     output_index: int

--- a/src/openai/types/responses/response_text_delta_event.py
+++ b/src/openai/types/responses/response_text_delta_event.py
@@ -37,7 +37,7 @@ class ResponseTextDeltaEvent(BaseModel):
     item_id: str
     """The ID of the output item that the text delta was added to."""
 
-    logprobs: List[Logprob] | None = None
+    logprobs: Optional[List[Logprob]] = None
     """The log probabilities of the tokens in the delta."""
 
     output_index: int


### PR DESCRIPTION
Fix the issue of no logprobes when calling non openai

set ResponseTextDeltaEvent function `lagprobs` field default none