### PR TITLE
feat: add ImageDetail as a named public type alias

### DIFF
--- a/src/openai/types/__init__.py
+++ b/src/openai/types/__init__.py
@@ -15,6 +15,7 @@ from .shared import (
     ErrorObject as ErrorObject,
     CompoundFilter as CompoundFilter,
     ResponsesModel as ResponsesModel,
+    ImageDetail as ImageDetail,
     ReasoningEffort as ReasoningEffort,
     ComparisonFilter as ComparisonFilter,
     FunctionDefinition as FunctionDefinition,

--- a/src/openai/types/shared/__init__.py
+++ b/src/openai/types/shared/__init__.py
@@ -7,6 +7,7 @@ from .chat_model import ChatModel as ChatModel
 from .error_object import ErrorObject as ErrorObject
 from .compound_filter import CompoundFilter as CompoundFilter
 from .responses_model import ResponsesModel as ResponsesModel
+from .image_detail import ImageDetail as ImageDetail
 from .reasoning_effort import ReasoningEffort as ReasoningEffort
 from .comparison_filter import ComparisonFilter as ComparisonFilter
 from .function_definition import FunctionDefinition as FunctionDefinition

--- a/src/openai/types/shared/image_detail.py
+++ b/src/openai/types/shared/image_detail.py
@@ -1,0 +1,8 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Optional
+from typing_extensions import Literal, TypeAlias
+
+__all__ = ["ImageDetail"]
+
+ImageDetail: TypeAlias = Optional[Literal["auto", "low", "high"]]


### PR DESCRIPTION
## Summary
Adds `ImageDetail` as a named public type alias, similar to `ReasoningEffort`.

## Changes
- Created `src/openai/types/shared/image_detail.py` with `ImageDetail` type alias
- Exported `ImageDetail` from `src/openai/types/shared/__init__.py`
- Exported `ImageDetail` from `src/openai/types/__init__.py`

## Details
`ImageDetail` is defined as `Optional[Literal['auto', 'low', 'high']]`, matching the existing usage in image-related parameters throughout the codebase.

This provides a consistent, named type that can be imported and used instead of repeating the Literal type annotation.

Fixes #2889