### PR TITLE
docs: use smaller image URL in vision example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ With an image URL:
 
 ```python
 prompt = "What is in this image?"
-img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/440px-2023_06_08_Raccoon1.jpg"
 
 response = client.responses.create(
     model="gpt-5.2",


### PR DESCRIPTION
Fixes #2776

## Problem

The vision example in the README uses a 1599px Wikimedia thumbnail URL that results in a ~3.5MB download. The API rejects this with a 400 error: `Error while downloading ...`.

## Fix

Replace the 1599px thumbnail with the 440px version of the same raccoon image, which is well within the API's size limits while remaining the same picture.

This contribution was developed with AI assistance (Claude Code).