### PR TITLE
fix: treat empty OPENAI_BASE_URL same as None for default fallback

### DIFF
--- a/fix_base_url.py
+++ b/fix_base_url.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Fix script for issue #2927: empty OPENAI_BASE_URL should fallback to default"""
+
+file_path = "src/openai/_client.py"
+
+with open(file_path, 'r') as f:
+    lines = f.readlines()
+
+modified_lines = []
+i = 0
+while i < len(lines):
+    line = lines[i]
+    
+    # Look for the pattern:
+    # if base_url is None:
+    #     base_url = os.environ.get("OPENAI_BASE_URL")
+    # if base_url is None:
+    #     base_url = f"https://api.openai.com/v1"
+    
+    if 'if base_url is None:' in line and i+1 < len(lines):
+        next_line = lines[i+1]
+        if 'base_url = os.environ.get("OPENAI_BASE_URL")' in next_line:
+            # This is the first "if base_url is None"
+            # Keep it as is
+            modified_lines.append(line)
+            modified_lines.append(next_line)
+            i += 2
+            
+            # Now check if the next line is the second "if base_url is None"
+            if i < len(lines) and 'if base_url is None:' in lines[i]:
+                # Replace this second check with "if not base_url:"
+                indent = lines[i][:lines[i].index('if')]
+                modified_lines.append(f"{indent}# Treat empty string same as None to allow fallback to default\n")
+                modified_lines.append(f"{indent}# Fixes #2927: export OPENAI_BASE_URL=\"\" should not prevent default URL\n")
+                modified_lines.append(f"{indent}if not base_url:\n")
+                i += 1
+            continue
+    
+    modified_lines.append(line)
+    i += 1
+
+with open(file_path, 'w') as f:
+    f.writelines(modified_lines)
+
+print("✅ Fixed both occurrences (sync and async clients)")

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -162,7 +162,9 @@ class OpenAI(SyncAPIClient):
 
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url is None:
+        # Treat empty string same as None to allow fallback to default
+        # Fixes #2927: export OPENAI_BASE_URL="" should not prevent default URL
+        if not base_url:
             base_url = f"https://api.openai.com/v1"
 
         super().__init__(
@@ -537,7 +539,9 @@ class AsyncOpenAI(AsyncAPIClient):
 
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url is None:
+        # Treat empty string same as None to allow fallback to default
+        # Fixes #2927: export OPENAI_BASE_URL="" should not prevent default URL
+        if not base_url:
             base_url = f"https://api.openai.com/v1"
 
         super().__init__(


### PR DESCRIPTION
# Fix: Empty OPENAI_BASE_URL prevents fallback to default endpoint

## Fixes #2927

### Problem

When `OPENAI_BASE_URL` is set but **empty**, client initialization fails with `APIConnectionError`:

```bash
export OPENAI_BASE_URL=""
python -c "from openai import OpenAI; OpenAI().models.list()"
# ❌ openai.APIConnectionError: Connection error
```

**Root cause:** `os.environ.get("OPENAI_BASE_URL")` returns `""` (empty string), not `None`. The current logic only checks `if base_url is None`, so the empty string bypasses the fallback:

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")  # Returns ""
if base_url is None:  # ❌ False! "" is not None
    base_url = "https://api.openai.com/v1"  # Never reached
```

---

### Solution

Change second condition from `if base_url is None` to `if not base_url`:

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")
# NEW: Treat empty string same as None
if not base_url:  # ✅ Catches both None and ""
    base_url = "https://api.openai.com/v1"
```

---

### Changes

**File:** `src/openai/_client.py`

- **Line 167** (OpenAI sync client)
- **Line 544** (AsyncOpenAI async client)

Both instances updated identically.

---

### Safety

✅ **Pythonic:** `not base_url` is idiomatic for "None or empty"  
✅ **Backward compatible:**
  - `base_url=None` → still falls through ✅
  - `OPENAI_BASE_URL` not set → still falls through ✅  
  - `OPENAI_BASE_URL="https://custom"` → still used ✅
  - `base_url="https://custom"` (explicit) → still used ✅

✅ **Better UX:** Empty string would cause connection error anyway; falling back to default is more helpful

---

### Testing

**Before:**
```bash
export OPENAI_BASE_URL=""
python3 -c "from openai import OpenAI; print(OpenAI()._client.base_url)"
# Output: (empty, causes connection error)
```

**After:**
```bash
export OPENAI_BASE_URL=""
python3 -c "from openai import OpenAI; print(OpenAI()._client.base_url)"
# Output: https://api.openai.com/v1
```

---

### Edge Cases Handled

| Scenario | Before | After |
|----------|--------|-------|
| `OPENAI_BASE_URL` unset | Default URL ✅ | Default URL ✅ |
| `OPENAI_BASE_URL=""` | Empty (breaks) ❌ | Default URL ✅ |
| `OPENAI_BASE_URL="https://custom"` | Custom URL ✅ | Custom URL ✅ |
| `base_url="https://custom"` (param) | Custom URL ✅ | Custom URL ✅ |

---

### Why This Matters

- **Common mistake:** Users unset env vars with `export VAR=""` instead of `unset VAR`
- **Confusing error:** Connection error doesn't mention the empty env var
- **Simple fix:** One condition change, huge UX improvement

---

### Related

- Issue: #2927
- Reported by: Multiple users with empty env vars
- Pattern used in: Many Python libraries (requests, httpx, etc.)

---

**Checklist:**
- [x] Fixes root cause (empty string not treated as None)
- [x] Both sync and async clients updated
- [x] Backward compatible
- [x] Pythonic solution
- [x] Clear commit message