### PR TITLE
fix(azure): support v1/preview/latest API versions

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -76,6 +76,10 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         and the API feature being called is **not** a deployments-based endpoint
         (i.e. requires /deployments/deployment-name in the URL path).
         """
+        # v1 API doesn't need URL rewriting - base_url already has /openai/v1/
+        if getattr(self, '_is_v1_api', False):
+            return super()._prepare_url(url)
+
         if self._azure_deployment and self._azure_endpoint and url not in _deployments_endpoints:
             merge_url = httpx.URL(url)
             if merge_url.is_relative_url:


### PR DESCRIPTION
  - [x] I understand that this repository is auto-generated and my pull request may not be merged

  ## Changes being requested

  Add support for Azure OpenAI v1/preview/latest API versions.

Currently, when using `api_version="v1"`, `"preview"`, or `"latest"`, the SDK generates incorrect URLs:


 ```python
  from openai import AzureOpenAI

  client = AzureOpenAI(
      api_version="preview",  # or "v1" or "latest"
      azure_endpoint="https://example-endpoint.openai.azure.com",
  )

 # Both work with the fix:
  completion = client.chat.completions.create(
      model="deployment-name",
      messages=[{"role": "user", "content": "Hello!"}],
  )

  response = client.responses.create(
      model="deployment-name",
      input="Hello!",
  )
  
print(response)
print(completion)

  ```
  
  |          | URL Generated                                                   |
  |----------|-----------------------------------------------------------------|
  | ❌ Before | /openai/deployments/gpt-4o/chat/completions?api-version=preview |
  | ✅ After  | /openai/v1/chat/completions?api-version=preview                 |
  
 The new Azure OpenAI v1 API uses /openai/v1/ path and the model is passed in the request body, not in the URL.

**Non breaking changes** - the values "v1", "preview", and "latest" previously resulted in 404 errors, so no existing working code is affected.
  
  
  ### Changes:
  - Add _is_v1_api flag to BaseAzureClient
  - Skip adding /deployments/{model}/ path for v1 API in _build_request
  - Use /openai/v1/ base URL for v1/preview/latest api_version values
  - Add comprehensive tests (23 new test cases)

Note: The `?api-version=` query parameter is still included for compatibility, as shown in the
  https://learn.microsoft.com/en-us/azure/ai-foundry/openai/reference-preview-latest.
  
 ### Additional context & links

  - Fixes: #2584
  - Azure docs: https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation