### PR TITLE
Normalize module client base_url trailing slash

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -204,7 +204,7 @@ class _ModuleClient(OpenAI):
     @override
     def base_url(self) -> _httpx.URL:
         if base_url is not None:
-            return _httpx.URL(base_url)
+            return self._enforce_trailing_slash(_httpx.URL(base_url))
 
         return super().base_url
 

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -42,8 +42,15 @@ def test_base_url_option() -> None:
 
     openai.base_url = "http://foo.com"
 
-    assert openai.base_url == URL("http://foo.com")
-    assert openai.completions._client.base_url == URL("http://foo.com")
+    assert openai.base_url == "http://foo.com"
+    assert openai.completions._client.base_url.raw_path == b"/"
+
+
+def test_base_url_option_without_trailing_slash() -> None:
+    openai.base_url = "http://foo.com/custom/path"
+
+    assert openai.base_url == "http://foo.com/custom/path"
+    assert openai.completions._client.base_url == URL("http://foo.com/custom/path/")
 
 
 def test_timeout_option() -> None:


### PR DESCRIPTION
## Summary

Fix inconsistent `base_url` normalization between the module-level client and instantiated clients.

When `openai.base_url` is set without a trailing slash, `_ModuleClient.base_url` returned the raw URL, while `OpenAI(base_url=...)` normalized it with a trailing slash. This could lead to malformed request URLs in module-level usage.

## Changes

- normalize `_ModuleClient.base_url` using the same trailing-slash enforcement as instantiated clients
- add a regression test for module-level `base_url` with a custom path and no trailing slash
- keep the module-level `openai.base_url` value unchanged as user input, while ensuring the resolved client URL is normalized

## Testing

- `python -m pytest tests/test_module_client.py -n 0`
- `python -m pytest tests/test_client.py -k "base_url" -n 0`

Closes #1373
