### PR TITLE
Fix Session import in push_to_talk_app.py example

### DIFF
--- a/examples/realtime/push_to_talk_app.py
+++ b/examples/realtime/push_to_talk_app.py
@@ -38,7 +38,7 @@ from textual.reactive import reactive
 from textual.containers import Container
 
 from openai import AsyncOpenAI
-from openai.types.realtime.session import Session
+from openai.types.realtime.session_update_event_param import Session
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Fix for the following error when running the ```push_to_talk_app.py``` example, which prevents the script from running:

```
from openai.types.realtime.session import Session
ModuleNotFoundError: No module named 'openai.types.realtime.session'
```

## Additional context & links
Import module was incorrect