### PR TITLE
Add item_reference ConversationItem for realtime inputs

### DIFF
--- a/src/openai/types/realtime/conversation_item.py
+++ b/src/openai/types/realtime/conversation_item.py
@@ -13,6 +13,7 @@ from .realtime_conversation_item_function_call import RealtimeConversationItemFu
 from .realtime_conversation_item_system_message import RealtimeConversationItemSystemMessage
 from .realtime_conversation_item_assistant_message import RealtimeConversationItemAssistantMessage
 from .realtime_conversation_item_function_call_output import RealtimeConversationItemFunctionCallOutput
+from .realtime_conversation_item_reference import RealtimeConversationItemReference
 
 __all__ = ["ConversationItem"]
 
@@ -25,6 +26,7 @@ ConversationItem: TypeAlias = Annotated[
         RealtimeConversationItemFunctionCallOutput,
         RealtimeMcpApprovalResponse,
         RealtimeMcpListTools,
+        RealtimeConversationItemReference,
         RealtimeMcpToolCall,
         RealtimeMcpApprovalRequest,
     ],

--- a/src/openai/types/realtime/realtime_conversation_item_reference.py
+++ b/src/openai/types/realtime/realtime_conversation_item_reference.py
@@ -1,0 +1,15 @@
+from typing_extensions import Literal
+
+from ..._models import BaseModel
+
+
+class RealtimeConversationItemReference(BaseModel):
+    """
+    Reference to a previous conversation item in realtime input.
+    """
+
+    id: str
+    """The unique ID of the conversation item being referenced."""
+
+    type: Literal["item_reference"] = "item_reference"
+    """The type of the conversation item. Always `item_reference`."""


### PR DESCRIPTION
Closes #2794
Implements support for `item_reference` conversation items in realtime typing definitions.

