### PR TITLE
fix(client): treat empty OPENAI_BASE_URL as unset, falling back to default endpoint

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 


### PR DESCRIPTION
## Description

When `OPENAI_BASE_URL` is set to an empty string (e.g. `export OPENAI_BASE_URL=""`), `os.environ.get("OPENAI_BASE_URL")` returns `""` which is **not** `None`. This causes the second `if base_url is None` check to be skipped, so the empty string is passed as `base_url` to the HTTP client, resulting in confusing connection errors rather than falling back to the default endpoint.

## Root Cause

```python
# Before fix
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")  # returns "" if set to empty
if base_url is None:                               # "" is not None, skipped!
    base_url = f"https://api.openai.com/v1"
```

## Fix

```python
# After fix
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL") or None  # "" becomes None
if base_url is None:
    base_url = f"https://api.openai.com/v1"               # fallback works correctly
```

This fix is applied to both `OpenAI` (sync) and `AsyncOpenAI` classes.

## Changes

- `src/openai/_client.py`: Use `or None` to coerce empty string env var to `None` in both sync and async client constructors

Closes #2927
