### PR TITLE
fix(streaming): add aclose() alias to AsyncStream

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -238,6 +238,10 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """Alias for :meth:`close`, following the standard Python async convention."""
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(


### PR DESCRIPTION
Fixes #2853

## Problem

`AsyncStream` exposes `close()` but not `aclose()`, causing `AttributeError` when callers use the standard Python async cleanup convention (`await stream.aclose()`). This surfaces with instrumentation libraries (e.g. Langfuse) that wrap the raw stream.

## Fix

Added `aclose()` as an alias for `close()` on `AsyncStream`, following the standard Python async resource convention (PEP 525, used by `asyncio`, `httpx`, etc.). Note that `AsyncStream.close()` already internally calls `self.response.aclose()`.

This contribution was developed with AI assistance (Claude Code).