### PR TITLE
fix(streaming): guard against IndexError in Responses API stream accumulator

### DIFF
--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -250,60 +250,69 @@ class ResponseStreamState(Generic[TextFormatT]):
         events: List[ResponseStreamEvent[TextFormatT]] = []
 
         if event.type == "response.output_text.delta":
-            output = snapshot.output[event.output_index]
-            assert output.type == "message"
+            if event.output_index < len(snapshot.output):
+                output = snapshot.output[event.output_index]
+                assert output.type == "message"
 
-            content = output.content[event.content_index]
-            assert content.type == "output_text"
+                content = output.content[event.content_index]
+                assert content.type == "output_text"
 
-            events.append(
-                build(
-                    ResponseTextDeltaEvent,
-                    content_index=event.content_index,
-                    delta=event.delta,
-                    item_id=event.item_id,
-                    output_index=event.output_index,
-                    sequence_number=event.sequence_number,
-                    logprobs=event.logprobs,
-                    type="response.output_text.delta",
-                    snapshot=content.text,
+                events.append(
+                    build(
+                        ResponseTextDeltaEvent,
+                        content_index=event.content_index,
+                        delta=event.delta,
+                        item_id=event.item_id,
+                        output_index=event.output_index,
+                        sequence_number=event.sequence_number,
+                        logprobs=event.logprobs,
+                        type="response.output_text.delta",
+                        snapshot=content.text,
+                    )
                 )
-            )
+            else:
+                events.append(event)
         elif event.type == "response.output_text.done":
-            output = snapshot.output[event.output_index]
-            assert output.type == "message"
+            if event.output_index < len(snapshot.output):
+                output = snapshot.output[event.output_index]
+                assert output.type == "message"
 
-            content = output.content[event.content_index]
-            assert content.type == "output_text"
+                content = output.content[event.content_index]
+                assert content.type == "output_text"
 
-            events.append(
-                build(
-                    ResponseTextDoneEvent[TextFormatT],
-                    content_index=event.content_index,
-                    item_id=event.item_id,
-                    output_index=event.output_index,
-                    sequence_number=event.sequence_number,
-                    logprobs=event.logprobs,
-                    type="response.output_text.done",
-                    text=event.text,
-                    parsed=parse_text(event.text, text_format=self._text_format),
+                events.append(
+                    build(
+                        ResponseTextDoneEvent[TextFormatT],
+                        content_index=event.content_index,
+                        item_id=event.item_id,
+                        output_index=event.output_index,
+                        sequence_number=event.sequence_number,
+                        logprobs=event.logprobs,
+                        type="response.output_text.done",
+                        text=event.text,
+                        parsed=parse_text(event.text, text_format=self._text_format),
+                    )
                 )
-            )
+            else:
+                events.append(event)
         elif event.type == "response.function_call_arguments.delta":
-            output = snapshot.output[event.output_index]
-            assert output.type == "function_call"
+            if event.output_index < len(snapshot.output):
+                output = snapshot.output[event.output_index]
+                assert output.type == "function_call"
 
-            events.append(
-                build(
-                    ResponseFunctionCallArgumentsDeltaEvent,
-                    delta=event.delta,
-                    item_id=event.item_id,
-                    output_index=event.output_index,
-                    sequence_number=event.sequence_number,
-                    type="response.function_call_arguments.delta",
-                    snapshot=output.arguments,
+                events.append(
+                    build(
+                        ResponseFunctionCallArgumentsDeltaEvent,
+                        delta=event.delta,
+                        item_id=event.item_id,
+                        output_index=event.output_index,
+                        sequence_number=event.sequence_number,
+                        type="response.function_call_arguments.delta",
+                        snapshot=output.arguments,
+                    )
                 )
-            )
+            else:
+                events.append(event)
 
         elif event.type == "response.completed":
             response = self._completed_response
@@ -341,21 +350,24 @@ class ResponseStreamState(Generic[TextFormatT]):
             else:
                 snapshot.output.append(event.item)
         elif event.type == "response.content_part.added":
-            output = snapshot.output[event.output_index]
-            if output.type == "message":
-                output.content.append(
-                    construct_type_unchecked(type_=cast(Any, ParsedContent), value=event.part.to_dict())
-                )
+            if event.output_index < len(snapshot.output):
+                output = snapshot.output[event.output_index]
+                if output.type == "message":
+                    output.content.append(
+                        construct_type_unchecked(type_=cast(Any, ParsedContent), value=event.part.to_dict())
+                    )
         elif event.type == "response.output_text.delta":
-            output = snapshot.output[event.output_index]
-            if output.type == "message":
-                content = output.content[event.content_index]
-                assert content.type == "output_text"
-                content.text += event.delta
+            if event.output_index < len(snapshot.output):
+                output = snapshot.output[event.output_index]
+                if output.type == "message":
+                    content = output.content[event.content_index]
+                    assert content.type == "output_text"
+                    content.text += event.delta
         elif event.type == "response.function_call_arguments.delta":
-            output = snapshot.output[event.output_index]
-            if output.type == "function_call":
-                output.arguments += event.delta
+            if event.output_index < len(snapshot.output):
+                output = snapshot.output[event.output_index]
+                if output.type == "function_call":
+                    output.arguments += event.delta
         elif event.type == "response.completed":
             self._completed_response = parse_response(
                 text_format=self._text_format,


### PR DESCRIPTION
## Summary

Fixes `IndexError: list index out of range` that occurs intermittently inside `ResponseStreamState.accumulate_event()` and `handle_event()` when `output_index` references a snapshot output item that has not yet been added.

Fixes #2852

## Problem

When streaming Responses API events with tools (e.g., `web_search`, `code_interpreter`) or when resuming a stream via `starting_after`, the stream accumulator can crash with:

```
File ".../openai/lib/streaming/responses/_responses.py", line 344, in accumulate_event
    IndexError: list index out of range
```

This happens because several event handlers in both `accumulate_event()` and `handle_event()` access `snapshot.output[event.output_index]` without verifying the index is within bounds. The `response.created` event initializes the snapshot with an empty (or partially populated) output list, and subsequent events like `response.content_part.added`, `response.output_text.delta`, or `response.function_call_arguments.delta` may reference indices not yet populated by `response.output_item.added`.

## Fix

Adds `event.output_index < len(snapshot.output)` bounds checks before every `snapshot.output[event.output_index]` access in both methods:

**`accumulate_event()`** — when the index is out of bounds, the snapshot update is silently skipped. The final `response.completed` event contains the full response data regardless, so no information is lost.

**`handle_event()`** — when the index is out of bounds, the raw (un-enriched) event is emitted to the caller instead of crashing. This preserves the event stream and lets consumers handle the event directly.

Affected event types:
- `response.content_part.added`
- `response.output_text.delta`
- `response.output_text.done`
- `response.function_call_arguments.delta`

## Test plan

- [x] Verify the fix handles out-of-bounds output indices gracefully
- [x] Confirm normal streaming (in-order events) is unaffected — the bounds check is a no-op when indices are valid
- [x] Confirm `get_final_response()` still returns the complete parsed response

🤖 Generated with [Claude Code](https://claude.com/claude-code)