### PR TITLE
fix: bound TypeAdapter lru_cache to prevent memory leak in multi-threaded usage

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -799,7 +799,7 @@ else:
 if not PYDANTIC_V1:
     from pydantic import TypeAdapter as _TypeAdapter
 
-    _CachedTypeAdapter = cast("TypeAdapter[object]", lru_cache(maxsize=None)(_TypeAdapter))
+    _CachedTypeAdapter = cast("TypeAdapter[object]", lru_cache(maxsize=4096)(_TypeAdapter))
 
     if TYPE_CHECKING:
         from pydantic import TypeAdapter


### PR DESCRIPTION
## Summary

Fixes #2672

### Problem

`_CachedTypeAdapter` uses `lru_cache(maxsize=None)` (unbounded), which causes memory leak in multi-threaded environments. When `responses.parse` is called from multiple threads, generic types like `ParsedResponseOutputMessage[MyClass]` are created anew by pydantic in each thread, generating distinct cache keys. This means the cache never hits and grows without bound.

### Root Cause

In `src/openai/_models.py` line 802:
```python
_CachedTypeAdapter = cast('TypeAdapter[object]', lru_cache(maxsize=None)(_TypeAdapter))
```

Python's `typing` module creates new generic type objects in different threads, so `ParsedResponseOutputMessage[Fact]` in thread A has a different identity than `ParsedResponseOutputMessage[Fact]` in thread B. Since `lru_cache` keys on object identity, each thread creates a new cache entry.

### Fix

Set `maxsize=4096` to cap memory usage while still providing effective caching for typical workloads. This is a standard practice for `lru_cache` — the LRU eviction policy ensures the most-used types stay cached while preventing unbounded growth.

### Testing

Verified that the cache is bounded:
```python
info = _CachedTypeAdapter.cache_info()
assert info.maxsize == 4096
```