### PR TITLE
Doc: Update streaming examples to use gpt-4o instead of gpt-3.5-turbo-instruct

### DIFF
--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -13,7 +13,7 @@ from openai import OpenAI, AsyncOpenAI
 def sync_main() -> None:
     client = OpenAI()
     response = client.completions.create(
-        model="gpt-3.5-turbo-instruct",
+        model="gpt-4o",
         prompt="1,2,3,",
         max_tokens=5,
         temperature=0,
@@ -33,7 +33,7 @@ def sync_main() -> None:
 async def async_main() -> None:
     client = AsyncOpenAI()
     response = await client.completions.create(
-        model="gpt-3.5-turbo-instruct",
+        model="gpt-4o",
         prompt="1,2,3,",
         max_tokens=5,
         temperature=0,


### PR DESCRIPTION
…preview

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This PR updates the following example files to use `gpt-4o` instead of the older `gpt-3.5-turbo-instruct` model:

- `streaming.py`


`gpt-4o` offers:

- Lower latency and cost compared to `gpt-3.5-turbo-instruct`
- Improved reasoning and overall performance
- Long-term support from OpenAI

Switching to `gpt-4o` ensures these examples stay up to date with current best practices and reduce friction for developers using the latest available models.

## Additional context & links
