### PR TITLE
Clarify index docstring for AnnotationFileCitation and AnnotationFilePath (GH#2512)

### DIFF
--- a/src/openai/types/responses/response_output_text.py
+++ b/src/openai/types/responses/response_output_text.py
@@ -26,7 +26,7 @@ class AnnotationFileCitation(BaseModel):
     """The filename of the file cited."""
 
     index: int
-    """The index at which to insert the file path annotation in the message text (zero-based character index)."""
+    """The index at which to insert the file citation in the message text (zero-based character index)."""
 
     type: Literal["file_citation"]
     """The type of the file citation. Always `file_citation`."""

--- a/src/openai/types/responses/response_output_text.py
+++ b/src/openai/types/responses/response_output_text.py
@@ -26,7 +26,7 @@ class AnnotationFileCitation(BaseModel):
     """The filename of the file cited."""
 
     index: int
-    """The index of the file in the list of files."""
+    """The index at which to insert the file path annotation in the message text (zero-based character index)."""
 
     type: Literal["file_citation"]
     """The type of the file citation. Always `file_citation`."""

--- a/src/openai/types/responses/response_output_text.py
+++ b/src/openai/types/responses/response_output_text.py
@@ -74,7 +74,7 @@ class AnnotationFilePath(BaseModel):
     """The ID of the file."""
 
     index: int
-    """The index of the file in the list of files."""
+    """The index at which to insert the file path annotation in the message text (zero-based character index)."""
 
     type: Literal["file_path"]
     """The type of the file path. Always `file_path`."""


### PR DESCRIPTION
 (GH#2512)
This pull request updates the docstring for the index field in both the AnnotationFileCitation and AnnotationFilePath classes.

The updated docstrings clarify that the index refers to the zero-based character position in the message text where the annotation should be inserted, rather than the index of a file in a list.

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !