### PR TITLE
fix(compat): handle None by_alias in model_dump for Pydantic v2

### DIFF
--- a/src/openai/_compat.py
+++ b/src/openai/_compat.py
@@ -149,7 +149,7 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            by_alias=bool(by_alias) if by_alias is not None else False,
         )
     return cast(
         "dict[str, Any]",

--- a/tests/compat/test_model_dump.py
+++ b/tests/compat/test_model_dump.py
@@ -1,0 +1,23 @@
+import pydantic
+
+from openai._compat import model_dump
+
+
+class SimpleModel(pydantic.BaseModel):
+    foo: str = "bar"
+
+
+def test_model_dump_by_alias_none() -> None:
+    """Regression test for #2921: by_alias=None should not raise TypeError."""
+    result = model_dump(SimpleModel(), by_alias=None)
+    assert result == {"foo": "bar"}
+
+
+def test_model_dump_by_alias_true() -> None:
+    result = model_dump(SimpleModel(), by_alias=True)
+    assert result == {"foo": "bar"}
+
+
+def test_model_dump_by_alias_false() -> None:
+    result = model_dump(SimpleModel(), by_alias=False)
+    assert result == {"foo": "bar"}


### PR DESCRIPTION
Fixes #2921

## Problem

`model_dump()` in `_compat.py` passes `by_alias=None` to Pydantic v2's `model_dump()`, which requires a `bool`. The Rust serializer raises:

```
TypeError: argument 'by_alias': 'NoneType' object cannot be converted to 'PyBool'
```

This triggers when the `openai` logger has `DEBUG` level enabled, because the affected `model_dump()` call is inside a `log.isEnabledFor(logging.DEBUG)` block.

## Fix

Convert `by_alias` from `None` to `False` before passing to Pydantic v2's `model_dump()`, matching the pattern already used in the Pydantic v1 fallback path (line 157: `by_alias=bool(by_alias)`).

## Tests

Added `tests/compat/test_model_dump.py` with tests for `by_alias=None`, `True`, and `False`.

This contribution was developed with AI assistance (Claude Code).