### PR TITLE
Treat empty OPENAI_BASE_URL as unset

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,11 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_base_url_empty_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = OpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1733,6 +1738,11 @@ class TestAsyncOpenAI:
         with update_env(OPENAI_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
+
+    async def test_base_url_empty_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION
## Summary

Treat an empty `OPENAI_BASE_URL` environment variable as unset so the client falls back to the default API endpoint.

Previously, `OPENAI_BASE_URL=""` bypassed the default fallback and produced an invalid empty base URL.

## Changes

- normalize empty `OPENAI_BASE_URL` environment values to `None`
- apply the fix to both sync and async clients
- add sync and async regression tests covering the empty-env fallback

## Testing

- `python -m pytest tests/test_client.py -k "base_url_empty_env_falls_back_to_default or test_base_url_env" -n 0`
- `python -m pytest tests/test_module_client.py -n 0`

Closes #2927
