### PR TITLE
fix: add aclose() method to AsyncStream for PEP 525 compliance

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -223,6 +223,10 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """Alias for :meth:`close` following the PEP 525 async cleanup convention."""
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(


### PR DESCRIPTION
## Summary

Fixes #2853

`AsyncStream` only exposed `close()` but not `aclose()`, causing `AttributeError` when callers use the standard Python async cleanup convention (`await stream.aclose()`).

This surfaces in production when instrumentation libraries (e.g. Langfuse) wrap the raw stream and call `aclose()` following PEP 525 convention.

## Fix

Add `aclose()` as a thin alias for `close()` on `AsyncStream`, matching the convention used by `httpx.Response`, `asyncio.StreamWriter`, and Python async generators.

## Changes

- `src/openai/_streaming.py`: Added `aclose()` method to `AsyncStream` class (4 lines)