### PR TITLE
fix: update ActionSearchSource type to support specialized API sources

### DIFF
--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -10,11 +10,14 @@ __all__ = ["ResponseFunctionWebSearch", "Action", "ActionSearch", "ActionSearchS
 
 
 class ActionSearchSource(BaseModel):
-    type: Literal["url"]
-    """The type of source. Always `url`."""
+    type: Literal["url", "api"]
+    """The type of source. Can be 'url' for web sources or 'api' for specialized OpenAI APIs."""
 
-    url: str
-    """The URL of the source."""
+    url: Optional[str] = None
+    """The URL of the source (present when type='url')."""
+
+    name: Optional[str] = None
+    """The name/identifier of the specialized API (e.g., 'oai-weather', 'oai-sports', 'oai-finance')."""
 
 
 class ActionSearch(BaseModel):

--- a/src/openai/types/responses/response_function_web_search_param.py
+++ b/src/openai/types/responses/response_function_web_search_param.py
@@ -16,11 +16,14 @@ __all__ = [
 
 
 class ActionSearchSource(TypedDict, total=False):
-    type: Required[Literal["url"]]
-    """The type of source. Always `url`."""
+    type: Required[Literal["url", "api"]]
+    """The type of source. Can be 'url' for web sources or 'api' for specialized OpenAI APIs."""
 
-    url: Required[str]
-    """The URL of the source."""
+    url: str
+    """The URL of the source (present when type='url')."""
+
+    name: str
+    """The name/identifier of the specialized API (e.g., 'oai-weather', 'oai-sports', 'oai-finance')."""
 
 
 class ActionSearch(TypedDict, total=False):


### PR DESCRIPTION
## Description

Fixes #2736 

This PR updates the `ActionSearchSource` type definition to match the actual API response structure when using specialized OpenAI APIs (weather, sports, finance).

## Problem

The current type definition only supports `type: Literal["url"]` and requires both `type` and `url` fields, but the actual API returns responses like:

```python
ActionSearchSource(type='api', url=None, name='oai-weather')
```

This causes type checking failures and forces developers to use `# type: ignore` or create custom type definitions.

## Solution

Updated both `ActionSearchSource` definitions (BaseModel and TypedDict versions) to:

1. **Support both source types**: Changed `type` from `Literal["url"]` to `Literal["url", "api"]`
2. **Make url optional**: Changed from required `str` to `Optional[str] = None` (present only when `type='url'`)
3. **Add name field**: Added `Optional[str]` for specialized API identifiers (e.g., `'oai-weather'`, `'oai-sports'`, `'oai-finance'`)

## Files Changed

- `src/openai/types/responses/response_function_web_search.py` (BaseModel version)
- `src/openai/types/responses/response_function_web_search_param.py` (TypedDict version)

## Testing

While I don't have access to test against the actual specialized APIs, the type changes are:
- Backward compatible (url sources still work)
- Aligned with the documented behavior in the [tools web search guide](https://platform.openai.com/docs/guides/tools-web-search)
- Based on the actual API response structure reported in the issue

## Additional Context

This aligns with the documentation mentioning specialized domains labeled as `oai-sports`, `oai-weather`, or `oai-finance`.