### PR TITLE
fix: treat empty OPENAI_BASE_URL env var as unset, fall back to default

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -161,7 +161,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -536,7 +536,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,11 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_empty_base_url_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = OpenAI(api_key=api_key, _strict_response_validation=True)
+            assert str(client.base_url) == "https://api.openai.com/v1/"
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1733,6 +1738,11 @@ class TestAsyncOpenAI:
         with update_env(OPENAI_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
+
+    async def test_empty_base_url_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
+            assert str(client.base_url) == "https://api.openai.com/v1/"
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION
## Summary

Fixes #2927.

When `OPENAI_BASE_URL` is set to `""` (empty string), `os.environ.get("OPENAI_BASE_URL")` returns `""` rather than `None`. The existing guard `if base_url is None` therefore never triggered, so the default `https://api.openai.com/v1` was never applied — the client ended up with an empty base URL and all requests failed.

**Root cause:** `os.environ.get` returns `""` for an empty env var; only `None` is returned when the variable is absent entirely.

**Fix:** Convert falsy values to `None` with `or None` on both `OpenAI` and `AsyncOpenAI` clients:

```python
# Before
base_url = os.environ.get("OPENAI_BASE_URL")

# After
base_url = os.environ.get("OPENAI_BASE_URL") or None
```

This is minimal and non-breaking: a non-empty `OPENAI_BASE_URL` still takes effect normally.

## Changes

- `src/openai/_client.py`: apply `or None` coercion in `OpenAI.__init__` and `AsyncOpenAI.__init__`
- `tests/test_client.py`: add `test_empty_base_url_env_falls_back_to_default` for both sync and async clients

## Test plan

- [x] `TestOpenAI::test_empty_base_url_env_falls_back_to_default` — passes
- [x] `TestAsyncOpenAI::test_empty_base_url_env_falls_back_to_default` — passes
- [x] Existing `test_base_url_env` tests (non-empty URL) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)