### PR TITLE
fix: convert by_alias=None to bool for pydantic v2

### DIFF
--- a/src/openai/_compat.py
+++ b/src/openai/_compat.py
@@ -149,7 +149,7 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            by_alias=bool(by_alias) if by_alias is not None else True,
         )
     return cast(
         "dict[str, Any]",


### PR DESCRIPTION
When DEBUG logging is enabled, `model_dump()` is called with `by_alias=None` (the default), which causes pydantic-core Rust serializer to raise:

```
TypeError: argument by_alias: NoneType object cannot be converted to PyBool
```

This fix converts `None` to `True` (pydantic default behavior) before passing to `model_dump()` for pydantic v2.

**Root cause:** The `_compat.py` function signature declares `by_alias: bool | None = None`, but passes it directly to pydantic v2s `model_dump()` which expects a bool, not None.

**Fix:** Convert `by_alias` to `bool` when passing to pydantic v2, defaulting to `True` (pydantic default) when `None` is passed.

Fixes: #2965