### PR TITLE
fix: handle ValidationError in structured output parsing gracefully

### DIFF
--- a/src/openai/lib/_parsing/_completions.py
+++ b/src/openai/lib/_parsing/_completions.py
@@ -193,7 +193,15 @@ def maybe_parse_content(
     message: ChatCompletionMessage | ParsedChatCompletionMessage[object],
 ) -> ResponseFormatT | None:
     if has_rich_response_format(response_format) and message.content and not message.refusal:
-        return _parse_content(response_format, message.content)
+        try:
+            return _parse_content(response_format, message.content)
+        except pydantic.ValidationError:
+            log.warning(
+                "Failed to parse structured output content into %s; "
+                "`.parsed` will be `None`.  Raw content is available via `.content`.",
+                response_format.__name__ if hasattr(response_format, "__name__") else response_format,
+            )
+            return None
 
     return None
 

--- a/tests/lib/chat/test_completions.py
+++ b/tests/lib/chat/test_completions.py
@@ -993,3 +993,41 @@ def test_parse_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpe
         checking_client.chat.completions.parse,
         exclude_params={"response_format", "stream"},
     )
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_parse_invalid_json_returns_none(
+    client: OpenAI, respx_mock: MockRouter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the API returns non-JSON content (e.g. whitespace), `parsed` should be None
+    rather than raising an unhandled ValidationError.
+
+    Regression test for https://github.com/openai/openai-python/issues/1763
+    """
+
+    class Location(BaseModel):
+        city: str
+        temperature: float
+        units: Literal["c", "f"]
+
+    completion = make_snapshot_request(
+        lambda c: c.chat.completions.parse(
+            model="gpt-4o-2024-08-06",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "What's the weather like in SF?",
+                },
+            ],
+            response_format=Location,
+        ),
+        content_snapshot=snapshot(
+            '{"id": "chatcmpl-invalid-json", "object": "chat.completion", "created": 1727346143, "model": "gpt-4o-2024-08-06", "choices": [{"index": 0, "message": {"role": "assistant", "content": "\\n   \\n\\n \\n   \\n", "refusal": null}, "logprobs": null, "finish_reason": "stop"}], "usage": {"prompt_tokens": 79, "completion_tokens": 14, "total_tokens": 93, "completion_tokens_details": {"reasoning_tokens": 0}}, "system_fingerprint": "fp_5050236cbd"}'
+        ),
+        path="/chat/completions",
+        mock_client=client,
+        respx_mock=respx_mock,
+    )
+
+    assert completion.choices[0].message.parsed is None
+    assert completion.choices[0].message.content == "\n   \n\n \n   \n"


### PR DESCRIPTION
## Problem

Fixes #1763

When using `beta.chat.completions.parse()` with structured outputs, the API can occasionally return malformed content (whitespace-only strings, truncated JSON, etc.). The SDK currently lets the resulting `pydantic.ValidationError` propagate unhandled, crashing the caller.

This is a production issue affecting multiple users, as shown by the 13+ reactions on the issue.

## Root Cause

`maybe_parse_content()` in `_completions.py` calls `_parse_content()` → `model_parse_json()` without catching `pydantic.ValidationError`. When the API returns non-JSON content (e.g., `"\n   \n\n \n   \n"`), Pydantic raises `ValidationError` which propagates all the way up.

## Fix

Wrap the `_parse_content()` call in `maybe_parse_content()` with a `try/except pydantic.ValidationError` that:
1. Logs a warning with the target type name so users can diagnose the issue
2. Returns `None`, setting `message.parsed = None`

This matches the existing behavior for refusals — `parsed` is `None` while the raw content remains available via `message.content`.

## Tests

Added `test_parse_invalid_json_returns_none` that mocks the API returning whitespace-only content and verifies:
- `parsed` is `None` (no crash)
- Raw content is still accessible via `message.content`

All 18 chat completion parsing tests pass (2 consecutive clean runs).