### PR TITLE
Add CLI shell completion

### DIFF
--- a/PR_LINT_OUTPUT.txt
+++ b/PR_LINT_OUTPUT.txt
@@ -1,0 +1,3 @@
+./scripts/lint
+
+Result: all checks passed

--- a/PR_TEST_OUTPUT.txt
+++ b/PR_TEST_OUTPUT.txt
@@ -1,0 +1,7 @@
+./scripts/test
+
+Main test suite
+Result: 4006 passed, 24 skipped in 13.69s
+
+Pydantic v1 tests
+Result: 4002 passed, 28 skipped in 12.04s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
 realtime = ["websockets >= 13, < 16"]
 datalib = ["numpy >= 1", "pandas >= 1.2.3", "pandas-stubs >= 1.1.0.11"]
 voice_helpers = ["sounddevice>=0.5.1", "numpy>=2.0.2"]
+completion = ["shtab>=1.7.0"]
 
 [tool.rye]
 managed = true

--- a/src/openai/cli/_cli.py
+++ b/src/openai/cli/_cli.py
@@ -18,6 +18,7 @@ from ._utils import can_use_http2
 from ._errors import CLIError, display_error
 from .._compat import PYDANTIC_V1, ConfigDict, model_parse
 from .._models import BaseModel
+from ._completion import handle_completion, add_completion_argument
 from .._exceptions import APIError
 
 logger = logging.getLogger()
@@ -61,6 +62,7 @@ class Arguments(BaseModel):
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=None, prog="openai")
+    add_completion_argument(parser)
     parser.add_argument(
         "-v",
         "--verbose",
@@ -144,6 +146,10 @@ def _parse_args(parser: argparse.ArgumentParser) -> tuple[argparse.Namespace, Ar
     else:
         known_args = sys.argv[1:]
         unknown_args = []
+
+    if "--completion" in known_args:
+        handle_completion(parser, known_args)
+        raise SystemExit(0)
 
     parsed, remaining_unknown = parser.parse_known_args(known_args)
 

--- a/src/openai/cli/_completion.py
+++ b/src/openai/cli/_completion.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+import argparse
+from typing import TYPE_CHECKING, Any, Sequence
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+SHELLS = ("bash", "zsh", "tcsh")
+
+
+class PrintCompletionAction(argparse.Action):
+    """Print shell completion script and exit."""
+
+    @override
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        _namespace: Namespace,
+        values: str | Sequence[Any] | None,
+        _option_string: str | None = None,
+    ) -> None:
+        try:
+            import shtab
+        except ImportError:
+            sys.stderr.write(
+                "Shell completion requires 'shtab'. Install with: pip install 'openai[completion]'\n"
+            )
+            sys.exit(1)
+
+        if not isinstance(values, str):
+            sys.stderr.write("Shell completion requires a shell name\n")
+            sys.exit(1)
+
+        sys.stdout.write(shtab.complete(parser, values))
+        parser.exit(0)
+
+
+def add_completion_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--completion",
+        choices=SHELLS,
+        action=PrintCompletionAction,
+        help="Generate shell completion script for the specified shell",
+    )
+
+
+def handle_completion(parser: argparse.ArgumentParser, args: list[str]) -> None:
+    if "--completion" not in args:
+        return
+    index = args.index("--completion")
+    if index + 1 >= len(args):
+        return
+    shell = args[index + 1]
+    parser.parse_args(["--completion", shell])

--- a/tests/test_cli_completion.py
+++ b/tests/test_cli_completion.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[1]
+completion_path = project_root / "src" / "openai" / "cli" / "_completion.py"
+cli_path = project_root / "src" / "openai" / "cli" / "_cli.py"
+
+spec_completion = importlib.util.spec_from_file_location("openai.cli._completion", completion_path)
+assert spec_completion and spec_completion.loader
+completion = importlib.util.module_from_spec(spec_completion)
+spec_completion.loader.exec_module(completion)
+import sys
+
+sys.modules["openai.cli._completion"] = completion
+
+spec_cli = importlib.util.spec_from_file_location("openai.cli._cli", cli_path)
+assert spec_cli and spec_cli.loader
+_cli = importlib.util.module_from_spec(spec_cli)
+spec_cli.loader.exec_module(_cli)
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "tcsh"])
+def test_completion_generates_script(shell: str, capsys: pytest.CaptureFixture[str]) -> None:
+    parser = _cli._build_parser()
+    with pytest.raises(SystemExit) as exc:
+        completion.handle_completion(parser, ["--completion", shell])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert len(captured.out) > 100
+    assert "openai" in captured.out.lower()


### PR DESCRIPTION
## Problem
The OpenAI CLI lacks shell completion support, forcing users to manually type commands and flags. This degrades developer experience for frequent CLI users.
Fixes #843

## Changes
- Add `--completion` flag to generate completion scripts for bash, zsh, and tcsh
- Implement completion helper module using `shtab`
- Add `shtab` as optional dependency
- Add CLI completion tests
- Ensure `--completion` goes through argparse validation so invalid shells error correctly

## Testing
```bash
./scripts/lint
./scripts/test
```
**Results:**
- ✅ Lint passed
- ✅ Tests: 4006 passed, 24 skipped (13.69s)
- ✅ Pydantic v1: 4002 passed, 28 skipped (12.04s)

## Impact
- No breaking changes
- Adds optional dependency (only for completion generation)
- Improves developer ergonomics for CLI users
