### PR TITLE
fix(api): align ChatCompletionCustomToolParam structure with API spec

### DIFF
--- a/src/openai/types/chat/chat_completion_custom_tool_param.py
+++ b/src/openai/types/chat/chat_completion_custom_tool_param.py
@@ -2,57 +2,22 @@
 
 from __future__ import annotations
 
-from typing import Union
-from typing_extensions import Literal, Required, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-__all__ = [
-    "ChatCompletionCustomToolParam",
-    "Custom",
-    "CustomFormat",
-    "CustomFormatText",
-    "CustomFormatGrammar",
-    "CustomFormatGrammarGrammar",
-]
+from ..shared_params.custom_tool_input_format import CustomToolInputFormat
+
+__all__ = ["ChatCompletionCustomToolParam"]
 
 
-class CustomFormatText(TypedDict, total=False):
-    type: Required[Literal["text"]]
-    """Unconstrained text format. Always `text`."""
-
-
-class CustomFormatGrammarGrammar(TypedDict, total=False):
-    definition: Required[str]
-    """The grammar definition."""
-
-    syntax: Required[Literal["lark", "regex"]]
-    """The syntax of the grammar definition. One of `lark` or `regex`."""
-
-
-class CustomFormatGrammar(TypedDict, total=False):
-    grammar: Required[CustomFormatGrammarGrammar]
-    """Your chosen grammar."""
-
-    type: Required[Literal["grammar"]]
-    """Grammar format. Always `grammar`."""
-
-
-CustomFormat: TypeAlias = Union[CustomFormatText, CustomFormatGrammar]
-
-
-class Custom(TypedDict, total=False):
+class ChatCompletionCustomToolParam(TypedDict, total=False):
     name: Required[str]
     """The name of the custom tool, used to identify it in tool calls."""
+
+    type: Required[Literal["custom"]]
+    """The type of the custom tool. Always `custom`."""
 
     description: str
     """Optional description of the custom tool, used to provide more context."""
 
-    format: CustomFormat
+    format: CustomToolInputFormat
     """The input format for the custom tool. Default is unconstrained text."""
-
-
-class ChatCompletionCustomToolParam(TypedDict, total=False):
-    custom: Required[Custom]
-    """Properties of the custom tool."""
-
-    type: Required[Literal["custom"]]
-    """The type of the custom tool. Always `custom`."""


### PR DESCRIPTION
## Summary

- Fixes the `ChatCompletionCustomToolParam` type definition to match the actual API structure
- Removes incorrect nesting (`custom` wrapper object and `format.grammar` wrapper)
- Reuses the shared `CustomToolInputFormat` type (same as Responses API)

## Problem

The Chat Completions API custom tool type had incorrect nesting that didn't match the [actual API structure](https://cookbook.openai.com/examples/gpt-5/gpt-5_new_params_and_tools):

**Before (incorrect):**
```python
{
    "type": "custom",
    "custom": {  # ← extra nesting
        "name": "tool_name",
        "format": {
            "type": "grammar",
            "grammar": {  # ← extra nesting
                "syntax": "lark",
                "definition": "..."
            }
        }
    }
}
```

**After (correct, matching API docs):**
```python
{
    "type": "custom",
    "name": "tool_name",
    "format": {
        "type": "grammar",
        "syntax": "lark",
        "definition": "..."
    }
}
```

## Test plan

- [x] Verified type structure now matches `CustomToolParam` from Responses API
- [x] Verified imports work correctly with shared `CustomToolInputFormat` type

Fixes #2667