### PR TITLE
fix: narrow broad except Exception in retry loop to httpx.RequestError

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1021,8 +1021,8 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
 
                 log.debug("Raising timeout error")
                 raise APITimeoutError(request=request) from err
-            except Exception as err:
-                log.debug("Encountered Exception", exc_info=True)
+            except httpx.RequestError as err:
+                log.debug("Encountered httpx.RequestError", exc_info=True)
 
                 if remaining_retries > 0:
                     self._sleep_for_retry(
@@ -1620,8 +1620,8 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
 
                 log.debug("Raising timeout error")
                 raise APITimeoutError(request=request) from err
-            except Exception as err:
-                log.debug("Encountered Exception", exc_info=True)
+            except httpx.RequestError as err:
+                log.debug("Encountered httpx.RequestError", exc_info=True)
 
                 if remaining_retries > 0:
                     await self._sleep_for_retry(


### PR DESCRIPTION
## Summary

Fixes #2737.

The `_send_with_request_id` retry loop in `_base_client.py` (both sync `SyncAPIClient` and async `AsyncAPIClient`) contained a broad `except Exception` fallback after the `except httpx.TimeoutException` handler. The intent is to catch transport-level errors from `httpx.send()` and convert them to `APIConnectionError` for retry or re-raise. However, catching all `Exception` subclasses means **any** non-`BaseException` exception raised during the HTTP send — including Celery's `SoftTimeLimitExceeded`, `billiard.exceptions.SoftTimeLimitExceeded`, or other process-management signals — is silently swallowed, wrapped as `APIConnectionError`, and either retried (burning retry budget) or re-raised with the wrong type, preventing caller cleanup logic from running.

## Change

Narrow the fallback `except Exception` to `except httpx.RequestError` in both the sync and async retry loops.

`httpx.RequestError` is the base class for all transport-layer errors that httpx raises from `client.send()` (connect errors, read errors, write errors, protocol errors, etc.). `httpx.TimeoutException` is itself a subclass of `httpx.RequestError`, so the preceding handler already covers timeouts and the fallback branch remains correctly scoped.

Any exception that does **not** derive from `httpx.RequestError` — including `SoftTimeLimitExceeded`, custom signals, or unexpected SDK bugs — will now propagate naturally to the caller instead of being silently converted into `APIConnectionError`.

## Before / After

**Before** (both sync and async):
```python
except httpx.TimeoutException as err:
    ...
    raise APITimeoutError(request=request) from err
except Exception as err:                          # catches SoftTimeLimitExceeded etc.
    ...
    raise APIConnectionError(request=request) from err
```

**After**:
```python
except httpx.TimeoutException as err:
    ...
    raise APITimeoutError(request=request) from err
except httpx.RequestError as err:                 # only catches httpx transport errors
    ...
    raise APIConnectionError(request=request) from err
```

## Scope

- Only two lines changed (one in `SyncAPIClient._send_with_request_id`, one in `AsyncAPIClient._send_with_request_id`).
- No behaviour change for any exception that was already an `httpx.RequestError`.
- No new dependencies.

## Test plan

- [ ] Existing test suite passes (`pytest tests/`)
- [ ] Manual: confirm a mock `SoftTimeLimitExceeded` raised inside `client.send()` now propagates out instead of being caught
- [ ] Manual: confirm `httpx.ConnectError` (a `RequestError` subclass) still results in `APIConnectionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)