### PR TITLE
fix: treat empty OPENAI_BASE_URL env var as unset

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 


### PR DESCRIPTION
## Problem

When `OPENAI_BASE_URL` is set to an empty string (`export OPENAI_BASE_URL=""`), the client fails with `APIConnectionError` instead of falling back to the default endpoint.

## Root Cause

`os.environ.get("OPENAI_BASE_URL")` returns `""` (not `None`) for empty env vars. The subsequent `if base_url is None` check doesn't trigger, so the default `https://api.openai.com/v1` is never assigned.

## Fix

Add `or None` to coerce empty strings to `None`:

```python
base_url = os.environ.get("OPENAI_BASE_URL") or None
```

Applied to both `OpenAI` and `AsyncOpenAI` client constructors.

Fixes #2927