### PR TITLE
chore: bump `inline-snapshot` version to 0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies = [
     "sniffio",
     "tqdm > 4",
     "jiter>=0.4.0, <1",
-    "inline-snapshot>=0.28.0",
 ]
 requires-python = ">= 3.8"
 classifiers = [
@@ -65,7 +64,7 @@ dev-dependencies = [
     "dirty-equals>=0.6.0",
     "importlib-metadata>=6.7.0",
     "rich>=13.7.1",
-    "inline-snapshot >=0.7.0",
+    "inline-snapshot>=0.28.0",
     "azure-identity >=1.14.1",
     "types-tqdm > 4",
     "types-pyaudio > 0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "sniffio",
     "tqdm > 4",
     "jiter>=0.4.0, <1",
+    "inline-snapshot>=0.28.0",
 ]
 requires-python = ">= 3.8"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -91,7 +91,6 @@ importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
 inline-snapshot==0.28.0
-    # via openai
 jiter==0.5.0
     # via openai
 markdown-it-py==3.0.0

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -90,7 +90,8 @@ idna==3.4
 importlib-metadata==7.0.0
 iniconfig==2.0.0
     # via pytest
-inline-snapshot==0.27.0
+inline-snapshot==0.28.0
+    # via openai
 jiter==0.5.0
     # via openai
 markdown-it-py==3.0.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -22,6 +22,8 @@ annotated-types==0.6.0
 anyio==4.1.0
     # via httpx
     # via openai
+asttokens==3.0.0
+    # via inline-snapshot
 async-timeout==5.0.1
     # via aiohttp
 attrs==25.3.0
@@ -35,6 +37,9 @@ distro==1.8.0
     # via openai
 exceptiongroup==1.2.2
     # via anyio
+    # via pytest
+executing==2.2.0
+    # via inline-snapshot
 frozenlist==1.7.0
     # via aiohttp
     # via aiosignal
@@ -51,8 +56,16 @@ idna==3.4
     # via anyio
     # via httpx
     # via yarl
+iniconfig==2.1.0
+    # via pytest
+inline-snapshot==0.28.0
+    # via openai
 jiter==0.6.1
     # via openai
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
 multidict==6.5.0
     # via aiohttp
     # via yarl
@@ -60,10 +73,14 @@ numpy==2.0.2
     # via openai
     # via pandas
     # via pandas-stubs
+packaging==25.0
+    # via pytest
 pandas==2.2.3
     # via openai
 pandas-stubs==2.2.2.240807
     # via openai
+pluggy==1.6.0
+    # via pytest
 propcache==0.3.2
     # via aiohttp
     # via yarl
@@ -73,10 +90,17 @@ pydantic==2.10.3
     # via openai
 pydantic-core==2.27.1
     # via pydantic
+pygments==2.19.2
+    # via pytest
+    # via rich
+pytest==8.4.1
+    # via inline-snapshot
 python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
+rich==14.1.0
+    # via inline-snapshot
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.0
@@ -84,6 +108,9 @@ sniffio==1.3.0
     # via openai
 sounddevice==0.5.1
     # via openai
+tomli==2.2.1
+    # via inline-snapshot
+    # via pytest
 tqdm==4.66.5
     # via openai
 types-pytz==2024.2.0.20241003

--- a/requirements.lock
+++ b/requirements.lock
@@ -22,8 +22,6 @@ annotated-types==0.6.0
 anyio==4.1.0
     # via httpx
     # via openai
-asttokens==3.0.0
-    # via inline-snapshot
 async-timeout==5.0.1
     # via aiohttp
 attrs==25.3.0
@@ -37,9 +35,6 @@ distro==1.8.0
     # via openai
 exceptiongroup==1.2.2
     # via anyio
-    # via pytest
-executing==2.2.0
-    # via inline-snapshot
 frozenlist==1.7.0
     # via aiohttp
     # via aiosignal
@@ -56,16 +51,8 @@ idna==3.4
     # via anyio
     # via httpx
     # via yarl
-iniconfig==2.1.0
-    # via pytest
-inline-snapshot==0.28.0
-    # via openai
 jiter==0.6.1
     # via openai
-markdown-it-py==3.0.0
-    # via rich
-mdurl==0.1.2
-    # via markdown-it-py
 multidict==6.5.0
     # via aiohttp
     # via yarl
@@ -73,14 +60,10 @@ numpy==2.0.2
     # via openai
     # via pandas
     # via pandas-stubs
-packaging==25.0
-    # via pytest
 pandas==2.2.3
     # via openai
 pandas-stubs==2.2.2.240807
     # via openai
-pluggy==1.6.0
-    # via pytest
 propcache==0.3.2
     # via aiohttp
     # via yarl
@@ -90,17 +73,10 @@ pydantic==2.10.3
     # via openai
 pydantic-core==2.27.1
     # via pydantic
-pygments==2.19.2
-    # via pytest
-    # via rich
-pytest==8.4.1
-    # via inline-snapshot
 python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.1
     # via pandas
-rich==14.1.0
-    # via inline-snapshot
 six==1.16.0
     # via python-dateutil
 sniffio==1.3.0
@@ -108,9 +84,6 @@ sniffio==1.3.0
     # via openai
 sounddevice==0.5.1
     # via openai
-tomli==2.2.1
-    # via inline-snapshot
-    # via pytest
 tqdm==4.66.5
     # via openai
 types-pytz==2024.2.0.20241003

--- a/tests/lib/chat/test_completions_streaming.py
+++ b/tests/lib/chat/test_completions_streaming.py
@@ -13,6 +13,7 @@ from inline_snapshot import (
     external,
     snapshot,
     outsource,  # pyright: ignore[reportUnknownVariableType]
+    get_snapshot_value,
 )
 
 import openai
@@ -30,7 +31,7 @@ from openai.lib.streaming.chat import (
 )
 from openai.lib._parsing._completions import ResponseFormatT
 
-from ..utils import print_obj, get_snapshot_value
+from ..utils import print_obj
 from ...conftest import base_url
 
 _T = TypeVar("_T")

--- a/tests/lib/snapshots.py
+++ b/tests/lib/snapshots.py
@@ -7,10 +7,9 @@ from typing_extensions import TypeVar
 
 import httpx
 from respx import MockRouter
+from inline_snapshot import get_snapshot_value
 
 from openai import OpenAI, AsyncOpenAI
-
-from .utils import get_snapshot_value
 
 _T = TypeVar("_T")
 

--- a/tests/lib/utils.py
+++ b/tests/lib/utils.py
@@ -52,15 +52,3 @@ def get_caller_name(*, stacklevel: int = 1) -> str:
 def clear_locals(string: str, *, stacklevel: int) -> str:
     caller = get_caller_name(stacklevel=stacklevel + 1)
     return string.replace(f"{caller}.<locals>.", "")
-
-
-def get_snapshot_value(snapshot: Any) -> Any:
-    if not hasattr(snapshot, "_old_value"):
-        return snapshot
-
-    old = snapshot._old_value
-    if not hasattr(old, "value"):
-        return old
-
-    loader = getattr(old.value, "_load_value", None)
-    return loader() if loader else old.value


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Bumps the version of [inline-snapshot](https://15r10nk.github.io/inline-snapshot/latest/) used for testing, and removes the custom function that was added to its public API.

## Additional context & links
