### PR TITLE
fix(streaming): move unreachable error event check out of thread. branch

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -67,7 +67,10 @@ class Stream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
+                elif sse.event == "error":
+                    data = sse.json()
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -80,8 +83,6 @@ class Stream(Generic[_T]):
                             request=self.response.request,
                             body=data["error"],
                         )
-
-                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
                     if is_mapping(data) and data.get("error"):
@@ -177,7 +178,10 @@ class AsyncStream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
+                elif sse.event == "error":
+                    data = sse.json()
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -190,8 +194,6 @@ class AsyncStream(Generic[_T]):
                             request=self.response.request,
                             body=data["error"],
                         )
-
-                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
                     if is_mapping(data) and data.get("error"):


### PR DESCRIPTION
## Summary

Fixes #2796.

The `sse.event == "error"` check in both `Stream.__stream__` and `AsyncStream.__stream__` is dead code — it's nested inside `if sse.event.startswith("thread.")`, but `"error"` never starts with `"thread."`.

## Root cause

This was introduced in commit 48188cc8 when the branch logic was refactored from checking for `response.*`/`transcript.*` events first to checking for `thread.*` events first. The `sse.event == "error"` check was in the `else` branch (non-`response.*` events) before the refactor, but was accidentally placed in the `thread.*` branch after it. The subsequent indentation fix in abc25966 preserved the mistake.

**Before 48188cc (correct):**
```python
if sse.event is None or (sse.event.startswith("response.") or ...):
    # generic error check
    if is_mapping(data) and data.get("error"): ...
else:
    # event-specific error check — reachable for event="error"
    if sse.event == "error" and ...: ...
```

**After 48188cc (broken):**
```python
if sse.event and sse.event.startswith("thread."):
    # error check is now unreachable — "error" != "thread.*"
    if sse.event == "error" and ...: ...
else:
    if is_mapping(data) and data.get("error"): ...
```

## Fix

Move the error event handling into its own `elif sse.event == "error":` branch between the `thread.*` check and the `else` fallback, so it can actually be reached when the server sends an SSE with `event: error`.

```python
if sse.event and sse.event.startswith("thread."):
    ...
elif sse.event == "error":
    # now reachable
    ...
else:
    ...
```

Applied to both `Stream.__stream__` (sync) and `AsyncStream.__stream__` (async).

## Test plan

- [x] Verify the `elif` branch is reached for `event: error` SSEs
- [x] Verify `thread.*` events still handled correctly (no behavior change)
- [x] Verify other events still fall through to `else` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)