### PR TITLE
fix(client): fall back when OPENAI_BASE_URL is empty

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,11 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_empty_base_url_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = OpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1733,6 +1738,11 @@ class TestAsyncOpenAI:
         with update_env(OPENAI_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
+
+    async def test_empty_base_url_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION
## Summary
- treat an empty `OPENAI_BASE_URL` environment value the same as an unset one
- keep explicit `base_url` arguments unchanged
- add sync and async regressions for the empty-env case

## Why
`OPENAI_BASE_URL=""` currently bypasses the default API URL fallback because `os.environ.get(...)` returns an empty string rather than `None`. That leaves the client with an invalid base URL even though this path is meant to be the environment defaulting logic.

## Testing
- `./.venv/bin/pytest tests/test_client.py -k "base_url_env" -n0`
- `./.venv/bin/ruff check src/openai/_client.py tests/test_client.py`
- `./.venv/bin/mypy src/openai/_client.py`
- `./.venv/bin/pyright -p pyproject.toml src/openai/_client.py`