### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- prettier-ignore -->
 [![PyPI version](https://img.shields.io/pypi/v/openai.svg?label=pypi%20(stable))](https://pypi.org/project/openai/)
 
-The OpenAI Python library provides convenient access to the OpenAI REST API from any Python 3.8+
+The OpenAI Python library provides convenient access to the OpenAI REST API from any Python 3.9+
 application. The library includes type definitions for all request params and response fields,
 and offers both synchronous and asynchronous clients powered by [httpx](https://github.com/encode/httpx).
 
@@ -854,7 +854,7 @@ print(openai.__version__)
 
 ## Requirements
 
-Python 3.8 or higher.
+Python 3.9 or higher.
 
 ## Contributing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ dependencies = [
     "tqdm > 4",
     "jiter>=0.10.0, <1",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 classifiers = [
   "Typing :: Typed",
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -159,7 +158,7 @@ format-command="ruff format --stdin-filename {filename}"
 # there are a couple of flags that are still disabled by
 # default in strict mode as they are experimental and niche.
 typeCheckingMode = "strict"
-pythonVersion = "3.8"
+pythonVersion = "3.9"
 
 exclude = [
     "_dev",

--- a/src/openai/_types.py
+++ b/src/openai/_types.py
@@ -51,12 +51,8 @@ _T = TypeVar("_T")
 # while adding support for `PathLike` instances
 ProxiesDict = Dict["str | URL", Union[None, str, URL, Proxy]]
 ProxiesTypes = Union[str, Proxy, ProxiesDict]
-if TYPE_CHECKING:
-    Base64FileInput = Union[IO[bytes], PathLike[str]]
-    FileContent = Union[IO[bytes], bytes, PathLike[str]]
-else:
-    Base64FileInput = Union[IO[bytes], PathLike]
-    FileContent = Union[IO[bytes], bytes, PathLike]  # PathLike is not subscriptable in Python 3.8.
+Base64FileInput = Union[IO[bytes], PathLike[str]]
+FileContent = Union[IO[bytes], bytes, PathLike[str]]
 FileTypes = Union[
     # file (or bytes)
     FileContent,

--- a/src/openai/_utils/_sync.py
+++ b/src/openai/_utils/_sync.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import sys
 import asyncio
 import functools
-import contextvars
-from typing import Any, TypeVar, Callable, Awaitable
+from typing import TypeVar, Callable, Awaitable
 from typing_extensions import ParamSpec
 
 import anyio
@@ -15,34 +13,11 @@ T_Retval = TypeVar("T_Retval")
 T_ParamSpec = ParamSpec("T_ParamSpec")
 
 
-if sys.version_info >= (3, 9):
-    _asyncio_to_thread = asyncio.to_thread
-else:
-    # backport of https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread
-    # for Python 3.8 support
-    async def _asyncio_to_thread(
-        func: Callable[T_ParamSpec, T_Retval], /, *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
-    ) -> Any:
-        """Asynchronously run function *func* in a separate thread.
-
-        Any *args and **kwargs supplied for this function are directly passed
-        to *func*. Also, the current :class:`contextvars.Context` is propagated,
-        allowing context variables from the main thread to be accessed in the
-        separate thread.
-
-        Returns a coroutine that can be awaited to get the eventual result of *func*.
-        """
-        loop = asyncio.events.get_running_loop()
-        ctx = contextvars.copy_context()
-        func_call = functools.partial(ctx.run, func, *args, **kwargs)
-        return await loop.run_in_executor(None, func_call)
-
-
 async def to_thread(
     func: Callable[T_ParamSpec, T_Retval], /, *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
 ) -> T_Retval:
     if sniffio.current_async_library() == "asyncio":
-        return await _asyncio_to_thread(func, *args, **kwargs)
+        return await asyncio.to_thread(func, *args, **kwargs)
 
     return await anyio.to_thread.run_sync(
         functools.partial(func, *args, **kwargs),


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Remove Python 3.8 support, since the dependency tree doesn't support it anymore.

## Additional context & links

```
"jiter>=0.10.0, <1",
```

This version of jiter is not compatible with Python 3.8

```
  × No solution found when resolving dependencies for split (markers: python_full_version == '3.8.*'):
  ╰─▶ Because the requested Python version (>=3.8) does not satisfy Python>=3.9 and jiter>=0.10.0 depends on Python>=3.9, we can conclude that jiter>=0.10.0 cannot be used.
      And because only the following versions of jiter are available:
          jiter<=0.10.0
          jiter==0.11.0
          jiter==0.11.1
      we can conclude that jiter>=0.10.0 cannot be used.
      And because your project depends on jiter>=0.10.0 and your project requires openai[aiohttp], we can conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (>=3.8) includes Python versions that are not supported by your dependencies (e.g., jiter>=0.10.0 only supports >=3.9). Consider using a more
      restrictive `requires-python` value (like >=3.9).

      hint: While the active Python version is 3.9, the resolution failed for other Python versions supported by your project. Consider limiting your project's supported Python versions
      using `requires-python`.

```