### PR TITLE
fix(streaming): move error event check before thread.* handling

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -60,11 +60,10 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
-                if sse.event and sse.event.startswith("thread."):
+                # Check for error events first
+                if sse.event == "error":
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -78,6 +77,9 @@ class Stream(Generic[_T]):
                             body=data["error"],
                         )
 
+                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
+                elif sse.event and sse.event.startswith("thread."):
+                    data = sse.json()
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
@@ -163,11 +165,10 @@ class AsyncStream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
-                if sse.event and sse.event.startswith("thread."):
+                # Check for error events first
+                if sse.event == "error":
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -181,6 +182,9 @@ class AsyncStream(Generic[_T]):
                             body=data["error"],
                         )
 
+                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
+                elif sse.event and sse.event.startswith("thread."):
+                    data = sse.json()
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()


### PR DESCRIPTION
## Summary

Fixes #2796

The `sse.event == "error"` check inside the `sse.event.startswith("thread.")` block was unreachable dead code, since a string cannot simultaneously equal `"error"` and start with `"thread."`.

## Changes

- Moved error event handling (`sse.event == "error"`) to a separate check **before** the `thread.*` event handling
- Applied fix to both sync (`Stream.__stream__`) and async (`AsyncStream.__stream__`) implementations
- Changed `if` to `elif` for the `thread.*` check to maintain proper control flow

## Before
```python
if sse.event and sse.event.startswith("thread."):
    # ...
    if sse.event == "error":  # ❌ Unreachable - never true
        raise APIError(...)
```

## After
```python
if sse.event == "error":  # ✅ Now reachable
    # ...
    raise APIError(...)
elif sse.event and sse.event.startswith("thread."):
    # ...
```

## Test Plan

- [x] Ruff check passes
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)