### PR TITLE
Fix optional logprobs field in ResponseTextDeltaEvent model

### DIFF
--- a/src/openai/types/responses/response_text_delta_event.py
+++ b/src/openai/types/responses/response_text_delta_event.py
@@ -37,7 +37,7 @@ class ResponseTextDeltaEvent(BaseModel):
     item_id: str
     """The ID of the output item that the text delta was added to."""
 
-    logprobs: List[Logprob]
+    logprobs: Optional[List[Logprob]] = None
     """The log probabilities of the tokens in the delta."""
 
     output_index: int


### PR DESCRIPTION
* [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This pull request fixes a bug in the `ResponseTextDeltaEvent` model where the `logprobs` field is not always present in actual API responses, causing validation errors when parsing streamed events.

### Specific change:

Before:

```python
logprobs: List[Logprob]
```

After:

```python
logprobs: Optional[List[Logprob]] = None
```

This makes the field optional and avoids `ValidationError` when `logprobs` is missing or explicitly `null`, which aligns with the actual OpenAI API behavior.

## Additional context & links

* Related issue: [[#2489](https://github.com/openai/openai-python/issues/2489)](https://github.com/openai/openai-python/issues/2489)
* This fix ensures compatibility with streamed response events that may omit `logprobs`.
* While this repository is auto-generated and this PR may not be merged, I hope this change can be reflected in the next SDK generation or help others encountering the same issue.
