### PR TITLE
Aung/fix text tokens and image tokens not documented or typed

### DIFF
--- a/src/openai/types/completion_usage.py
+++ b/src/openai/types/completion_usage.py
@@ -36,6 +36,12 @@ class PromptTokensDetails(BaseModel):
     cached_tokens: Optional[int] = None
     """Cached tokens present in the prompt."""
 
+    image_tokens: Optional[int] = None
+    """Image input tokens present in the prompt."""
+
+    text_tokens: Optional[int] = None
+    """Text input tokens present in the prompt."""
+
 
 class CompletionUsage(BaseModel):
     completion_tokens: int


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested


## In your IDE without definition:
details = response.usage.prompt_tokens_details
details.text_  # ← No autocomplete! 
details.text_tokens  # ← Type checker error!


## In your IDE with definition:
details = response.usage.prompt_tokens_details
details.text_  # ← IDE autocompletes to "text_tokens"! ✅
details.text_tokens  # ← Type checker OK! ✅


## Additional context & links
Since below code is allowing extra fields, we can still access the image_tokens and text_tokens, but it's not good practice knowing that '`text_tokens`' and '`image_tokens`' is obviously available inside '`prompt_tokens_details`'

```
class Config(pydantic.BaseConfig):
    extra: Any = pydantic.Extra.allow  # ← This allows extra fields!
```

To test this, need to use [gpt-4o-audio model (gpt-4o-audio-preview)](https://platform.openai.com/docs/models/gpt-4o-audio-preview) with [kaggle audio dataset](https://www.kaggle.com/datasets/crischir/sample-wav-audio-files) to make mini audio_to_text.py to be able to output 'text_tokens' and 'image_tokens' inside 'prompt_tokens_details'

## Next Step
Updating [in one of the example documentations](https://platform.openai.com/docs/api-reference/chat-streaming/streaming) here to include `text_tokens` and `image_token` inside `usage` > `prompt_tokens_details`

<img width="1228" height="924" alt="image" src="https://github.com/user-attachments/assets/6146b80b-8a9b-4c90-877a-e450e07df472" />


Fixed #2554 