### PR TITLE
fix: strip model from Azure request body after URL construction

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -61,7 +61,7 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         retries_taken: int = 0,
     ) -> httpx.Request:
         if options.url in _deployments_endpoints and is_mapping(options.json_data):
-            model = options.json_data.get("model")
+            model = options.json_data.pop("model", None)
             if model is not None and "/deployments" not in str(self.base_url.path):
                 options.url = f"/deployments/{model}{options.url}"
 

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -61,9 +61,10 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         retries_taken: int = 0,
     ) -> httpx.Request:
         if options.url in _deployments_endpoints and is_mapping(options.json_data):
-            model = options.json_data.pop("model", None)
+            model = options.json_data.get("model")
             if model is not None and "/deployments" not in str(self.base_url.path):
                 options.url = f"/deployments/{model}{options.url}"
+                options.json_data = {k: v for k, v in options.json_data.items() if k != "model"}
 
         return super()._build_request(options, retries_taken=retries_taken)
 


### PR DESCRIPTION
## Summary

- Fix `_build_request` in `BaseAzureClient` to use `.pop("model", None)` instead of `.get("model")`, removing the `model` parameter from the JSON request body after it has been used to construct the `/deployments/{model}/...` URL path.
- This prevents Azure OpenAI from rejecting requests when the deployment name differs from the actual model name (e.g., `gpt-image-1-5` deployment for model `gpt-image-1.5`).

Fixes #2892

## Root Cause

In `src/openai/lib/azure.py`, `_build_request` reads the `model` field from `options.json_data` to build the deployment URL but does not remove it. The Azure backend then validates the body's `model` value against known model names, rejecting deployment names like `gpt-image-1-5` that don't match exactly (Azure naming rules prohibit dots in deployment names).

## Fix

One-line change: `options.json_data.get("model")` -> `options.json_data.pop("model", None)`

This removes `model` from the body after extracting it for URL construction, which aligns with the Azure OpenAI REST API spec where model selection is done entirely via the URL path for deployment-based endpoints.

## Test plan

- [ ] Verify existing tests pass (the change is backwards-compatible since `model` in the body was always redundant for Azure deployment endpoints)
- [ ] Test with Azure deployment where deployment name differs from model name (e.g., `gpt-image-1-5` for `gpt-image-1.5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)