### PR TITLE
fix(realtime): add conversation item reference type

### DIFF
--- a/src/openai/types/realtime/__init__.py
+++ b/src/openai/types/realtime/__init__.py
@@ -33,6 +33,12 @@ from .realtime_mcphttp_error import RealtimeMcphttpError as RealtimeMcphttpError
 from .response_created_event import ResponseCreatedEvent as ResponseCreatedEvent
 from .conversation_item_added import ConversationItemAdded as ConversationItemAdded
 from .conversation_item_param import ConversationItemParam as ConversationItemParam
+from .realtime_conversation_item_reference import (
+    RealtimeConversationItemReference as RealtimeConversationItemReference,
+)
+from .realtime_conversation_item_reference_param import (
+    RealtimeConversationItemReferenceParam as RealtimeConversationItemReferenceParam,
+)
 from .realtime_connect_params import RealtimeConnectParams as RealtimeConnectParams
 from .realtime_mcp_list_tools import RealtimeMcpListTools as RealtimeMcpListTools
 from .realtime_response_usage import RealtimeResponseUsage as RealtimeResponseUsage

--- a/src/openai/types/realtime/conversation_item.py
+++ b/src/openai/types/realtime/conversation_item.py
@@ -13,6 +13,7 @@ from .realtime_conversation_item_function_call import RealtimeConversationItemFu
 from .realtime_conversation_item_system_message import RealtimeConversationItemSystemMessage
 from .realtime_conversation_item_assistant_message import RealtimeConversationItemAssistantMessage
 from .realtime_conversation_item_function_call_output import RealtimeConversationItemFunctionCallOutput
+from .realtime_conversation_item_reference import RealtimeConversationItemReference
 
 __all__ = ["ConversationItem"]
 
@@ -23,6 +24,7 @@ ConversationItem: TypeAlias = Annotated[
         RealtimeConversationItemAssistantMessage,
         RealtimeConversationItemFunctionCall,
         RealtimeConversationItemFunctionCallOutput,
+        RealtimeConversationItemReference,
         RealtimeMcpApprovalResponse,
         RealtimeMcpListTools,
         RealtimeMcpToolCall,

--- a/src/openai/types/realtime/conversation_item_param.py
+++ b/src/openai/types/realtime/conversation_item_param.py
@@ -14,6 +14,7 @@ from .realtime_conversation_item_function_call_param import RealtimeConversation
 from .realtime_conversation_item_system_message_param import RealtimeConversationItemSystemMessageParam
 from .realtime_conversation_item_assistant_message_param import RealtimeConversationItemAssistantMessageParam
 from .realtime_conversation_item_function_call_output_param import RealtimeConversationItemFunctionCallOutputParam
+from .realtime_conversation_item_reference_param import RealtimeConversationItemReferenceParam
 
 __all__ = ["ConversationItemParam"]
 
@@ -23,6 +24,7 @@ ConversationItemParam: TypeAlias = Union[
     RealtimeConversationItemAssistantMessageParam,
     RealtimeConversationItemFunctionCallParam,
     RealtimeConversationItemFunctionCallOutputParam,
+    RealtimeConversationItemReferenceParam,
     RealtimeMcpApprovalResponseParam,
     RealtimeMcpListToolsParam,
     RealtimeMcpToolCallParam,

--- a/src/openai/types/realtime/realtime_conversation_item_reference.py
+++ b/src/openai/types/realtime/realtime_conversation_item_reference.py
@@ -1,0 +1,17 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing_extensions import Literal
+
+from ..._models import BaseModel
+
+__all__ = ["RealtimeConversationItemReference"]
+
+
+class RealtimeConversationItemReference(BaseModel):
+    """A reference to an existing conversation item in a Realtime prompt."""
+
+    id: str
+    """The unique ID of the conversation item being referenced."""
+
+    type: Literal["item_reference"]
+    """The type of the reference. Always `item_reference`."""

--- a/src/openai/types/realtime/realtime_conversation_item_reference_param.py
+++ b/src/openai/types/realtime/realtime_conversation_item_reference_param.py
@@ -1,0 +1,17 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Literal, Required, TypedDict
+
+__all__ = ["RealtimeConversationItemReferenceParam"]
+
+
+class RealtimeConversationItemReferenceParam(TypedDict, total=False):
+    """A reference to an existing conversation item in a Realtime prompt."""
+
+    id: Required[str]
+    """The unique ID of the conversation item being referenced."""
+
+    type: Required[Literal["item_reference"]]
+    """The type of the reference. Always `item_reference`."""

--- a/tests/test_realtime_conversation_item_reference.py
+++ b/tests/test_realtime_conversation_item_reference.py
@@ -1,0 +1,14 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from openai.types.realtime import ConversationItem, RealtimeConversationItemReference
+
+from tests.utils import assert_matches_type
+
+
+def test_conversation_item_reference_matches_type() -> None:
+    item = RealtimeConversationItemReference(
+        id="item_123",
+        type="item_reference",
+    )
+
+    assert_matches_type(ConversationItem, item, path=["item"])


### PR DESCRIPTION
## Summary
- add realtime conversation item type for item_reference
- include item_reference in ConversationItem and ConversationItemParam unions
- add regression test to validate item_reference matches ConversationItem

## Testing
- PYTHONPATH=src pytest tests/test_realtime_conversation_item_reference.py -o addopts= -o filterwarnings= -p no:benchmark
- env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u all_proxy PYTHONPATH=src pytest -o addopts= -o filterwarnings= -p no:benchmark (fails: tests/api_resources/test_videos.py expects model=string but Prism spec only allows sora-2/sora-2-pro, 422)