### PR TITLE
fix(streaming): remove unreachable sse.event == error check

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -64,7 +64,7 @@ class Stream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -167,7 +167,7 @@ class AsyncStream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):


### PR DESCRIPTION
## Summary

Fixes dead code bug where the `sse.event == "error"` condition was unreachable.

## Problem

The `sse.event == "error"` check was nested inside a block that requires `sse.event.startswith("thread.")`:

```python
if sse.event and sse.event.startswith("thread."):
    data = sse.json()
    if sse.event == "error" and is_mapping(data) and data.get("error"):  # Always False!
        raise APIError(...)
```

Since `"error"` does not start with `"thread."`, this condition can never be True.

## Solution

Changed the check to look for error data in the payload rather than the event name:

```python
if sse.event and sse.event.startswith("thread."):
    data = sse.json()
    if is_mapping(data) and data.get("error"):  # Now works!
        raise APIError(...)
```

This is consistent with how errors are handled in the `else` branch for non-thread events (lines 84-96).

## Changes

- `src/openai/_streaming.py`: Fixed both sync (line 67) and async (line 170) versions

## Test Plan

- [x] Syntax validation passes
- [x] Logic now allows error detection for thread.* events by checking the data payload

Fixes #2796