### PR TITLE
fix: async client timeout in streaming requests

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import asyncio
 import inspect
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Iterator, Optional, AsyncIterator, cast
@@ -10,7 +11,7 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 import httpx
 
 from ._utils import is_mapping, extract_type_var_from_base
-from ._exceptions import APIError
+from ._exceptions import APIError, APITimeoutError
 
 if TYPE_CHECKING:
     from ._client import OpenAI, AsyncOpenAI
@@ -105,6 +106,8 @@ class Stream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except httpx.TimeoutException as err:
+            raise APITimeoutError(request=self.response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             response.close()
@@ -215,6 +218,8 @@ class AsyncStream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except (httpx.TimeoutException, asyncio.TimeoutError) as err:
+            raise APITimeoutError(request=self.response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             await response.aclose()


### PR DESCRIPTION
Fixes #2373

## Problem
When a timeout occurs during streaming iteration (not just during the initial request), the underlying `httpx.TimeoutException` or `asyncio.TimeoutError` was not being properly converted to `APITimeoutError`. This meant that users catching `APITimeoutError` would not catch timeouts that occur while iterating over a stream.

## Solution
Add try-except blocks in both `Stream.__stream__()` and `AsyncStream.__stream__()` to catch timeout exceptions and convert them to `APITimeoutError`, consistent with how timeouts are handled in the base client.

## Changes
- Import `asyncio` and `APITimeoutError` in `_streaming.py`
- Add `httpx.TimeoutException` handling in `Stream.__stream__()`
- Add `httpx.TimeoutException` and `asyncio.TimeoutError` handling in `AsyncStream.__stream__()`

## Testing
All existing tests pass, including the timeout-related tests in `test_client.py`.