### PR TITLE
fix(client): treat empty OPENAI_BASE_URL env var as unset

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 


### PR DESCRIPTION
## Problem

When `OPENAI_BASE_URL` is defined but empty (`OPENAI_BASE_URL=""`), `os.environ.get("OPENAI_BASE_URL")` returns an empty string. An empty string is falsy for `== None` but **not** for `is None`, so the second `if base_url is None` guard is never triggered and the intended fallback to `https://api.openai.com/v1` is skipped.

The client then passes an empty string as `base_url`, which results in a confusing `APIConnectionError: Connection error.`

## Fix

```python
# Before
base_url = os.environ.get("OPENAI_BASE_URL")

# After
base_url = os.environ.get("OPENAI_BASE_URL") or None
```

Normalise an empty env var to `None` so the default URL is applied.

Same fix applied to both `OpenAI` and `AsyncOpenAI` client `__init__` methods.

Fixes #2927