### PR TITLE
fix: encode httpx headers with utf-8

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -436,7 +436,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         self._validate_headers(headers_dict, custom_headers)
 
         # headers are case-insensitive while dictionaries are not.
-        headers = httpx.Headers(headers_dict)
+        headers = httpx.Headers(headers_dict, encoding="utf-8")
 
         idempotency_header = self._idempotency_header
         if idempotency_header and options.idempotency_key and idempotency_header not in headers:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

When custom headers contain CJK or other non-ascii characters, `httpx.Headers(headers_dict)` without explicit `utf-8` encoding will raise:

```
  File "...", line 85, in generate
    response = await self._client.chat.completions.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<6 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py", line 2603, in create
    return await self._post(
           ^^^^^^^^^^^^^^^^^
    ...<48 lines>...
    )
    ^
  File ".venv/lib/python3.13/site-packages/openai/_base_client.py", line 1794, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".venv/lib/python3.13/site-packages/openai/_base_client.py", line 1515, in request
    request = self._build_request(options, retries_taken=retries_taken)
  File ".venv/lib/python3.13/site-packages/openai/_base_client.py", line 495, in _build_request
    headers = self._build_headers(options, retries_taken=retries_taken)
  File ".venv/lib/python3.13/site-packages/openai/_base_client.py", line 439, in _build_headers
    headers = httpx.Headers(headers_dict)
  File ".venv/lib/python3.13/site-packages/httpx/_models.py", line 156, in __init__
    bytes_value = _normalize_header_value(v, encoding)
  File ".venv/lib/python3.13/site-packages/httpx/_models.py", line 82, in _normalize_header_value
    return value.encode(encoding or "ascii")
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'ascii' codec can't encode characters in position 58-59: ordinal not in range(128)
```

## Additional context & links
