### PR TITLE
Include retry attempt counts in INFO retry logs

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1085,13 +1085,8 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         self, *, retries_taken: int, max_retries: int, options: FinalRequestOptions, response: httpx.Response | None
     ) -> None:
         remaining_retries = max_retries - retries_taken
-        if remaining_retries == 1:
-            log.debug("1 retry left")
-        else:
-            log.debug("%i retries left", remaining_retries)
-
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
-        log.info("Retrying request to %s in %f seconds", options.url, timeout)
+        log.info("Retrying request to %s in %f seconds (%i/%i)", options.url, timeout, retries_taken + 1, max_retries)
 
         time.sleep(timeout)
 
@@ -1684,13 +1679,8 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         self, *, retries_taken: int, max_retries: int, options: FinalRequestOptions, response: httpx.Response | None
     ) -> None:
         remaining_retries = max_retries - retries_taken
-        if remaining_retries == 1:
-            log.debug("1 retry left")
-        else:
-            log.debug("%i retries left", remaining_retries)
-
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
-        log.info("Retrying request to %s in %f seconds", options.url, timeout)
+        log.info("Retrying request to %s in %f seconds (%i/%i)", options.url, timeout, retries_taken + 1, max_retries)
 
         await anyio.sleep(timeout)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ import gc
 import os
 import sys
 import json
+import logging
 import asyncio
 import inspect
 import dataclasses
@@ -937,6 +938,38 @@ class TestOpenAI:
 
         assert response.retries_taken == failures_before_success
         assert int(response.http_request.headers.get("x-stainless-retry-count")) == failures_before_success
+
+    @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
+    @pytest.mark.respx(base_url=base_url)
+    def test_retry_log_includes_attempt_count(
+        self, client: OpenAI, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = client.with_options(max_retries=4)
+
+        nb_retries = 0
+
+        def retry_handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal nb_retries
+            if nb_retries < 2:
+                nb_retries += 1
+                return httpx.Response(500)
+            return httpx.Response(200)
+
+        respx_mock.post("/chat/completions").mock(side_effect=retry_handler)
+
+        with caplog.at_level(logging.INFO):
+            client.chat.completions.with_raw_response.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-5.4",
+            )
+
+        assert any("Retrying request to /chat/completions" in message and "(1/4)" in message for message in caplog.messages)
+        assert any("Retrying request to /chat/completions" in message and "(2/4)" in message for message in caplog.messages)
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
@@ -1984,6 +2017,38 @@ class TestAsyncOpenAI:
 
         assert response.retries_taken == failures_before_success
         assert int(response.http_request.headers.get("x-stainless-retry-count")) == failures_before_success
+
+    @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
+    @pytest.mark.respx(base_url=base_url)
+    async def test_retry_log_includes_attempt_count(
+        self, async_client: AsyncOpenAI, respx_mock: MockRouter, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = async_client.with_options(max_retries=4)
+
+        nb_retries = 0
+
+        def retry_handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal nb_retries
+            if nb_retries < 2:
+                nb_retries += 1
+                return httpx.Response(500)
+            return httpx.Response(200)
+
+        respx_mock.post("/chat/completions").mock(side_effect=retry_handler)
+
+        with caplog.at_level(logging.INFO):
+            await client.chat.completions.with_raw_response.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-5.4",
+            )
+
+        assert any("Retrying request to /chat/completions" in message and "(1/4)" in message for message in caplog.messages)
+        assert any("Retrying request to /chat/completions" in message and "(2/4)" in message for message in caplog.messages)
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)


### PR DESCRIPTION
﻿## Summary
- include the current retry attempt and configured retry limit in the existing INFO-level retry log
- remove the separate DEBUG-only "retries left" log now that the INFO log carries the same context
- add sync and async retry log assertions alongside the existing retry-count tests

## Testing
- ./.venv/Scripts/python -m pytest tests/test_client.py -k "retry_log_includes_attempt_count or retries_taken" -o addopts="--tb=short"

Closes #2404
