### PR TITLE
fix(compat): coerce by_alias=None to False in model_dump to fix TypeError with pydantic v2

### DIFF
--- a/src/openai/_compat.py
+++ b/src/openai/_compat.py
@@ -149,7 +149,8 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            by_alias=by_alias,
+            # pydantic-core's Rust serializer rejects None for by_alias; coerce to bool.
+            by_alias=bool(by_alias) if by_alias is not None else False,
         )
     return cast(
         "dict[str, Any]",


### PR DESCRIPTION
## Summary

Fixes #2921

### Problem

`model_dump()` in `_compat.py` declares `by_alias: bool | None = None` and was forwarding the value as-is to pydantic's `model_dump()`. pydantic-core's Rust-based serializer (pydantic v2) does not accept `None` for `by_alias` and raises:

```
TypeError: argument 'by_alias': 'NoneType' object cannot be converted to 'PyBool'
```

This error only manifests when DEBUG-level logging is enabled on the `openai` logger, because the affected call site omits `by_alias` (so it defaults to `None`) and is inside a `if log.isEnabledFor(logging.DEBUG)` block in `_base_client.py`.

### Fix

Coerce `None` to `False` before passing to pydantic:

```python
# Before
by_alias=by_alias

# After
by_alias=bool(by_alias) if by_alias is not None else False
```

The pydantic v1 code path already used `bool(by_alias)`, so this aligns both branches.

### Testing

```python
import logging
logging.basicConfig(level=logging.DEBUG)
from openai import OpenAI
client = OpenAI(api_key="fake")
client.chat.completions.create(model="gpt-4.1", messages=[{"role": "user", "content": "hi"}])
# No longer raises TypeError — proceeds to the network request
```