### PR TITLE
OpenAI API: image input should have default "detail" field.

### DIFF
--- a/src/openai/types/responses/response_input_image_param.py
+++ b/src/openai/types/responses/response_input_image_param.py
@@ -14,7 +14,7 @@ class ResponseInputImageParam(TypedDict, total=False):
     Learn about [image inputs](https://platform.openai.com/docs/guides/vision).
     """
 
-    detail: Required[Literal["low", "high", "auto"]]
+    detail: Optional[Literal["low", "high", "auto"]] = "auto"
     """The detail level of the image to be sent to the model.
 
     One of `high`, `low`, or `auto`. Defaults to `auto`.


### PR DESCRIPTION
This is to be compatible with OpenAI API official document:

https://platform.openai.com/docs/api-reference/responses/create?lang=curl

```
curl https://api.openai.com/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -d '{
    "model": "gpt-4.1",
    "input": [
      {
        "role": "user",
        "content": [
          {"type": "input_text", "text": "what is in this image?"},
          {
            "type": "input_image",
            "image_url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
          }
        ]
      }
    ]
  }'
```

where `detail` is NOT specified.

Deserializing the above JSON request would result in pydantic error without the fix.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
