### PR TITLE
fix(types): allow image generation input items without result/status

### DIFF
--- a/src/openai/types/responses/response_input_item_param.py
+++ b/src/openai/types/responses/response_input_item_param.py
@@ -176,10 +176,10 @@ class ImageGenerationCall(TypedDict, total=False):
     id: Required[str]
     """The unique ID of the image generation call."""
 
-    result: Required[Optional[str]]
+    result: Optional[str]
     """The generated image encoded in base64."""
 
-    status: Required[Literal["in_progress", "completed", "generating", "failed"]]
+    status: Literal["in_progress", "completed", "generating", "failed"]
     """The status of the image generation call."""
 
     type: Required[Literal["image_generation_call"]]

--- a/src/openai/types/responses/response_input_param.py
+++ b/src/openai/types/responses/response_input_param.py
@@ -177,10 +177,10 @@ class ImageGenerationCall(TypedDict, total=False):
     id: Required[str]
     """The unique ID of the image generation call."""
 
-    result: Required[Optional[str]]
+    result: Optional[str]
     """The generated image encoded in base64."""
 
-    status: Required[Literal["in_progress", "completed", "generating", "failed"]]
+    status: Literal["in_progress", "completed", "generating", "failed"]
     """The status of the image generation call."""
 
     type: Required[Literal["image_generation_call"]]

--- a/tests/test_response_input_types.py
+++ b/tests/test_response_input_types.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from openai.types.responses import ResponseInputParam
+from openai.types.responses.response_input_item_param import ImageGenerationCall
+
+
+def test_image_generation_call_input_allows_id_only() -> None:
+    image_generation_call: ImageGenerationCall = {
+        "id": "ig_123",
+        "type": "image_generation_call",
+    }
+
+    response_input: ResponseInputParam = [image_generation_call]
+
+    assert response_input == [image_generation_call]


### PR DESCRIPTION
## Summary
- make `ImageGenerationCall` input params accept image-id-only items without requiring `result` or `status`
- apply the fix in both response input type aliases so the public params stay consistent
- add a small regression test that pyright checks and pytest imports cleanly

Closes #2648

## Validation
- `pytest tests/test_response_input_types.py -n0`
- `scripts/run-pyright src/openai/types/responses/response_input_item_param.py src/openai/types/responses/response_input_param.py tests/test_response_input_types.py`
- `mypy src/openai/types/responses/response_input_item_param.py src/openai/types/responses/response_input_param.py`
- `ruff check src/openai/types/responses/response_input_item_param.py src/openai/types/responses/response_input_param.py tests/test_response_input_types.py`