### PR TITLE
fix: pickle exceptions with custom `__reduce__`

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -136,6 +136,10 @@ class APITimeoutError(APIConnectionError):
     def __init__(self, request: httpx.Request) -> None:
         super().__init__(message="Request timed out.", request=request)
 
+    @override
+    def __reduce__(self) -> tuple[Callable[..., Self], tuple[Any, ...]]:
+        return (self.__class__, (self.request,))
+
 
 class BadRequestError(APIStatusError):
     status_code: Literal[400] = 400  # pyright: ignore[reportIncompatibleVariableOverride]


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Closes #2629. When working in a distributed environment, its useful to pickle and unpickle exceptions between workers. The default `__reduce__` in Python does not account for keyword-only args, which is why we need to handle it ourselves.

Alternatively, we could modify the constructor of the exception classes to not use keyword-only args, but that was a larger change.

