### PR TITLE
responses: guard Response.output_text against null content.text (fixes #3011)

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -313,9 +313,9 @@ class Response(BaseModel):
         """
         texts: List[str] = []
         for output in self.output:
-          if output.type == "message":
-            for content in output.content:
-              if content.type == "output_text" and content.text:
-                texts.append(content.text)
+            if output.type == "message":
+                for content in output.content:
+                    if content.type == "output_text" and content.text:
+                        texts.append(content.text)
 
         return "".join(texts)

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -313,9 +313,9 @@ class Response(BaseModel):
         """
         texts: List[str] = []
         for output in self.output:
-            if output.type == "message":
-                for content in output.content:
-                    if content.type == "output_text":
-                        texts.append(content.text)
+          if output.type == "message":
+            for content in output.content:
+              if content.type == "output_text" and content.text:
+                texts.append(content.text)
 
         return "".join(texts)


### PR DESCRIPTION
What: Skip None-valued output_text content items when aggregating Response.output_text.
Why: Some models can return output_text items with text: null; concatenating those values raises a TypeError when accessing the convenience property.
Change: Add a guard to ignore content.text if it is None before appending to the aggregated text.
Risk: Minimal — defensive change to a convenience property only, no breaking API changes expected.
Fixes: #3011