### PR TITLE
fix: add aclose() alias to AsyncStream

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -238,6 +238,15 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """
+        Alias for close() to support the standard Python async cleanup protocol.
+
+        This allows AsyncStream to be used with asyncio utilities and libraries
+        that expect an aclose() method (e.g. contextlib.aclosing, httpx, anyio).
+        """
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(


### PR DESCRIPTION
## Summary

- `AsyncStream` had a `close()` method but was missing `aclose()`, which is the standard async resource cleanup method in Python
- Adds `aclose()` as an alias for `close()` in `AsyncStream` to support the async cleanup protocol used by `asyncio`, `contextlib.aclosing()`, `httpx`, `anyio`, and instrumentation/tracing libraries
- The sync `Stream` class already follows the context manager protocol correctly; this brings `AsyncStream` to parity for callers that rely on the conventional `aclose()` name

## Test plan

- [ ] Verify `AsyncStream` can be used with `contextlib.aclosing(stream)` in async contexts
- [ ] Verify `await stream.aclose()` closes the underlying response (same as `await stream.close()`)
- [ ] Existing tests should continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)