### PR TITLE
fix(azure): strip model from request body after URL routing

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -64,6 +64,7 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
             model = options.json_data.get("model")
             if model is not None and "/deployments" not in str(self.base_url.path):
                 options.url = f"/deployments/{model}{options.url}"
+                options.json_data.pop("model", None)
 
         return super()._build_request(options, retries_taken=retries_taken)
 

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -47,6 +47,29 @@ def test_implicit_deployment_path(client: Client) -> None:
     )
 
 
+@pytest.mark.parametrize("client", [sync_client, async_client])
+def test_implicit_deployment_strips_model_from_body(client: Client) -> None:
+    """model is used for URL routing and must not remain in the request body.
+
+    Azure validates the body ``model`` field against canonical model names,
+    so keeping a deployment name that differs (e.g. ``gpt-image-1-5`` vs
+    ``gpt-image-1.5``) causes a 400 Bad Request.  See #2892.
+    """
+    import json
+
+    req = client._build_request(
+        FinalRequestOptions.construct(
+            method="post",
+            url="/images/generations",
+            json_data={"model": "gpt-image-1-5", "prompt": "A sunset"},
+        )
+    )
+    assert "/deployments/gpt-image-1-5/" in str(req.url)
+    body = json.loads(req.content)
+    assert "model" not in body
+    assert body["prompt"] == "A sunset"
+
+
 @pytest.mark.parametrize(
     "client,method",
     [


### PR DESCRIPTION
## Problem

When using `AzureOpenAI`, the `_build_request` method extracts the `model` field from the request body to construct the deployment URL path (`/deployments/{model}/...`), but leaves the `model` field in the JSON body. Azure's backend then validates the body's `model` against canonical model names (e.g. `gpt-image-1.5`), causing **400 Bad Request** when the deployment name differs from the model name.

This is particularly problematic for models like `gpt-image-1.5` where Azure naming rules **prohibit dots** in deployment names, forcing users to use names like `gpt-image-1-5` that will never match the canonical model name.

## Root Cause

In `src/openai/lib/azure.py`, `BaseAzureClient._build_request()`:

```python
model = options.json_data.get("model")
if model is not None and "/deployments" not in str(self.base_url.path):
    options.url = f"/deployments/{model}{options.url}"
    # BUG: model is still in options.json_data when request is sent
```

## Fix

After extracting `model` for URL routing, remove it from the request body with `options.json_data.pop("model", None)`. Azure OpenAI REST API does **not** include `model` in the request body for deployment-based endpoints — model selection is done entirely via the URL path.

## Test

Added `test_implicit_deployment_strips_model_from_body` that verifies:
- URL correctly contains the deployment path
- Request body no longer contains `model`
- Other body fields are preserved

All 51 Azure tests pass (2 consecutive clean runs).

Fixes #2892