### PR TITLE
fix: treat empty OPENAI_BASE_URL as unset

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -518,7 +518,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 


### PR DESCRIPTION
## Summary

When `OPENAI_BASE_URL` is set to an empty string (e.g. `export OPENAI_BASE_URL=""`), `os.environ.get("OPENAI_BASE_URL")` returns `""` instead of `None`. The subsequent `if base_url is None` check passes, so the default `https://api.openai.com/v1` fallback is never applied. This causes an `APIConnectionError` on the next API call.

Fixes #2927.

## Change

Added `or None` to coerce empty strings to `None` in both the `OpenAI` and `AsyncOpenAI` constructors:

```python
# Before
base_url = os.environ.get("OPENAI_BASE_URL")

# After
base_url = os.environ.get("OPENAI_BASE_URL") or None
```

This is consistent with how an unset variable should behave — an empty string is not a valid base URL.