### PR TITLE
Fix Pydantic extra='allow' handling in strict JSON schema

### DIFF
--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -47,7 +47,7 @@ def _ensure_strict_json_schema(
             _ensure_strict_json_schema(definition_schema, path=(*path, "definitions", definition_name), root=root)
 
     typ = json_schema.get("type")
-    if typ == "object" and "additionalProperties" not in json_schema:
+    if typ == "object":
         json_schema["additionalProperties"] = False
 
     # object types


### PR DESCRIPTION
## Description

Fixes #2740 

The `to_strict_json_schema` function was not properly handling Pydantic models with `extra="allow"`. 

## Problem

When using Pydantic models with `model_config = ConfigDict(extra="allow")`, the generated JSON schema includes `"additionalProperties": true`. The OpenAI structured outputs API requires `"additionalProperties": false` for all schemas.

The existing code only set `additionalProperties=false` when the key didn't exist:
```python
if typ == "object" and "additionalProperties" not in json_schema:
    json_schema["additionalProperties"] = False
```

This meant models with `extra="allow"` (which already have `additionalProperties=true` in their schema) were not being corrected.

## Solution

Remove the `"additionalProperties" not in json_schema` check to always enforce `additionalProperties=false` for object types:

```python
if typ == "object":
    json_schema["additionalProperties"] = False
```

This aligns with the OpenAI API requirement and fixes the bug reported in #2740.

## Testing

The fix ensures all object types in JSON schemas will have `additionalProperties` set to `false`, regardless of the Pydantic model configuration.