### PR TITLE
fix(tests): use correct "compaction" value for context_management type

### DIFF
--- a/tests/api_resources/test_responses.py
+++ b/tests/api_resources/test_responses.py
@@ -32,7 +32,7 @@ class TestResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -119,7 +119,7 @@ class TestResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -440,7 +440,7 @@ class TestAsyncResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -527,7 +527,7 @@ class TestAsyncResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],


### PR DESCRIPTION
Fixes #2868

The tests were using `"type": "type"` as a placeholder value for `context_management[].type`, but the API spec (`response_create_params.py`) states that only `"compaction"` is supported. This updates all 4 occurrences in `test_responses.py`.

## Changes
- `tests/api_resources/test_responses.py`: Replace `"type": "type"` with `"type": "compaction"` in 4 test methods