### PR TITLE
fix(types): make ResponseOutputMessageParam.id optional

### DIFF
--- a/src/openai/types/responses/response_output_message_param.py
+++ b/src/openai/types/responses/response_output_message_param.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Union, Iterable, Optional
-from typing_extensions import Literal, Required, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, TypeAlias, TypedDict, NotRequired
 
 from .response_output_text_param import ResponseOutputTextParam
 from .response_output_refusal_param import ResponseOutputRefusalParam
@@ -16,7 +16,7 @@ Content: TypeAlias = Union[ResponseOutputTextParam, ResponseOutputRefusalParam]
 class ResponseOutputMessageParam(TypedDict, total=False):
     """An output message from the model."""
 
-    id: Required[str]
+    id: NotRequired[str]
     """The unique ID of the output message."""
 
     content: Required[Iterable[Content]]

--- a/tests/test_response_output_message_param.py
+++ b/tests/test_response_output_message_param.py
@@ -1,0 +1,21 @@
+from typing_extensions import assert_type
+
+from openai.types.responses.response_output_message_param import ResponseOutputMessageParam
+
+
+def test_response_output_message_param_id_is_optional() -> None:
+    message: ResponseOutputMessageParam = {
+        "role": "assistant",
+        "status": "completed",
+        "type": "message",
+        "content": [
+            {
+                "type": "output_text",
+                "text": "hello",
+                "annotations": [],
+            }
+        ],
+    }
+
+    assert_type(message, ResponseOutputMessageParam)
+    assert "id" not in message


### PR DESCRIPTION
## Summary
- make `ResponseOutputMessageParam.id` explicitly optional with `NotRequired[str]`
- add a focused regression test showing an assistant message can be typed without an OpenAI-generated `id`

## Testing
- `./.venv/bin/pytest tests/test_response_output_message_param.py -n0`
- `./.venv/bin/pyright -p pyproject.toml src/openai/types/responses/response_output_message_param.py tests/test_response_output_message_param.py`
- `./.venv/bin/mypy src/openai/types/responses/response_output_message_param.py`
- `./.venv/bin/ruff check src/openai/types/responses/response_output_message_param.py tests/test_response_output_message_param.py`

Closes #2501.
