### PR TITLE
Update model parameter type in Session for better compatibility with recently released models

### DIFF
--- a/src/openai/types/beta/realtime/session_update_event.py
+++ b/src/openai/types/beta/realtime/session_update_event.py
@@ -224,13 +224,16 @@ class Session(BaseModel):
     """
 
     model: Optional[
-        Literal[
-            "gpt-4o-realtime-preview",
-            "gpt-4o-realtime-preview-2024-10-01",
-            "gpt-4o-realtime-preview-2024-12-17",
-            "gpt-4o-realtime-preview-2025-06-03",
-            "gpt-4o-mini-realtime-preview",
-            "gpt-4o-mini-realtime-preview-2024-12-17",
+        Union[
+            Literal[
+                "gpt-4o-realtime-preview",
+                "gpt-4o-realtime-preview-2024-10-01",
+                "gpt-4o-realtime-preview-2024-12-17",
+                "gpt-4o-realtime-preview-2025-06-03",
+                "gpt-4o-mini-realtime-preview",
+                "gpt-4o-mini-realtime-preview-2024-12-17",
+            ],
+            str,
         ]
     ] = None
     """The Realtime model used for this session."""


### PR DESCRIPTION
syncing with Agents SDK (https://github.com/openai/openai-agents-python/blob/main/src/agents/realtime/config.py), enabling the session model config to accept models that are not pre-specified (e.g., gpt-4o-realtime-preview-2025-08-12, gpt-realtime).

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
model param type update in Session
## Additional context & links
