### PR TITLE
fix: handle empty OPENAI_BASE_URL env var by falling back to default

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,11 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_base_url_env_empty_string(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = OpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1733,6 +1738,11 @@ class TestAsyncOpenAI:
         with update_env(OPENAI_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
+
+    async def test_base_url_env_empty_string(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION
## Summary

Fixes #2927 — When `OPENAI_BASE_URL` is set to an empty string (e.g., `export OPENAI_BASE_URL=""`), the client fails with `APIConnectionError` instead of falling back to `https://api.openai.com/v1`.

## Root Cause

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")  # returns "" not None
if base_url is None:  # "" is not None → fallback skipped
    base_url = f"https://api.openai.com/v1"
```

`os.environ.get("OPENAI_BASE_URL")` returns `""` when the variable is set but empty. Since `""` is not `None`, the default URL fallback is skipped.

## Fix

```python
base_url = os.environ.get("OPENAI_BASE_URL") or None
```

`or None` coerces empty strings (and other falsy values) to `None`, allowing the default fallback to activate. Applied to both `OpenAI` and `AsyncOpenAI` constructors.

## Tests

Added 2 new test cases (`test_base_url_env_empty_string`) verifying both sync and async clients fall back to the default URL when `OPENAI_BASE_URL=""`. All existing `test_base_url_env` tests continue to pass.
