### PR TITLE
docs: fix streaming comment typo

### DIFF
--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -379,7 +379,7 @@ class ChatCompletionStreamState(Generic[ResponseFormatT]):
                                     choice_snapshot.message,
                                     # we don't want to serialise / deserialise our custom properties
                                     # as they won't appear in the delta and we don't want to have to
-                                    # continuosly reparse the content
+                                    # continuously reparse the content
                                     exclude=cast(
                                         # cast required as mypy isn't smart enough to infer `True` here to `Literal[True]`
                                         IncEx,


### PR DESCRIPTION
## Summary
- fix a typo in the streaming chat completion comment

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- Read https://github.com/openai/openai-python/blob/main/CONTRIBUTING.md
- one-file comment-only change in `src/openai/lib/`, which the guide notes is safe for manual edits
- no behavior change

## Validation
- Not run (comment-only change)
