### PR TITLE
fix: skip meta-only SSE events with empty data to prevent JSONDecodeError

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,6 +63,9 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
+                if not sse.data:
+                    continue
+
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
@@ -172,6 +175,9 @@ class AsyncStream(Generic[_T]):
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
                     break
+
+                if not sse.data:
+                    continue
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -216,6 +216,44 @@ async def test_multi_byte_character_multiple_chunks(
     assert sse.json() == {"content": "известни"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_stream_skips_meta_only_retry_event(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"retry: 3000\n\n"
+        yield b'data: {"foo":true}\n\n'
+
+    results = await collect_stream(body(), sync=sync, client=client, async_client=async_client)
+    assert len(results) == 1
+    assert results[0] == {"foo": True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_stream_skips_event_without_data(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"event: ping\n\n"
+        yield b'data: {"bar":1}\n\n'
+        yield b"data: [DONE]\n\n"
+
+    results = await collect_stream(body(), sync=sync, client=client, async_client=async_client)
+    assert len(results) == 1
+    assert results[0] == {"bar": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_stream_skips_thread_event_without_data(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"event: thread.created\n\n"
+        yield b'event: thread.created\ndata: {"id":"t1"}\n\n'
+        yield b"data: [DONE]\n\n"
+
+    results = await collect_stream(body(), sync=sync, client=client, async_client=async_client)
+    assert len(results) == 1
+    assert results[0] == {"data": {"id": "t1"}, "event": "thread.created"}
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk
@@ -246,3 +284,22 @@ def make_event_iterator(
     return AsyncStream(
         cast_to=object, client=async_client, response=httpx.Response(200, content=to_aiter(content))
     )._iter_events()
+
+
+async def collect_stream(
+    content: Iterator[bytes],
+    *,
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> list[object]:
+    results: list[object] = []
+    if sync:
+        stream = Stream(cast_to=object, client=client, response=httpx.Response(200, content=content))
+        for item in stream:
+            results.append(item)
+    else:
+        stream = AsyncStream(cast_to=object, client=async_client, response=httpx.Response(200, content=to_aiter(content)))
+        async for item in stream:
+            results.append(item)
+    return results


### PR DESCRIPTION
## Summary

Fixes #2722

Per the [SSE spec (WHATWG HTML § 9.2)](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), SSE streams may contain meta-only events — events with only `retry`, `id`, or `event` fields but no `data`. Example: `retry: 3000\n\n`.

The `SSEDecoder` correctly parses these and emits `ServerSentEvent` with `data=""`. However, `Stream.__stream__()` and `AsyncStream.__stream__()` unconditionally call `sse.json()` (which does `json.loads("")`), causing `JSONDecodeError`.

This happens in practice when streaming through gateways/proxies that inject SSE retry directives.

## Fix

Added `if not sse.data: continue` in both sync and async `__stream__()` loops, right after the `[DONE]` check. Meta-only SSE events (empty `data`) are control frames and carry no user-facing payload — they are now silently skipped.

## Tests

Added 3 new test cases (each parametrized for sync/async, 6 tests total) that exercise `__stream__()` directly:

1. **Meta-only retry event** followed by valid JSON — verifies no `JSONDecodeError`
2. **Event-only frame (no data)** interleaved with valid data — verifies only JSON events are yielded
3. **`thread.*` event without data** — verifies the thread-event branch also skips empty data

All existing tests continue to pass.

---

- [x] I confirm that the changes in this PR are mine and I have the right to submit them under the project's license.