### PR TITLE
fix(types): add optional `name` field to ChatCompletionToolMessageParam

### DIFF
--- a/src/openai/types/chat/chat_completion_tool_message_param.py
+++ b/src/openai/types/chat/chat_completion_tool_message_param.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Union, Iterable
+from typing import Optional, Union, Iterable
 from typing_extensions import Literal, Required, TypedDict
 
 from .chat_completion_content_part_text_param import ChatCompletionContentPartTextParam
@@ -19,3 +19,13 @@ class ChatCompletionToolMessageParam(TypedDict, total=False):
 
     tool_call_id: Required[str]
     """Tool call that this message is responding to."""
+
+    name: Optional[str]
+    """The name of the tool that was called.
+
+    This field is optional and mirrors the `name` field present on other message
+    types (e.g. ``ChatCompletionFunctionMessageParam``). Including the tool name
+    can improve clarity when multiple tools are used in a single conversation turn,
+    and is consistent with OpenAI's own documentation examples for parallel
+    function calling.
+    """


### PR DESCRIPTION
## Summary

Fixes #1078

The [OpenAI docs for parallel function calling](https://platform.openai.com/docs/guides/function-calling) include a `name` field in tool result messages:

```python
messages.append({
    "tool_call_id": tool_call.id,
    "role": "tool",
    "name": function_name,  # documented but not typed
    "content": function_response,
})
```

However, `ChatCompletionToolMessageParam` did not include this field, causing `mypy`/`pyright` type errors for users following the official docs.

## Changes

- Added optional `name: Optional[str]` field to `ChatCompletionToolMessageParam`
- Mirrors the `name` field already present on `ChatCompletionFunctionMessageParam`
- Fully backwards compatible — no existing code is affected

## Verification

```python
from openai.types.chat import ChatCompletionToolMessageParam

def tool_result(tool_call_id: str, name: str, content: str) -> ChatCompletionToolMessageParam:
    return {
        "tool_call_id": tool_call_id,
        "role": "tool",
        "name": name,   # now type-checks cleanly
        "content": content,
    }
```

Passes `mypy` and `pyright` without errors.