### PR TITLE
Fix: Correct parameter passing in vector_stores poll() methods

### DIFF
--- a/src/openai/resources/vector_stores/file_batches.py
+++ b/src/openai/resources/vector_stores/file_batches.py
@@ -295,7 +295,7 @@ class FileBatches(SyncAPIResource):
 
         while True:
             response = self.with_raw_response.retrieve(
-                batch_id,
+                batch_id=batch_id,
                 vector_store_id=vector_store_id,
                 extra_headers=headers,
             )
@@ -632,7 +632,7 @@ class AsyncFileBatches(AsyncAPIResource):
 
         while True:
             response = await self.with_raw_response.retrieve(
-                batch_id,
+                batch_id=batch_id,
                 vector_store_id=vector_store_id,
                 extra_headers=headers,
             )

--- a/src/openai/resources/vector_stores/files.py
+++ b/src/openai/resources/vector_stores/files.py
@@ -337,7 +337,7 @@ class Files(SyncAPIResource):
 
         while True:
             response = self.with_raw_response.retrieve(
-                file_id,
+                file_id=file_id,
                 vector_store_id=vector_store_id,
                 extra_headers=headers,
             )
@@ -745,7 +745,7 @@ class AsyncFiles(AsyncAPIResource):
 
         while True:
             response = await self.with_raw_response.retrieve(
-                file_id,
+                file_id=file_id,
                 vector_store_id=vector_store_id,
                 extra_headers=headers,
             )


### PR DESCRIPTION
## Changes being requested

Fixes #2717 - `poll()` methods in vector_stores now pass parameters correctly

The `poll()` methods in both `Files` and `FileBatches` were passing IDs as positional arguments instead of named parameters when calling `retrieve()`. This causes `TypeError` because `retrieve()` expects named parameters.

**Fixed in 4 locations:**
- `FileBatches.poll()` (sync) - line 295
- `AsyncFileBatches.poll()` (async) - line 632
- `Files.poll()` (sync) - line 337
- `AsyncFiles.poll()` (async) - line 745

Changed from:
```python
batch_id,  # positional
vector_store_id,
```

To:
```python
batch_id=batch_id,  # named parameter
vector_store_id=vector_store_id,
```

## Additional context & links

Issue: #2717
Affected: All users calling `poll()` on vector store files or file batches
Impact: Method was failing with TypeError when trying to poll for completion status
