### PR TITLE
Fix: Prevent retry of termination signals (Celery SoftTimeLimitExceeded)

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -112,7 +112,7 @@ def _should_not_retry(exc: Exception) -> bool:
         return True
 
     # asyncio cancellation
-    if exc_module == "asyncio" and exc_name == "CancelledError":
+    if exc_module.startswith("asyncio") and exc_name == "CancelledError":
         return True
 
     return False

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -88,6 +88,36 @@ from ._legacy_response import LegacyAPIResponse
 log: logging.Logger = logging.getLogger(__name__)
 log.addFilter(SensitiveHeadersFilter())
 
+
+def _should_not_retry(exc: Exception) -> bool:
+    """
+    Check if an exception should propagate immediately without retry.
+
+    This includes task cancellation signals from async frameworks
+    and task executors like Celery that should not be caught and retried.
+
+    Args:
+        exc: The exception to check
+
+    Returns:
+        True if the exception should propagate without retry, False otherwise
+    """
+    exc_class = exc.__class__
+    exc_module = exc_class.__module__
+    exc_name = exc_class.__name__
+
+    # Celery task termination (don't import celery - check by name)
+    # Examples: SoftTimeLimitExceeded, TimeLimitExceeded, Terminated
+    if exc_module.startswith("celery") and ("Limit" in exc_name or "Terminated" in exc_name):
+        return True
+
+    # asyncio cancellation
+    if exc_module == "asyncio" and exc_name == "CancelledError":
+        return True
+
+    return False
+
+
 # TODO: make base page type vars covariant
 SyncPageT = TypeVar("SyncPageT", bound="BaseSyncPage[Any]")
 AsyncPageT = TypeVar("AsyncPageT", bound="BaseAsyncPage[Any]")
@@ -1001,6 +1031,10 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
             except Exception as err:
                 log.debug("Encountered Exception", exc_info=True)
 
+                # Check if this is a termination signal that should not be retried
+                if _should_not_retry(err):
+                    raise
+
                 if remaining_retries > 0:
                     self._sleep_for_retry(
                         retries_taken=retries_taken,
@@ -1547,6 +1581,10 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
                 raise APITimeoutError(request=request) from err
             except Exception as err:
                 log.debug("Encountered Exception", exc_info=True)
+
+                # Check if this is a termination signal that should not be retried
+                if _should_not_retry(err):
+                    raise
 
                 if remaining_retries > 0:
                     await self._sleep_for_retry(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -916,6 +916,37 @@ class TestOpenAI:
         # Verify only one attempt was made (no retries)
         assert len(respx_mock.calls) == 1
 
+    @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
+    @pytest.mark.respx(base_url=base_url)
+    def test_asyncio_cancelled_error_not_retried(self, respx_mock: MockRouter, client: OpenAI) -> None:
+        """Test that asyncio.CancelledError is not retried."""
+        client = client.with_options(max_retries=3)
+
+        # Create a mock exception that mimics asyncio.exceptions.CancelledError
+        class MockCancelledError(Exception):
+            """Mock of asyncio.exceptions.CancelledError"""
+
+            __module__ = "asyncio.exceptions"
+            __name__ = "CancelledError"
+
+        # Mock the request to raise our cancellation signal
+        respx_mock.post("/chat/completions").mock(side_effect=MockCancelledError("Task cancelled"))
+
+        # Verify the exception propagates without retry
+        with pytest.raises(MockCancelledError):
+            client.chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-4o",
+            )
+
+        # Verify only one attempt was made (no retries)
+        assert len(respx_mock.calls) == 1
+
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This PR fixes issue #2737 where the OpenAI client's broad exception handling was catching Celery's `SoftTimeLimitExceeded` exception and retrying the request instead of allowing it to propagate for graceful task shutdown.

**Changes:**
- Added `_should_not_retry()` helper function to identify termination signals that should propagate immediately
- Modified both sync and async exception handlers to check for termination signals before attempting retry
- Added test coverage to verify termination signals are not retried

**Affected exception types:**
- Celery task limits: `SoftTimeLimitExceeded`, `TimeLimitExceeded`, `Terminated`
- Asyncio cancellation: `CancelledError`

The fix preserves all existing retry logic while ensuring task executor termination signals are properly handled.

## Additional context & links

Fixes #2737

**Background:**
When using the OpenAI client in Celery tasks with soft time limits, if the task exceeds its limit during an API call, Celery raises `SoftTimeLimitExceeded`. The client's `except Exception` clause was catching this and treating it as a retryable connection error, preventing cleanup logic from running.

**Solution approach:**
Instead of narrowing the exception catch (which could miss legitimate connection errors), we check if caught exceptions are termination signals and re-raise them immediately without retry. This approach:
- Maintains backward compatibility
- Doesn't require importing Celery (checks by module name)
- Handles both sync and async code paths
- Is extensible for other task executors