### PR TITLE
feat(types): add ImageDetail as a public type alias

### DIFF
--- a/src/openai/types/__init__.py
+++ b/src/openai/types/__init__.py
@@ -16,6 +16,7 @@ from .shared import (
     CompoundFilter as CompoundFilter,
     ResponsesModel as ResponsesModel,
     ReasoningEffort as ReasoningEffort,
+    ImageDetail as ImageDetail,
     ComparisonFilter as ComparisonFilter,
     FunctionDefinition as FunctionDefinition,
     FunctionParameters as FunctionParameters,

--- a/src/openai/types/shared/__init__.py
+++ b/src/openai/types/shared/__init__.py
@@ -17,3 +17,4 @@ from .response_format_json_object import ResponseFormatJSONObject as ResponseFor
 from .response_format_json_schema import ResponseFormatJSONSchema as ResponseFormatJSONSchema
 from .response_format_text_python import ResponseFormatTextPython as ResponseFormatTextPython
 from .response_format_text_grammar import ResponseFormatTextGrammar as ResponseFormatTextGrammar
+from .image_detail import ImageDetail as ImageDetail

--- a/src/openai/types/shared/image_detail.py
+++ b/src/openai/types/shared/image_detail.py
@@ -1,0 +1,8 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Optional
+from typing_extensions import Literal, TypeAlias
+
+__all__ = ["ImageDetail"]
+
+ImageDetail: TypeAlias = Optional[Literal["low", "high", "auto"]]


### PR DESCRIPTION
## Summary

Adds `ImageDetail` as a named public type alias following the same pattern as `ReasoningEffort`.

This allows users to import and use the type directly:

```python
from openai.types import ImageDetail

cast(ImageDetail, image_quality.value if image_quality else 'high')
```

Previously users had to repeat the inline literal:
```python
cast(Literal["low", "high", "auto"], image_quality.value)
```

## Changes

- Created `src/openai/types/shared/image_detail.py` with `ImageDetail: TypeAlias = Optional[Literal["low", "high", "auto"]]`
- Exported from `src/openai/types/shared/__init__.py`
- Exported from `src/openai/types/__init__.py` for direct import

Fixes #2889