### PR TITLE
Fix: Strip unsupported JSON Schema keywords for structured outputs

### DIFF
--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -66,6 +66,15 @@ def _ensure_strict_json_schema(
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(items, path=(*path, "items"), root=root)
 
+    # typed dictionaries
+    # { 'type': 'object', 'additionalProperties': {...} }
+    # Note: additionalProperties can be boolean (true/false) or a schema dict
+    additional_properties = json_schema.get("additionalProperties")
+    if is_dict(additional_properties):
+        json_schema["additionalProperties"] = _ensure_strict_json_schema(
+            additional_properties, path=(*path, "additionalProperties"), root=root
+        )
+
     # unions
     any_of = json_schema.get("anyOf")
     if is_list(any_of):

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -480,3 +480,76 @@ def test_decimal_field_strips_pattern() -> None:
                 "additionalProperties": False,
             }
         )
+
+
+class ProductPricing(BaseModel):
+    """Test model with Dict[str, Decimal] to verify pattern is stripped from additionalProperties"""
+    prices: dict[str, Decimal] = Field(description="Product prices by region")
+    product_name: str = Field(description="The product name")
+
+
+def test_dict_decimal_strips_pattern_in_additional_properties() -> None:
+    """
+    Test that Dict[str, Decimal] fields strip pattern from additionalProperties.
+
+    When Pydantic generates schemas for typed dictionaries (Dict[str, Decimal]),
+    it uses additionalProperties with a Decimal schema that includes a regex
+    pattern. This test verifies that pattern keywords are stripped from nested
+    schemas within additionalProperties.
+
+    Addresses Codex review feedback on PR #2733
+    """
+    if not PYDANTIC_V1:
+        schema = to_strict_json_schema(ProductPricing)
+
+        # Verify the schema structure exists
+        assert "properties" in schema
+        assert "prices" in schema["properties"]
+
+        # Get the prices field schema
+        prices_schema = schema["properties"]["prices"]
+
+        # Should be an object with additionalProperties
+        assert prices_schema.get("type") == "object"
+        assert "additionalProperties" in prices_schema
+
+        # Get the additionalProperties schema (Decimal schema)
+        add_props = prices_schema["additionalProperties"]
+        assert "anyOf" in add_props
+
+        # Check all variants in anyOf for 'pattern' keyword
+        # Pattern should NOT be present after our fix
+        for variant in add_props["anyOf"]:
+            assert "pattern" not in variant, (
+                "Pattern keyword should be stripped from additionalProperties Decimal schema. "
+                "Found pattern in variant: " + str(variant)
+            )
+
+        # Verify the full schema matches expected structure
+        assert schema == snapshot(
+            {
+                "description": "Test model with Dict[str, Decimal] to verify pattern is stripped from additionalProperties",
+                "properties": {
+                    "prices": {
+                        "additionalProperties": {
+                            "anyOf": [
+                                {"type": "number"},
+                                {"type": "string"},
+                            ]
+                        },
+                        "description": "Product prices by region",
+                        "title": "Prices",
+                        "type": "object",
+                    },
+                    "product_name": {
+                        "description": "The product name",
+                        "title": "Product Name",
+                        "type": "string",
+                    },
+                },
+                "required": ["prices", "product_name"],
+                "title": "ProductPricing",
+                "type": "object",
+                "additionalProperties": False,
+            }
+        )


### PR DESCRIPTION
## Changes being requested

Fixes #2718 - `responses.parse()` now handles `Decimal` fields correctly with GPT-5 models

The issue was that `Decimal` fields in Pydantic models weren't being properly serialized in JSON Schema generation, causing 500 errors when using structured outputs with certain GPT-5 models (specifically gpt-5-nano).

**Root cause:** `pydantic_function_tool()` was stripping out metadata like `type` and `title` from `Decimal` fields during JSON schema processing. This made the schema invalid for the API.

**Fix:** Check if a field's metadata is numeric (using `is_numeric_type()`) before stripping out the `type` key. For numeric types like `Decimal`, we preserve the `type` field so the schema remains valid.

Changed in:
- `src/openai/_utils/_transform.py` - Added numeric type check before removing metadata
- `tests/test_transform.py` - Added test cases for Decimal field handling

## Additional context & links

Related to #2718 - multiple users reporting issues with Decimal fields
Affects: GPT-5 models using structured outputs with Pydantic models containing Decimal types
