### PR TITLE
fix(streaming): skip empty SSE data events and move error-event check out of thread. block

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,10 +63,20 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
+                # Skip SSE meta-only events that carry no data (e.g. standalone
+                # `retry:` or `id:` directives).  Per the SSE spec these are valid
+                # but contain an empty data field; calling sse.json() on them
+                # raises JSONDecodeError.
+                if not sse.data or not sse.data.strip():
+                    continue
+
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
-
+                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
+                else:
+                    data = sse.json()
+                    # Handle error events that carry an "error" event type (outside thread.* scope)
                     if sse.event == "error" and is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
@@ -81,9 +91,6 @@ class Stream(Generic[_T]):
                             body=data["error"],
                         )
 
-                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
-                else:
-                    data = sse.json()
                     if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
@@ -173,10 +180,20 @@ class AsyncStream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
+                # Skip SSE meta-only events that carry no data (e.g. standalone
+                # `retry:` or `id:` directives).  Per the SSE spec these are valid
+                # but contain an empty data field; calling sse.json() on them
+                # raises JSONDecodeError.
+                if not sse.data or not sse.data.strip():
+                    continue
+
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
-
+                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
+                else:
+                    data = sse.json()
+                    # Handle error events that carry an "error" event type (outside thread.* scope)
                     if sse.event == "error" and is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
@@ -191,9 +208,6 @@ class AsyncStream(Generic[_T]):
                             body=data["error"],
                         )
 
-                    yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
-                else:
-                    data = sse.json()
                     if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")


### PR DESCRIPTION
## Summary

Two related bugs in `Stream.__stream__` and `AsyncStream.__stream__` (`src/openai/_streaming.py`), both sync and async paths.

### Bug 1: `JSONDecodeError` on meta-only SSE events (closes #2722)

The [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) allows events that carry only meta-fields (`retry:`, `id:`, `event:`) with no `data` field. The SDK's SSE parser correctly handles these by setting `data = ""`, but `__stream__` called `sse.json()` unconditionally:

```python
data = sse.json()   # JSONDecodeError when sse.data == ""
```

This crashes with `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` when any API gateway or proxy injects an SSE `retry:` directive.

**Fix:** skip events whose `data` field is empty or whitespace before any JSON parsing.

### Bug 2: Unreachable `sse.event == "error"` check (closes #2796)

The error-event guard was nested *inside* the `if sse.event.startswith("thread.")` branch:

```python
if sse.event and sse.event.startswith("thread."):
    data = sse.json()
    if sse.event == "error" and ...:   # ← DEAD CODE: "error" never starts with "thread."
        raise APIError(...)
```

Since `"error"` does not start with `"thread."`, this check can never be true — it's dead code and was a regression from commit `abc25966`. The error-event handling belongs in the `else` branch (non-thread events).

**Fix:** move the `sse.event == "error"` guard to the `else` branch.

## Changes

- `src/openai/_streaming.py` — sync `Stream.__stream__` and async `AsyncStream.__stream__`
  - Add guard: `if not sse.data or not sse.data.strip(): continue`
  - Relocate `sse.event == "error"` check from `thread.` block to `else` block
