### PR TITLE
Auth provider that leaves room for future challenge auth to be implemented

### DIFF
--- a/examples/azure_ad.py
+++ b/examples/azure_ad.py
@@ -3,9 +3,9 @@ import asyncio
 from openai.lib.azure import OpenAI, AsyncOpenAI, AzureAuth, AsyncAzureAuth, AzureADTokenProvider, AsyncAzureADTokenProvider
 
 # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal#create-a-resource
-endpoint = "https://my-resource.openai.azure.com" and 'https://johan-mczd33pe-swedencentral.cognitiveservices.azure.com/openai/v1'
+endpoint = "https://my-resource.openai.azure.com"
 
-deployment_name = "deployment-name" and 'gpt-4.1-nano' # e.g. gpt-35-instant
+deployment_name = "deployment-name" # e.g. gpt-35-instant
 
 
 def sync_main() -> None:

--- a/examples/azure_ad.py
+++ b/examples/azure_ad.py
@@ -1,28 +1,24 @@
 import asyncio
 
-from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI, AzureADTokenProvider, AsyncAzureADTokenProvider
-
-scopes = "https://cognitiveservices.azure.com/.default"
-
-# May change in the future
-# https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#rest-api-versioning
-api_version = "2023-07-01-preview"
+from openai.lib.azure import OpenAI, AsyncOpenAI, AzureAuth, AsyncAzureAuth, AzureADTokenProvider, AsyncAzureADTokenProvider
 
 # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal#create-a-resource
-endpoint = "https://my-resource.openai.azure.com"
+endpoint = "https://my-resource.openai.azure.com" and 'https://johan-mczd33pe-swedencentral.cognitiveservices.azure.com/openai/v1'
 
-deployment_name = "deployment-name"  # e.g. gpt-35-instant
+deployment_name = "deployment-name" and 'gpt-4.1-nano' # e.g. gpt-35-instant
 
 
 def sync_main() -> None:
     from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
-    token_provider: AzureADTokenProvider = get_bearer_token_provider(DefaultAzureCredential(), scopes)
+    token_provider: AzureADTokenProvider = get_bearer_token_provider(DefaultAzureCredential(), AzureAuth.DEFAULT_SCOPE)
 
