### PR TITLE
Handle Azure preview API versions

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -62,7 +62,13 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
     ) -> httpx.Request:
         if options.url in _deployments_endpoints and is_mapping(options.json_data):
             model = options.json_data.get("model")
-            if model is not None and "/deployments" not in str(self.base_url.path):
+            api_version = getattr(self, "_api_version", None)
+            version = api_version.lower() if isinstance(api_version, str) else None
+            if (
+                model is not None
+                and "/deployments" not in str(self.base_url.path)
+                and version not in {"preview", "latest"}
+            ):
                 options.url = f"/deployments/{model}{options.url}"
 
         return super()._build_request(options, retries_taken=retries_taken)


### PR DESCRIPTION
## Summary
- keep Azure preview/latest API versions from being rewritten to `/deployments/{model}` so we hit the new `/openai/v1/...` surface instead of the legacy deployments path
- reuse the base URL directly when `api_version` is `preview` or `latest`, mirroring how Azure’s next-generation API expects requests to be structured
- this fixes the `NotFoundError` that occurred whenever `AzureOpenAI(..., api_version="preview")` tried to reach `/openai/deployments/.../chat/completions`

## Testing
- not run (requires an Azure preview endpoint/deployment)

Closes #2584
