### PR TITLE
fix(streaming): add aclose() to AsyncStream for standard async cleanup protocol

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -252,6 +252,17 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """Async-convention alias for :meth:`close`.
+
+        Follows the standard Python async cleanup protocol used by
+        ``asyncio.StreamWriter``, ``httpx.AsyncByteStream``, and async
+        generators (PEP 525), allowing callers and instrumentation libraries
+        to call ``await stream.aclose()`` uniformly without special-casing
+        this class.
+        """
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(


### PR DESCRIPTION
## Problem

`AsyncStream` exposes `close()` but not `aclose()`, causing `AttributeError` when instrumentation libraries (Langfuse, OpenTelemetry wrappers, etc.) call the standard Python async cleanup convention:

```python
await stream.aclose()
# AttributeError: 'AsyncStream' object has no attribute 'aclose'. Did you mean: 'close'?
```

The error surfaces in production via the call chain in `AsyncChatCompletionStream`:
```
AsyncChatCompletionStreamManager.__aexit__
  -> AsyncChatCompletionStream.close()        # line 215
  -> self._response.aclose()                  # AttributeError when _response is AsyncStream
```

When instrumentation wraps the raw `AsyncStream`, `self._response` resolves to the `AsyncStream` itself rather than the underlying `httpx.Response`. Since `AsyncStream` has `close()` but not `aclose()`, cleanup fails.

Closes #2853

## Fix

Add `aclose()` as a thin alias that delegates to `close()`:

```python
async def aclose(self) -> None:
    """Async-convention alias for close()."""
    await self.close()
```

`aclose()` is the standard async cleanup method used by `asyncio.StreamWriter`, `httpx.AsyncByteStream`, and async generators (PEP 525). Adding it lets callers and wrappers use either name without special-casing `AsyncStream`.

The sync `Stream` class is not affected since its callers use `close()`.
