### PR TITLE
fix(client): treat empty OPENAI_BASE_URL as unset and fall back to default

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 


### PR DESCRIPTION
## Problem

When `OPENAI_BASE_URL` is set to an empty string (e.g., `export OPENAI_BASE_URL=""`), `os.environ.get("OPENAI_BASE_URL")` returns `""` — which is **not** `None`. As a result, the second `if base_url is None` check never fires, the default `https://api.openai.com/v1` fallback is skipped, and the client tries to connect to an empty URL, producing a confusing `APIConnectionError`.

```python
# Before (broken with OPENAI_BASE_URL="")
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")  # returns ""
if base_url is None:          # "" is not None — this branch is skipped!
    base_url = "https://api.openai.com/v1"
```

## Solution

Convert the empty string to `None` using `or None`, so the fallback fires correctly:

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL") or None
if base_url is None:
    base_url = "https://api.openai.com/v1"
```

Applied to both the sync `OpenAI` client and the async `AsyncOpenAI` client.

## Testing

- Syntax verified with Python AST parser
- Reproducer: `export OPENAI_BASE_URL="" && python -c "from openai import OpenAI; OpenAI().models.list()"` — previously raised `APIConnectionError`, now falls back to default endpoint

Fixes #2927
