### PR TITLE
fix(types): correct prompt_cache_retention literal from in-memory to in_memory

### DIFF
--- a/src/openai/types/chat/completion_create_params.py
+++ b/src/openai/types/chat/completion_create_params.py
@@ -185,7 +185,7 @@ class CompletionCreateParamsBase(TypedDict, total=False):
     [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
     """
 
-    prompt_cache_retention: Optional[Literal["in-memory", "24h"]]
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]]
     """The retention policy for the prompt cache.
 
     Set to `24h` to enable extended prompt caching, which keeps cached prefixes

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -214,7 +214,7 @@ class Response(BaseModel):
     [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
     """
 
-    prompt_cache_retention: Optional[Literal["in-memory", "24h"]] = None
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
     """The retention policy for the prompt cache.
 
     Set to `24h` to enable extended prompt caching, which keeps cached prefixes

--- a/src/openai/types/responses/response_create_params.py
+++ b/src/openai/types/responses/response_create_params.py
@@ -152,7 +152,7 @@ class ResponseCreateParamsBase(TypedDict, total=False):
     [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
     """
 
-    prompt_cache_retention: Optional[Literal["in-memory", "24h"]]
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]]
     """The retention policy for the prompt cache.
 
     Set to `24h` to enable extended prompt caching, which keeps cached prefixes

--- a/src/openai/types/responses/responses_client_event.py
+++ b/src/openai/types/responses/responses_client_event.py
@@ -184,7 +184,7 @@ class ResponsesClientEvent(BaseModel):
     [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
     """
 
-    prompt_cache_retention: Optional[Literal["in-memory", "24h"]] = None
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]] = None
     """The retention policy for the prompt cache.
 
     Set to `24h` to enable extended prompt caching, which keeps cached prefixes

--- a/src/openai/types/responses/responses_client_event_param.py
+++ b/src/openai/types/responses/responses_client_event_param.py
@@ -185,7 +185,7 @@ class ResponsesClientEventParam(TypedDict, total=False):
     [Learn more](https://platform.openai.com/docs/guides/prompt-caching).
     """
 
-    prompt_cache_retention: Optional[Literal["in-memory", "24h"]]
+    prompt_cache_retention: Optional[Literal["in_memory", "24h"]]
     """The retention policy for the prompt cache.
 
     Set to `24h` to enable extended prompt caching, which keeps cached prefixes


### PR DESCRIPTION
Fixes #2883

## Problem
The SDK declares `prompt_cache_retention` with `Literal["in-memory", "24h"]` (hyphen), but the OpenAI API rejects `"in-memory"` with 400 and only accepts `"in_memory"` (underscore).

## Fix
Replaced `"in-memory"` with `"in_memory"` in all affected type declarations.

## Testing
Users relying on the typed value will now get the API-accepted value.