### PR TITLE
fix(streaming): Move error event handling outside thread.* condition

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -60,11 +60,10 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
-                if sse.event and sse.event.startswith("thread."):
+                # Check for error events first
+                if sse.event == "error":
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -78,6 +77,9 @@ class Stream(Generic[_T]):
                             body=data["error"],
                         )
 
+                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
+                if sse.event and sse.event.startswith("thread."):
+                    data = sse.json()
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
@@ -163,11 +165,10 @@ class AsyncStream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
-                if sse.event and sse.event.startswith("thread."):
+                # Check for error events first
+                if sse.event == "error":
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -181,6 +182,9 @@ class AsyncStream(Generic[_T]):
                             body=data["error"],
                         )
 
+                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
+                if sse.event and sse.event.startswith("thread."):
+                    data = sse.json()
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()


### PR DESCRIPTION
## Summary

Fixes #2796 - Removes dead code in streaming error handling

### Problem
The error handling logic for `sse.event == "error"` was incorrectly nested inside the `if sse.event.startswith("thread.")` condition at:
- Lines 67-79 in `Stream.__stream__` method
- Lines 170-182 in `AsyncStream.__stream__` method

This made the error handling code logically unreachable (dead code) because a string cannot simultaneously:
- Equal "error" 
- Start with "thread."

### Root Cause
Regression introduced in commit `abc25966` which fixed indentation but accidentally moved the error handler from an else branch into the thread.* condition block.

### Solution
Restructured the conditional logic to:
1. Check for `sse.event == "error"` FIRST (before any event type routing)
2. Handle `thread.*` events with their special data structure format
3. Handle all other events in the else block

This ensures error events are properly caught and raise `APIError` with the appropriate error message.

### Changes
- Modified `src/openai/_streaming.py`:
  - Extracted error event handling to top-level if statement
  - Used independent if statements (not elif) for clear logic flow
  - Applied identical fix to both `Stream` and `AsyncStream` classes

### Testing
- ✅ All existing tests pass (20/20 in test_streaming.py)
- ✅ Linting passes (`ruff check .`)
- ✅ Formatting passes (`ruff format`)
- ✅ No regressions in streaming functionality
- ✅ Module imports correctly

### Test Plan
- Run full test suite: All streaming tests pass
- Verify both sync and async streams handle errors correctly
- No breaking changes - the buggy code path was unreachable