### PR TITLE
feat: export ChatCompletion, Response, ResponseUsage from openai.types

### DIFF
--- a/src/openai/types/__init__.py
+++ b/src/openai/types/__init__.py
@@ -6,6 +6,9 @@ from .batch import Batch as Batch
 from .image import Image as Image
 from .model import Model as Model
 from .video import Video as Video
+from .chat import ChatCompletion as ChatCompletion
+from .responses import Response as Response
+from .responses import ResponseUsage as ResponseUsage
 from .shared import (
     Metadata as Metadata,
     AllModels as AllModels,

--- a/tests/test_type_exports.py
+++ b/tests/test_type_exports.py
@@ -1,0 +1,48 @@
+"""Tests for type exports from openai.types.
+
+Verifies that major types are exported from openai.types for easier access.
+Relates to issue #2680: Major types are not exposed in openai.types
+"""
+
+import pytest
+
+
+class TestTypeExports:
+    """Test that major types are exported from openai.types."""
+
+    def test_chat_completion_exported(self) -> None:
+        """Verify ChatCompletion is exported from openai.types (fixes #2680)."""
+        from openai.types import ChatCompletion
+        from openai.types.chat import ChatCompletion as ChatCompletionOriginal
+
+        assert ChatCompletion is ChatCompletionOriginal
+
+    def test_response_exported(self) -> None:
+        """Verify Response is exported from openai.types (fixes #2680)."""
+        from openai.types import Response
+        from openai.types.responses import Response as ResponseOriginal
+
+        assert Response is ResponseOriginal
+
+    def test_response_usage_exported(self) -> None:
+        """Verify ResponseUsage is exported from openai.types (fixes #2680)."""
+        from openai.types import ResponseUsage
+        from openai.types.responses import ResponseUsage as ResponseUsageOriginal
+
+        assert ResponseUsage is ResponseUsageOriginal
+
+    def test_types_can_be_used_for_type_hints(self) -> None:
+        """Verify that imported types can be used for type hints."""
+        from openai.types import ChatCompletion, Response, ResponseUsage
+
+        def process_chat_completion(completion: ChatCompletion) -> None:
+            pass
+
+        def process_response(response: Response) -> None:
+            pass
+
+        def process_usage(usage: ResponseUsage) -> None:
+            pass
+
+        # If we get here without errors, the types work for hints
+        assert True


### PR DESCRIPTION
## Summary
- Export `ChatCompletion`, `Response`, `ResponseUsage` from `openai.types`

## Fixes
Closes #2680

## Problem
Users cannot import major types directly from `openai.types`:
```python
# This didn't work
from openai.types import ChatCompletion  # Not available
```

## Solution
Added re-exports to `openai/types/__init__.py`:
```python
from openai.types import ChatCompletion, Response, ResponseUsage
```

## Test
Added `tests/test_type_exports.py` to verify the types are correctly exported.