### PR TITLE
fix(client): narrow retry exception handling to transport errors

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1021,8 +1021,8 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
 
                 log.debug("Raising timeout error")
                 raise APITimeoutError(request=request) from err
-            except Exception as err:
-                log.debug("Encountered Exception", exc_info=True)
+            except (httpx.TransportError, OSError) as err:
+                log.debug("Encountered transport error", exc_info=True)
 
                 if remaining_retries > 0:
                     self._sleep_for_retry(
@@ -1620,8 +1620,8 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
 
                 log.debug("Raising timeout error")
                 raise APITimeoutError(request=request) from err
-            except Exception as err:
-                log.debug("Encountered Exception", exc_info=True)
+            except (httpx.TransportError, OSError) as err:
+                log.debug("Encountered transport error", exc_info=True)
 
                 if remaining_retries > 0:
                     await self._sleep_for_retry(

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1021,8 +1021,8 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
 
                 log.debug("Raising timeout error")
                 raise APITimeoutError(request=request) from err
-            except (httpx.TransportError, OSError) as err:
-                log.debug("Encountered transport error", exc_info=True)
+            except (httpx.RequestError, OSError) as err:
+                log.debug("Encountered request error", exc_info=True)
 
                 if remaining_retries > 0:
                     self._sleep_for_retry(
@@ -1620,8 +1620,8 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
 
                 log.debug("Raising timeout error")
                 raise APITimeoutError(request=request) from err
-            except (httpx.TransportError, OSError) as err:
-                log.debug("Encountered transport error", exc_info=True)
+            except (httpx.RequestError, OSError) as err:
+                log.debug("Encountered request error", exc_info=True)
 
                 if remaining_retries > 0:
                     await self._sleep_for_retry(


### PR DESCRIPTION
## Summary

- Narrows `except Exception` in both sync and async retry loops to `except (httpx.TransportError, OSError)`, so only network/transport failures trigger retries
- Fixes issue where application-level exceptions (e.g. Celery's `SoftTimeLimitExceeded`) were caught and retried instead of propagating

Fixes #2737

## Details

The retry logic in `SyncAPIClient._retry_request` and `AsyncAPIClient._retry_request` previously caught bare `Exception`. This meant any non-`APITimeoutError` exception - including framework signals like Celery's `SoftTimeLimitExceeded` or `KeyboardInterrupt` subclasses - would be caught and retried up to `max_retries` times before re-raising.

`httpx.TransportError` is the base class for all httpx transport-level errors (connection failures, read errors, etc.), and `OSError` covers low-level socket errors that may not be wrapped by httpx. Together they cover the full set of retriable network failures without catching application-level exceptions.

## Test plan

- [x] All 49 existing retry tests pass (`tests/test_client.py` retry-related tests)
- [x] Verified exception hierarchy: `httpx.TimeoutException` is a subclass of `httpx.TransportError` (already handled separately as `APITimeoutError`)
- [x] Verified `SoftTimeLimitExceeded` (and similar non-network exceptions) are NOT subclasses of `TransportError` or `OSError`

This contribution was developed with AI assistance (Claude Code).