### PR TITLE
fix(client): treat empty OPENAI_BASE_URL as unset

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,11 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_base_url_env_empty_string(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = OpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1733,6 +1738,11 @@ class TestAsyncOpenAI:
         with update_env(OPENAI_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
+
+    async def test_base_url_env_empty_string(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION
Fixes #2927

## Problem

When `OPENAI_BASE_URL` is set to an empty string (e.g., `OPENAI_BASE_URL=""`), `os.environ.get("OPENAI_BASE_URL")` returns `""` instead of `None`. The subsequent `if base_url is None` check passes, so the client uses an empty string as the base URL instead of falling back to `https://api.openai.com/v1`.

## Fix

Use `or None` to normalize empty strings to `None`, allowing the default fallback to trigger correctly. Applied to both `OpenAI` and `AsyncOpenAI` constructors.

## Tests

Added `test_base_url_env_empty_string` for both sync and async clients, verifying that an empty `OPENAI_BASE_URL` falls back to the default endpoint.

This contribution was developed with AI assistance (Claude Code).