### PR TITLE
feat(lib): export type_to_response_format_param publicly

### DIFF
--- a/src/openai/lib/__init__.py
+++ b/src/openai/lib/__init__.py
@@ -1,2 +1,3 @@
 from ._tools import pydantic_function_tool as pydantic_function_tool
 from ._parsing import ResponseFormatT as ResponseFormatT
+from ._parsing import type_to_response_format_param as type_to_response_format_param

--- a/src/openai/lib/__init__.py
+++ b/src/openai/lib/__init__.py
@@ -1,3 +1,2 @@
 from ._tools import pydantic_function_tool as pydantic_function_tool
-from ._parsing import ResponseFormatT as ResponseFormatT
-from ._parsing import type_to_response_format_param as type_to_response_format_param
+from ._parsing import ResponseFormatT as ResponseFormatT, type_to_response_format_param as type_to_response_format_param

--- a/tests/lib/test_public_exports.py
+++ b/tests/lib/test_public_exports.py
@@ -1,0 +1,6 @@
+from openai.lib import type_to_response_format_param
+from openai.lib._parsing import type_to_response_format_param as internal_type_to_response_format_param
+
+
+def test_type_to_response_format_param_is_publicly_exported() -> None:
+    assert type_to_response_format_param is internal_type_to_response_format_param


### PR DESCRIPTION
Closes #2695

## Summary
- Exports `type_to_response_format_param` from `openai.lib` so users can import it without reaching into private modules

Currently users must import from `openai.lib._parsing._completions`, which is an internal path. This adds it to the public `openai.lib` namespace alongside the other publicly exported helpers.

## Test plan
- Verified `from openai.lib import type_to_response_format_param` works
- No behavior change — just a re-export