### PR TITLE
Align chat named tool choice param with docs

### DIFF
--- a/src/openai/types/chat/chat_completion_named_tool_choice_param.py
+++ b/src/openai/types/chat/chat_completion_named_tool_choice_param.py
@@ -4,12 +4,7 @@ from __future__ import annotations
 
 from typing_extensions import Literal, Required, TypedDict
 
-__all__ = ["ChatCompletionNamedToolChoiceParam", "Function"]
-
-
-class Function(TypedDict, total=False):
-    name: Required[str]
-    """The name of the function to call."""
+__all__ = ["ChatCompletionNamedToolChoiceParam"]
 
 
 class ChatCompletionNamedToolChoiceParam(TypedDict, total=False):
@@ -18,7 +13,8 @@ class ChatCompletionNamedToolChoiceParam(TypedDict, total=False):
     Use to force the model to call a specific function.
     """
 
-    function: Required[Function]
+    name: Required[str]
+    """The name of the function to call."""
 
     type: Required[Literal["function"]]
     """For function calling, the type is always `function`."""

--- a/tests/api_resources/test_videos.py
+++ b/tests/api_resources/test_videos.py
@@ -39,7 +39,7 @@ class TestVideos:
         video = client.videos.create(
             prompt="x",
             input_reference=b"raw file contents",
-            model="string",
+            model="sora-2",
             seconds="4",
             size="720x1280",
         )
@@ -297,7 +297,7 @@ class TestAsyncVideos:
         video = await async_client.videos.create(
             prompt="x",
             input_reference=b"raw file contents",
-            model="string",
+            model="sora-2",
             seconds="4",
             size="720x1280",
         )

--- a/tests/test_chat_completion_tool_choice_param.py
+++ b/tests/test_chat_completion_tool_choice_param.py
@@ -1,0 +1,9 @@
+from openai.types.chat import ChatCompletionNamedToolChoiceParam
+
+
+def test_chat_completion_named_tool_choice_param_name() -> None:
+    annotations = ChatCompletionNamedToolChoiceParam.__annotations__
+
+    assert "type" in annotations
+    assert "name" in annotations
+    assert "function" not in annotations


### PR DESCRIPTION
## Summary
- update chat named tool choice param to use top-level name field
- add regression test to ensure name is the documented key
- adjust video API tests to use supported model values

## Testing
- PYTHONPATH=src pytest tests/test_chat_completion_tool_choice_param.py -o addopts= -o filterwarnings= -p no:benchmark
- env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u all_proxy PYTHONPATH=src pytest -o addopts= -o filterwarnings= -p no:benchmark