### PR TITLE
docs: use smaller image URL in vision example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ With an image URL:
 
 ```python
 prompt = "What is in this image?"
-img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/640px-2023_06_08_Raccoon1.jpg"
 
 response = client.responses.create(
     model="gpt-4o-mini",


### PR DESCRIPTION
## Summary
- Changed vision example image URL from 1599px to 640px version

## Fixes
Closes #2776

## Problem
The original image URL was too large and caused a 400 error:
```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'Error while downloading...'}}
```

## Solution
Changed the image URL to use a smaller 640px thumbnail version which downloads successfully.