-    client = AzureOpenAI(
-        api_version=api_version,
-        azure_endpoint=endpoint,
-        azure_ad_token_provider=token_provider,
+    client = OpenAI(
+        base_url=endpoint,
+        auth_provider=AzureAuth(token_provider),
+        default_query={ # Temporary requirement to specify api version - will be removed once v1 routes go GA
+            'api-version': 'preview'
+        }
     )
 
     completion = client.chat.completions.create(
@@ -41,12 +37,14 @@ def sync_main() -> None:
 async def async_main() -> None:
     from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
 
-    token_provider: AsyncAzureADTokenProvider = get_bearer_token_provider(DefaultAzureCredential(), scopes)
+    token_provider: AsyncAzureADTokenProvider = get_bearer_token_provider(DefaultAzureCredential(), AsyncAzureAuth.DEFAULT_SCOPE)
 
-    client = AsyncAzureOpenAI(
-        api_version=api_version,
-        azure_endpoint=endpoint,
-        azure_ad_token_provider=token_provider,
+    client = AsyncOpenAI(
+        base_url=endpoint,
+        auth_provider=AsyncAzureAuth(token_provider),
+        default_query={ # Temporary requirement to specify api version - will be removed once v1 routes go GA
+            'api-version': 'preview'
+        }
     )
 
     completion = await client.chat.completions.create(

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -19,6 +19,7 @@ from ._client import (
     AsyncOpenAI,
     AsyncStream,
     AuthProvider,
+    AsyncAuthProvider,
     RequestOptions,
 )
 from ._models import BaseModel
@@ -83,6 +84,8 @@ __all__ = [
     "AsyncStream",
     "OpenAI",
     "AsyncOpenAI",
+    "AuthProvider",
+    "AsyncAuthProvider",
     "file_from_path",
     "BaseModel",
     "DEFAULT_TIMEOUT",
@@ -98,7 +101,7 @@ if not _t.TYPE_CHECKING:
 
 from .lib import azure as _azure, pydantic_function_tool as pydantic_function_tool
 from .version import VERSION as VERSION
-from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI
+from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI, AzureAuth as AzureAuth, AsyncAzureAuth as AsyncAzureAuth
 from .lib._old_api import *
 from .lib.streaming import (
     AssistantEventHandler as AssistantEventHandler,

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -9,7 +9,18 @@ from typing_extensions import override
 from . import types
 from ._types import NOT_GIVEN, Omit, NoneType, NotGiven, Transport, ProxiesTypes
 from ._utils import file_from_path
-from ._client import Client, OpenAI, Stream, Timeout, Transport, AsyncClient, AsyncOpenAI, AsyncStream, RequestOptions
+from ._client import (
+    Client,
+    OpenAI,
+    Stream,
+    Timeout,
+    Transport,
+    AsyncClient,
+    AsyncOpenAI,
+    AsyncStream,
+    TokenProvider,
+    RequestOptions,
+)
 from ._models import BaseModel
 from ._version import __title__, __version__
 from ._response import APIResponse as APIResponse, AsyncAPIResponse as AsyncAPIResponse
@@ -119,6 +130,8 @@ from ._base_client import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
 
 api_key: str | None = None
 
+token_provider: TokenProvider | None = None
+
 organization: str | None = None
 
 project: str | None = None
@@ -164,6 +177,17 @@ class _ModuleClient(OpenAI):
         global api_key
 
         api_key = value
+
+    @property  # type: ignore
+    @override
+    def token_provider(self) -> TokenProvider | None:
+        return token_provider
+
+    @token_provider.setter  # type: ignore
+    def token_provider(self, value: TokenProvider | None) -> None:  # type: ignore
+        global token_provider
+
+        token_provider = value
 
     @property  # type: ignore
     @override
@@ -348,6 +372,7 @@ def _load_client() -> OpenAI:  # type: ignore[reportUnusedFunction]
 
         _client = _ModuleClient(
             api_key=api_key,
+            token_provider=token_provider,
             organization=organization,
             project=project,
             webhook_secret=webhook_secret,

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -18,7 +18,7 @@ from ._client import (
     AsyncClient,
     AsyncOpenAI,
     AsyncStream,
-    TokenProvider,
+    AuthProvider,
     RequestOptions,
 )
 from ._models import BaseModel
@@ -130,7 +130,7 @@ from ._base_client import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
 
 api_key: str | None = None
 
-token_provider: TokenProvider | None = None
+auth_provider: AuthProvider | None = None
 
 organization: str | None = None
 
@@ -180,14 +180,14 @@ class _ModuleClient(OpenAI):
 
     @property  # type: ignore
     @override
-    def token_provider(self) -> TokenProvider | None:
-        return token_provider
+    def auth_provider(self) -> AuthProvider | None:
+        return auth_provider
 
-    @token_provider.setter  # type: ignore
-    def token_provider(self, value: TokenProvider | None) -> None:  # type: ignore
-        global token_provider
+    @auth_provider.setter  # type: ignore
+    def auth_provider(self, value: AuthProvider | None) -> None:  # type: ignore
+        global auth_provider
 
-        token_provider = value
+        auth_provider = value
 
     @property  # type: ignore
     @override
@@ -372,7 +372,7 @@ def _load_client() -> OpenAI:  # type: ignore[reportUnusedFunction]
 
         _client = _ModuleClient(
             api_key=api_key,
-            token_provider=token_provider,
+            auth_provider=auth_provider,
             organization=organization,
             project=project,
             webhook_secret=webhook_secret,

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -322,12 +322,12 @@ class OpenAI(SyncAPIClient):
     @property
     @override
     def auth_headers(self) -> dict[str, str]:
-        if self.api_key:
-            return {
-                "Authorization": f"Bearer {self.api_key}"
-            }
-        return {}
-
+        api_key = self.api_key
+        if not api_key:
+            # if the api key is an empty string, encoding the header will fail
+            return {}
+        return {"Authorization": f"Bearer {api_key}"}
+    
     @property
     @override
     def default_headers(self) -> dict[str, str | Omit]:
@@ -664,11 +664,11 @@ class AsyncOpenAI(AsyncAPIClient):
     @property
     @override
     def auth_headers(self) -> dict[str, str]:
-        if self.api_key:
-            return {
-                "Authorization": f"Bearer {self.api_key}"
-            }
-        return {}
+        api_key = self.api_key
+        if not api_key:
+            # if the api key is an empty string, encoding the header will fail
+            return {}
+        return {"Authorization": f"Bearer {api_key}"}
 
     @property
     @override

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Union, Mapping
+from typing import TYPE_CHECKING, Any, Union, Mapping, Callable, Awaitable
 from typing_extensions import Self, override
 
 import httpx
@@ -25,6 +25,7 @@ from ._utils import (
     get_async_library,
 )
 from ._compat import cached_property
+from ._models import FinalRequestOptions
 from ._version import __version__
 from ._streaming import Stream as Stream, AsyncStream as AsyncStream
 from ._exceptions import OpenAIError, APIStatusError
@@ -73,6 +74,9 @@ if TYPE_CHECKING:
 
 __all__ = ["Timeout", "Transport", "ProxiesTypes", "RequestOptions", "OpenAI", "AsyncOpenAI", "Client", "AsyncClient"]
 
+TokenProvider = Callable[[], "str | dict[str, str]"]
+AsyncTokenProvider = Callable[[], Awaitable["str | dict[str, str]"]]
+
 
 class OpenAI(SyncAPIClient):
     # client options
@@ -93,6 +97,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        token_provider: TokenProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -124,13 +129,16 @@ class OpenAI(SyncAPIClient):
         - `project` from `OPENAI_PROJECT_ID`
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
         """
+        if api_key and token_provider:
+            raise ValueError("The `api_key` and `token_provider` arguments are mutually exclusive")
         if api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None:
+        if api_key is None and token_provider is None:
             raise OpenAIError(
-                "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+                "The api_key or token_provider client option must be set either by passing api_key or token_provider to the client or by setting the OPENAI_API_KEY environment variable"
             )
-        self.api_key = api_key
+        self.token_provider = token_provider
+        self.api_key = api_key or ""
 
         if organization is None:
             organization = os.environ.get("OPENAI_ORG_ID")
@@ -163,6 +171,7 @@ class OpenAI(SyncAPIClient):
         )
 
         self._default_stream_cls = Stream
+        self._auth_headers: dict[str, str] = {}
 
     @cached_property
     def completions(self) -> Completions:
@@ -279,14 +288,27 @@ class OpenAI(SyncAPIClient):
     def qs(self) -> Querystring:
         return Querystring(array_format="brackets")
 
+    def refresh_auth_headers(self) -> None:
+        secret = self.token_provider() if self.token_provider else self.api_key
+        if not secret:
+            # if secret is an empty string, encoding the header will fail
+            # so we set it to an empty dict
+            # this is to avoid sending an invalid Authorization header
+            self._auth_headers = {}
+        elif isinstance(secret, str):
+            self._auth_headers = {"Authorization": f"Bearer {secret}"}
+        else:
+            self._auth_headers = secret
+
+    @override
+    def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        self.refresh_auth_headers()
+        return super()._prepare_options(options)
+
     @property
     @override
     def auth_headers(self) -> dict[str, str]:
-        api_key = self.api_key
-        if not api_key:
-            # if the api key is an empty string, encoding the header will fail
-            return {}
-        return {"Authorization": f"Bearer {api_key}"}
+        return self._auth_headers
 
     @property
     @override
@@ -303,6 +325,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        token_provider: TokenProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -337,6 +360,10 @@ class OpenAI(SyncAPIClient):
             params = {**params, **default_query}
         elif set_default_query is not None:
             params = set_default_query
+
+        token_provider = token_provider or self.token_provider
+        if token_provider is not None:
+            _extra_kwargs = {**_extra_kwargs, "token_provider": token_provider}
 
         http_client = http_client or self._client
         return self.__class__(
@@ -412,6 +439,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        token_provider: AsyncTokenProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -443,13 +471,16 @@ class AsyncOpenAI(AsyncAPIClient):
         - `project` from `OPENAI_PROJECT_ID`
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
         """
+        if api_key and token_provider:
+            raise ValueError("The `api_key` and `token_provider` arguments are mutually exclusive")
         if api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None:
+        if api_key is None and token_provider is None:
             raise OpenAIError(
-                "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
+                "The api_key or token_provider client option must be set either by passing api_key or token_provider to the client or by setting the OPENAI_API_KEY environment variable"
             )
-        self.api_key = api_key
+        self.token_provider = token_provider
+        self.api_key = api_key or ""
 
         if organization is None:
             organization = os.environ.get("OPENAI_ORG_ID")
@@ -482,6 +513,7 @@ class AsyncOpenAI(AsyncAPIClient):
         )
 
         self._default_stream_cls = AsyncStream
+        self._auth_headers: dict[str, str] = {}
 
     @cached_property
     def completions(self) -> AsyncCompletions:
@@ -598,14 +630,30 @@ class AsyncOpenAI(AsyncAPIClient):
     def qs(self) -> Querystring:
         return Querystring(array_format="brackets")
 
+    async def refresh_auth_headers(self) -> None:
+        if self.token_provider:
+            secret = await self.token_provider()
+        else:
+            secret = self.api_key
+        if not secret:
+            # if the secret is an empty string, encoding the header will fail
+            # so we set it to an empty dict
+            # this is to avoid sending an invalid Authorization header
+            self._auth_headers = {}
+        elif isinstance(secret, str):
+            self._auth_headers = {"Authorization": f"Bearer {secret}"}
+        else:
+            self._auth_headers = secret
+
+    @override
+    async def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        await self.refresh_auth_headers()
+        return await super()._prepare_options(options)
+
     @property
     @override
     def auth_headers(self) -> dict[str, str]:
-        api_key = self.api_key
-        if not api_key:
-            # if the api key is an empty string, encoding the header will fail
-            return {}
-        return {"Authorization": f"Bearer {api_key}"}
+        return self._auth_headers
 
     @property
     @override
@@ -622,6 +670,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
+        token_provider: AsyncTokenProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -656,6 +705,10 @@ class AsyncOpenAI(AsyncAPIClient):
             params = {**params, **default_query}
         elif set_default_query is not None:
             params = set_default_query
+
+        token_provider = token_provider or self.token_provider
+        if token_provider is not None:
+            _extra_kwargs = {**_extra_kwargs, "token_provider": token_provider}
 
         http_client = http_client or self._client
         return self.__class__(

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -74,8 +74,8 @@ if TYPE_CHECKING:
 
 __all__ = ["Timeout", "Transport", "ProxiesTypes", "RequestOptions", "OpenAI", "AsyncOpenAI", "Client", "AsyncClient"]
 
-TokenProvider = Callable[[], "str | dict[str, str]"]
-AsyncTokenProvider = Callable[[], Awaitable["str | dict[str, str]"]]
+AuthProvider = Callable[[], "str | dict[str, str]"]
+AsyncAuthProvider = Callable[[], Awaitable["str | dict[str, str]"]]
 
 
 class OpenAI(SyncAPIClient):
@@ -97,7 +97,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        token_provider: TokenProvider | None = None,
+        auth_provider: AuthProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -129,15 +129,15 @@ class OpenAI(SyncAPIClient):
         - `project` from `OPENAI_PROJECT_ID`
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
         """
-        if api_key and token_provider:
-            raise ValueError("The `api_key` and `token_provider` arguments are mutually exclusive")
+        if api_key and auth_provider:
+            raise ValueError("The `api_key` and `auth_provider` arguments are mutually exclusive")
         if api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None and token_provider is None:
+        if api_key is None and auth_provider is None:
             raise OpenAIError(
-                "The api_key or token_provider client option must be set either by passing api_key or token_provider to the client or by setting the OPENAI_API_KEY environment variable"
+                "The api_key or auth_provider client option must be set either by passing api_key or auth_provider to the client or by setting the OPENAI_API_KEY environment variable"
             )
-        self.token_provider = token_provider
+        self.auth_provider = auth_provider
         self.api_key = api_key or ""
 
         if organization is None:
@@ -289,7 +289,7 @@ class OpenAI(SyncAPIClient):
         return Querystring(array_format="brackets")
 
     def refresh_auth_headers(self) -> None:
-        secret = self.token_provider() if self.token_provider else self.api_key
+        secret = self.auth_provider() if self.auth_provider else self.api_key
         if not secret:
             # if secret is an empty string, encoding the header will fail
             # so we set it to an empty dict
@@ -325,7 +325,7 @@ class OpenAI(SyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        token_provider: TokenProvider | None = None,
+        auth_provider: AuthProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -361,9 +361,9 @@ class OpenAI(SyncAPIClient):
         elif set_default_query is not None:
             params = set_default_query
 
-        token_provider = token_provider or self.token_provider
-        if token_provider is not None:
-            _extra_kwargs = {**_extra_kwargs, "token_provider": token_provider}
+        auth_provider = auth_provider or self.auth_provider
+        if auth_provider is not None:
+            _extra_kwargs = {**_extra_kwargs, "auth_provider": auth_provider}
 
         http_client = http_client or self._client
         return self.__class__(
@@ -439,7 +439,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        token_provider: AsyncTokenProvider | None = None,
+        auth_provider: AsyncAuthProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -471,15 +471,15 @@ class AsyncOpenAI(AsyncAPIClient):
         - `project` from `OPENAI_PROJECT_ID`
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
         """
-        if api_key and token_provider:
-            raise ValueError("The `api_key` and `token_provider` arguments are mutually exclusive")
+        if api_key and auth_provider:
+            raise ValueError("The `api_key` and `auth_provider` arguments are mutually exclusive")
         if api_key is None:
             api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key is None and token_provider is None:
+        if api_key is None and auth_provider is None:
             raise OpenAIError(
-                "The api_key or token_provider client option must be set either by passing api_key or token_provider to the client or by setting the OPENAI_API_KEY environment variable"
+                "The api_key or auth_provider client option must be set either by passing api_key or auth_provider to the client or by setting the OPENAI_API_KEY environment variable"
             )
-        self.token_provider = token_provider
+        self.auth_provider = auth_provider
         self.api_key = api_key or ""
 
         if organization is None:
@@ -631,8 +631,8 @@ class AsyncOpenAI(AsyncAPIClient):
         return Querystring(array_format="brackets")
 
     async def refresh_auth_headers(self) -> None:
-        if self.token_provider:
-            secret = await self.token_provider()
+        if self.auth_provider:
+            secret = await self.auth_provider()
         else:
             secret = self.api_key
         if not secret:
@@ -670,7 +670,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self,
         *,
         api_key: str | None = None,
-        token_provider: AsyncTokenProvider | None = None,
+        auth_provider: AsyncAuthProvider | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -706,9 +706,9 @@ class AsyncOpenAI(AsyncAPIClient):
         elif set_default_query is not None:
             params = set_default_query
 
-        token_provider = token_provider or self.token_provider
-        if token_provider is not None:
-            _extra_kwargs = {**_extra_kwargs, "token_provider": token_provider}
+        auth_provider = auth_provider or self.auth_provider
+        if auth_provider is not None:
+            _extra_kwargs = {**_extra_kwargs, "auth_provider": auth_provider}
 
         http_client = http_client or self._client
         return self.__class__(

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -255,7 +255,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
         self._azure_endpoint = httpx.URL(azure_endpoint) if azure_endpoint else None
 
     @override
-    def copy(
+    def copy(  # type: ignore
         self,
         *,
         api_key: str | None = None,
@@ -301,7 +301,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
             },
         )
 
-    with_options = copy
+    with_options = copy  # type: ignore
 
     def _get_azure_ad_token(self) -> str | None:
         if self._azure_ad_token is not None:
@@ -536,7 +536,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
         self._azure_endpoint = httpx.URL(azure_endpoint) if azure_endpoint else None
 
     @override
-    def copy(
+    def copy(  # type: ignore
         self,
         *,
         api_key: str | None = None,
@@ -582,7 +582,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
             },
         )
 
-    with_options = copy
+    with_options = copy  # type: ignore
 
     async def _get_azure_ad_token(self) -> str | None:
         if self._azure_ad_token is not None:

--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -358,6 +358,7 @@ class AsyncRealtimeConnectionManager:
             raise OpenAIError("You need to install `openai[realtime]` to use this method") from exc
 
         extra_query = self.__extra_query
+        await self.__client.refresh_auth_headers()
         auth_headers = self.__client.auth_headers
         if is_async_azure_client(self.__client):
             url, auth_headers = await self.__client._configure_realtime(self.__model, extra_query)
@@ -540,6 +541,7 @@ class RealtimeConnectionManager:
             raise OpenAIError("You need to install `openai[realtime]` to use this method") from exc
 
         extra_query = self.__extra_query
+        self.__client.refresh_auth_headers()
         auth_headers = self.__client.auth_headers
         if is_azure_client(self.__client):
             url, auth_headers = self.__client._configure_realtime(self.__model, extra_query)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ import asyncio
 import inspect
 import subprocess
 import tracemalloc
-from typing import Any, Union, cast
+from typing import Any, Union, Protocol, cast
 from textwrap import dedent
 from unittest import mock
 from typing_extensions import Literal
@@ -39,6 +39,10 @@ from .utils import update_env
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 api_key = "My API Key"
+
+
+class MockRequestCall(Protocol):
+    request: httpx.Request
 
 
 def _get_params(client: BaseClient[Any, Any]) -> dict[str, str]:
@@ -337,7 +341,9 @@ class TestOpenAI:
 
     def test_validate_headers(self) -> None:
         client = OpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
-        request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+        options = client._prepare_options(FinalRequestOptions(method="get", url="/foo"))
+        request = client._build_request(options)
+
         assert request.headers.get("Authorization") == f"Bearer {api_key}"
 
         with pytest.raises(OpenAIError):
@@ -939,6 +945,68 @@ class TestOpenAI:
         assert exc_info.value.response.status_code == 302
         assert exc_info.value.response.headers["Location"] == f"{base_url}/redirected"
 
+    def test_refresh_auth_headers_str_token(self) -> None:
+        client = OpenAI(base_url=base_url, token_provider=lambda: "test_bearer_token")
+        client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_bearer_token"
+
+    def test_refresh_auth_headers_dict(self) -> None:
+        client = OpenAI(base_url=base_url, token_provider=lambda: {"Authorization": "Bearer test_bearer_token"})
+        client.refresh_auth_headers()
+        assert client.auth_headers == {"Authorization": "Bearer test_bearer_token"}
+
+    def test_refresh_auth_headers_key(self) -> None:
+        client = OpenAI(base_url=base_url, api_key="test_api_key")
+        client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_api_key"
+
+    @pytest.mark.respx()
+    def test_token_provider_refresh(self, respx_mock: MockRouter) -> None:
+        respx_mock.post(base_url + "/chat/completions").mock(
+            side_effect=[
+                httpx.Response(500, json={"error": "server error"}),
+                httpx.Response(200, json={"foo": "bar"}),
+            ]
+        )
+
+        counter = 0
+
+        def token_provider() -> str:
+            nonlocal counter
+
+            counter += 1
+
+            if counter == 1:
+                return "first"
+
+            return "second"
+
+        client = OpenAI(base_url=base_url, token_provider=token_provider)
+        client.chat.completions.create(messages=[], model="gpt-4")
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 2
+
+        assert calls[0].request.headers.get("Authorization") == "Bearer first"
+        assert calls[1].request.headers.get("Authorization") == "Bearer second"
+
+    def test_auth_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            OpenAI(base_url=base_url, api_key=api_key, token_provider=lambda: "test_bearer_token")
+        assert str(exc_info.value) == "The `api_key` and `token_provider` arguments are mutually exclusive"
+
+    def test_copy_auth(self) -> None:
+        client = OpenAI(base_url=base_url, token_provider=lambda: "test_bearer_token_1").copy(
+            token_provider=lambda: "test_bearer_token_2"
+        )
+        client.refresh_auth_headers()
+        assert client.auth_headers == {"Authorization": "Bearer test_bearer_token_2"}
+
+    def test_copy_auth_mutually_exclusive(self) -> None:
+        with pytest.raises(ValueError) as exc_info:
+            OpenAI(base_url=base_url, api_key=api_key).copy(token_provider=lambda: "test_bearer_token")
+        assert str(exc_info.value) == "The `api_key` and `token_provider` arguments are mutually exclusive"
+
 
 class TestAsyncOpenAI:
     client = AsyncOpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
@@ -1220,9 +1288,10 @@ class TestAsyncOpenAI:
         assert request.headers.get("x-foo") == "stainless"
         assert request.headers.get("x-stainless-lang") == "my-overriding-header"
 
-    def test_validate_headers(self) -> None:
+    async def test_validate_headers(self) -> None:
         client = AsyncOpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
-        request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+        options = await client._prepare_options(FinalRequestOptions(method="get", url="/foo"))
+        request = client._build_request(options)
         assert request.headers.get("Authorization") == f"Bearer {api_key}"
 
         with pytest.raises(OpenAIError):
@@ -1887,3 +1956,86 @@ class TestAsyncOpenAI:
 
         assert exc_info.value.response.status_code == 302
         assert exc_info.value.response.headers["Location"] == f"{base_url}/redirected"
+
+    @pytest.mark.asyncio
+    async def test_refresh_auth_headers_str_token_async(self) -> None:
+        async def token_provider() -> str:
+            return "test_bearer_token"
+
+        client = AsyncOpenAI(base_url=base_url, token_provider=token_provider)
+        await client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_bearer_token"
+
+    @pytest.mark.asyncio
+    async def test_refresh_auth_headers_dict_async(self) -> None:
+        async def token_provider() -> dict[str, str]:
+            return {"Authorization": "Bearer test_bearer_token"}
+
+        client = AsyncOpenAI(base_url=base_url, token_provider=token_provider)
+        await client.refresh_auth_headers()
+        assert client.auth_headers == {"Authorization": "Bearer test_bearer_token"}
+
+    @pytest.mark.asyncio
+    async def test_refresh_auth_headers_key_async(self) -> None:
+        client = AsyncOpenAI(base_url=base_url, api_key="test_api_key")
+        await client.refresh_auth_headers()
+        assert client.auth_headers.get("Authorization") == "Bearer test_api_key"
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx()
+    async def test_bearer_token_refresh_async(self, respx_mock: MockRouter) -> None:
+        respx_mock.post(base_url + "/chat/completions").mock(
+            side_effect=[
+                httpx.Response(500, json={"error": "server error"}),
+                httpx.Response(200, json={"foo": "bar"}),
+            ]
+        )
+
+        counter = 0
+
+        async def token_provider() -> str:
+            nonlocal counter
+
+            counter += 1
+
+            if counter == 1:
+                return "first"
+
+            return "second"
+
+        client = AsyncOpenAI(base_url=base_url, token_provider=token_provider)
+        await client.chat.completions.create(messages=[], model="gpt-4")
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 2
+
+        assert calls[0].request.headers.get("Authorization") == "Bearer first"
+        assert calls[1].request.headers.get("Authorization") == "Bearer second"
+
+    def test_auth_mutually_exclusive_async(self) -> None:
+        async def token_provider() -> str:
+            return "test_bearer_token"
+
+        with pytest.raises(ValueError) as exc_info:
+            AsyncOpenAI(base_url=base_url, api_key=api_key, token_provider=token_provider)
+        assert str(exc_info.value) == "The `api_key` and `token_provider` arguments are mutually exclusive"
+
+    @pytest.mark.asyncio
+    async def test_copy_auth(self) -> None:
+        async def token_provider_1() -> str:
+            return "test_bearer_token_1"
+
+        async def token_provider_2() -> str:
+            return "test_bearer_token_2"
+
+        client = AsyncOpenAI(base_url=base_url, token_provider=token_provider_1).copy(token_provider=token_provider_2)
+        await client.refresh_auth_headers()
+        assert client.auth_headers == {"Authorization": "Bearer test_bearer_token_2"}
+
+    def test_copy_auth_mutually_exclusive_async(self) -> None:
+        async def token_provider() -> str:
+            return "test_bearer_token"
+
+        with pytest.raises(ValueError) as exc_info:
+            AsyncOpenAI(base_url=base_url, api_key=api_key).copy(token_provider=token_provider)
+        assert str(exc_info.value) == "The `api_key` and `token_provider` arguments are mutually exclusive"

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -15,7 +15,7 @@ from openai import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
 def reset_state() -> None:
     openai._reset_client()
     openai.api_key = None or "My API Key"
-    openai.token_provider = None
+    openai.auth_provider = None
     openai.organization = None
     openai.project = None
     openai.webhook_secret = None
@@ -98,26 +98,26 @@ def test_http_client_option() -> None:
     assert openai.completions._client._client is new_client
 
 
-def test_token_provider_str_option() -> None:
-    assert openai.token_provider is None
-    assert openai.completions._client.token_provider is None
+def test_auth_provider_str_option() -> None:
+    assert openai.auth_provider is None
+    assert openai.completions._client.auth_provider is None
 
-    openai.token_provider = lambda: "foo"
+    openai.auth_provider = lambda: "foo"
 
-    assert openai.token_provider() == "foo"
-    assert openai.completions._client.token_provider
-    assert openai.completions._client.token_provider() == "foo"
+    assert openai.auth_provider() == "foo"
+    assert openai.completions._client.auth_provider
+    assert openai.completions._client.auth_provider() == "foo"
 
 
-def test_token_provider_dict_option() -> None:
-    assert openai.token_provider is None
-    assert openai.completions._client.token_provider is None
+def test_auth_provider_dict_option() -> None:
+    assert openai.auth_provider is None
+    assert openai.completions._client.auth_provider is None
 
-    openai.token_provider = lambda: {"foo": "bar"}
+    openai.auth_provider = lambda: {"foo": "bar"}
 
-    assert openai.token_provider() == {"foo": "bar"}
-    assert openai.completions._client.token_provider
-    assert openai.completions._client.token_provider() == {"foo": "bar"}
+    assert openai.auth_provider() == {"foo": "bar"}
+    assert openai.completions._client.auth_provider
+    assert openai.completions._client.auth_provider() == {"foo": "bar"}
 
 
 import contextlib
@@ -146,23 +146,23 @@ def test_only_api_key_results_in_openai_api() -> None:
         assert type(openai.completions._client).__name__ == "_ModuleClient"
 
 
-def test_only_token_provider_in_openai_api() -> None:
+def test_only_auth_provider_in_openai_api() -> None:
     with fresh_env():
         openai.api_type = None
         openai.api_key = None
-        openai.token_provider = lambda: "example bearer token"
+        openai.auth_provider = lambda: "example bearer token"
 
         assert type(openai.completions._client).__name__ == "_ModuleClient"
 
 
-def test_both_api_key_and_token_provider_in_openai_api() -> None:
+def test_both_api_key_and_auth_provider_in_openai_api() -> None:
     with fresh_env():
         openai.api_key = "example API key"
-        openai.token_provider = lambda: "example bearer token"
+        openai.auth_provider = lambda: "example bearer token"
 
         with pytest.raises(
             ValueError,
-            match=r"The `api_key` and `token_provider` arguments are mutually exclusive",
+            match=r"The `api_key` and `auth_provider` arguments are mutually exclusive",
         ):
             openai.completions._client  # noqa: B018
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Enable custom authentication mechanisms for the OpenAI client similar to what is supported with the bearer token provider for the AzureOpenAI client. 

The auth instance itself is a protocol that takes (target) url, query parameters, headers and cookies as input and returns updated values, which should allow for the vast majority of auth scenarios for most service and api gateways put in front of the service (oauth, header based api keys w. arbitrary header names, cookie based auth, challenge requests).

In order to enable challenge auth, we'd have to plug it in to the request pipeline of the client and respond to 401 responses rather than just retrying the request (passing in the 401 response to the do_auth method of the auth provider). 

## Additional context & links
