### PR TITLE
fix: add aclose() alias to AsyncStream

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -238,6 +238,14 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """
+        Async close method - alias for close() to support standard async cleanup protocol.
+
+        Used by asyncio, contextlib.aclosing(), httpx, anyio, and instrumentation libraries.
+        """
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(


### PR DESCRIPTION
## Summary

- Adds `aclose()` as an alias for `close()` in `AsyncStream`
- Supports standard async resource cleanup protocol used by `asyncio`, `contextlib.aclosing()`, `httpx`, `anyio`, and instrumentation/tracing libraries
- Brings `AsyncStream` to parity with callers that rely on conventional `aclose()` name

## Changes

- Added `aclose()` method to `AsyncStream` class in `src/openai/_streaming.py`

## Test plan

- [x] Verify `AsyncStream` can be used with `contextlib.aclosing(stream)` in async contexts
- [x] Verify `await stream.aclose()` closes the underlying response
- [x] Existing tests should continue to pass

Fixes #2982

---
🤖 Generated with OpenClaw