### PR TITLE
Add aclose alias to AsyncStream

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -238,6 +238,10 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """Alias for `close()` for compatibility with async context consumers."""
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -246,3 +246,26 @@ def make_event_iterator(
     return AsyncStream(
         cast_to=object, client=async_client, response=httpx.Response(200, content=to_aiter(content))
     )._iter_events()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_has_aclose_alias(async_client: AsyncOpenAI) -> None:
+    stream = AsyncStream(
+        cast_to=object,
+        client=async_client,
+        response=httpx.Response(200, content=to_aiter(iter(()))),
+    )
+
+    assert hasattr(stream, "aclose")
+    assert callable(stream.aclose)
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_aclose_closes_response(async_client: AsyncOpenAI) -> None:
+    response = httpx.Response(200, content=to_aiter(iter(())))
+    stream = AsyncStream(cast_to=object, client=async_client, response=response)
+
+    await stream.aclose()
+
+    assert response.is_closed


### PR DESCRIPTION
## Summary

Add an `aclose()` alias to `AsyncStream` for compatibility with async stream consumers that expect the standard close method name.

This keeps `AsyncStream` aligned with other async response wrappers in the SDK and avoids `AttributeError` in integrations that call `await stream.aclose()`.

## Changes

- add `AsyncStream.aclose()` as an alias for `close()`
- add regression tests covering the alias and confirming it closes the underlying response

## Testing

- `python -m pytest tests/test_streaming.py -k "async_stream_has_aclose_alias or async_stream_aclose_closes_response" -n 0`

Closes #2853
