### PR TITLE
fix: treat empty OPENAI_BASE_URL env var as unset to restore default fallback

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 


### PR DESCRIPTION
## Problem

Fixes #2927

When `OPENAI_BASE_URL` is set to an empty string (e.g. `export OPENAI_BASE_URL=""`), `os.environ.get("OPENAI_BASE_URL")` returns `""` — which is **not** `None`. The fallback check:

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")
if base_url is None:        # ← never reached when env var is ""
    base_url = f"https://api.openai.com/v1"
```

leaves `base_url` as an empty string, which is an invalid URL. Every subsequent API call then raises a confusing `APIConnectionError` with no clear pointer to the root cause.

This can happen silently in CI/CD pipelines, Docker containers, or .env files where a variable is defined but not populated.

## Solution

Add `or None` after the `os.environ.get()` call so empty strings are treated the same as a missing variable:

```python
base_url = os.environ.get("OPENAI_BASE_URL") or None
```

Applied to both the sync `OpenAI` client and the async `AsyncOpenAI` client constructors.

## Testing

```bash
export OPENAI_BASE_URL=""
python -c "from openai import OpenAI; c = OpenAI(api_key='test'); print(c.base_url)"
# Before: raises APIConnectionError
# After:  prints https://api.openai.com/v1
```