### PR TITLE
fix: add `ActionFindInPage` and allow null url in `ActionOpenPage`

### DIFF
--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -6,7 +6,7 @@ from typing_extensions import Literal, Annotated, TypeAlias
 from ..._utils import PropertyInfo
 from ..._models import BaseModel
 
-__all__ = ["ResponseFunctionWebSearch", "Action", "ActionSearch", "ActionSearchSource", "ActionOpenPage", "ActionFind"]
+__all__ = ["ResponseFunctionWebSearch", "Action", "ActionSearch", "ActionSearchSource", "ActionOpenPage", "ActionFind", "ActionFindInPage"]
 
 
 class ActionSearchSource(BaseModel):
@@ -32,7 +32,7 @@ class ActionOpenPage(BaseModel):
     type: Literal["open_page"]
     """The action type."""
 
-    url: str
+    url: Optional[str] = None
     """The URL opened by the model."""
 
 
@@ -47,7 +47,18 @@ class ActionFind(BaseModel):
     """The URL of the page searched for the pattern."""
 
 
-Action: TypeAlias = Annotated[Union[ActionSearch, ActionOpenPage, ActionFind], PropertyInfo(discriminator="type")]
+class ActionFindInPage(BaseModel):
+    pattern: str
+    """The pattern or text to search for within the page."""
+
+    type: Literal["find_in_page"]
+    """The action type."""
+
+    url: str
+    """The URL of the page searched for the pattern."""
+
+
+Action: TypeAlias = Annotated[Union[ActionSearch, ActionOpenPage, ActionFind, ActionFindInPage], PropertyInfo(discriminator="type")]
 
 
 class ResponseFunctionWebSearch(BaseModel):


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Added `ActionFindInPage` class to handle searching patterns within a page and updated Action type alias to include it.
Updated `ActionOpenPage` class to allow empty URL.

## Additional context & links

Should resolve #2620 #2621 