### PR TITLE
fix: move unreachable error event check before thread event guard in streaming

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,11 +63,9 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
-                if sse.event and sse.event.startswith("thread."):
+                if sse.event == "error":
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -80,6 +78,10 @@ class Stream(Generic[_T]):
                             request=self.response.request,
                             body=data["error"],
                         )
+
+                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
+                if sse.event and sse.event.startswith("thread."):
+                    data = sse.json()
 
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
@@ -173,11 +175,9 @@ class AsyncStream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
-                if sse.event and sse.event.startswith("thread."):
+                if sse.event == "error":
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -190,6 +190,10 @@ class AsyncStream(Generic[_T]):
                             request=self.response.request,
                             body=data["error"],
                         )
+
+                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
+                if sse.event and sse.event.startswith("thread."):
+                    data = sse.json()
 
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:


### PR DESCRIPTION
## Summary

Fixes #2796

The `sse.event == "error"` check inside both `Stream.__stream__()` and `AsyncStream.__stream__()` was nested inside the `if sse.event.startswith("thread.")` block. Since `"error"` never starts with `"thread."`, the error-event check was unreachable dead code.

## Changes

Move the error-event check to execute **before** the thread-event guard so that SSE error events are properly detected regardless of event name prefix. The data-level error check in the `else` branch is preserved as a second line of defence for non-thread events.

### Before
```python
if sse.event and sse.event.startswith("thread."):
    data = sse.json()
    if sse.event == "error" ...  # ← unreachable: "error" never starts with "thread."
        raise APIError(...)
    yield ...
else:
    ...
```

### After
```python
if sse.event == "error":
    data = sse.json()
    if is_mapping(data) and data.get("error"):
        raise APIError(...)

if sse.event and sse.event.startswith("thread."):
    data = sse.json()
    yield ...
else:
    ...
```

Applied to both `Stream.__stream__()` (sync) and `AsyncStream.__stream__()` (async).

## Testing

All 20 streaming tests pass (2 consecutive clean runs).