### PR TITLE
Fix undocumented reasoning+message pairing constraint in Responses API

### DIFF
--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -195,6 +195,12 @@ class Responses(SyncAPIResource):
 
           input: Text, image, or file inputs to the model, used to generate a response.
 
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
+
               Learn more:
 
               - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
@@ -451,6 +457,12 @@ class Responses(SyncAPIResource):
 
           input: Text, image, or file inputs to the model, used to generate a response.
 
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
+
               Learn more:
 
               - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
@@ -699,6 +711,12 @@ class Responses(SyncAPIResource):
                 in the zero data retention program).
 
           input: Text, image, or file inputs to the model, used to generate a response.
+
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
 
               Learn more:
 
@@ -1692,6 +1710,12 @@ class Responses(SyncAPIResource):
 
           input: Text, image, or file inputs to the model, used to generate a response
 
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
+
           instructions: A system (or developer) message inserted into the model's context. When used
               along with `previous_response_id`, the instructions from a previous response
               will not be carried over to the next response. This makes it simple to swap out
@@ -1861,6 +1885,12 @@ class AsyncResponses(AsyncAPIResource):
                 in the zero data retention program).
 
           input: Text, image, or file inputs to the model, used to generate a response.
+
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
 
               Learn more:
 
@@ -2118,6 +2148,12 @@ class AsyncResponses(AsyncAPIResource):
 
           input: Text, image, or file inputs to the model, used to generate a response.
 
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
+
               Learn more:
 
               - [Text inputs and outputs](https://platform.openai.com/docs/guides/text)
@@ -2366,6 +2402,12 @@ class AsyncResponses(AsyncAPIResource):
                 in the zero data retention program).
 
           input: Text, image, or file inputs to the model, used to generate a response.
+
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
 
               Learn more:
 
@@ -3362,6 +3404,12 @@ class AsyncResponses(AsyncAPIResource):
               available models.
 
           input: Text, image, or file inputs to the model, used to generate a response
+
+              When passing reasoning items in the input for multi-turn conversations, note
+              that reasoning items must always be immediately followed by their corresponding
+              message item in the input. This constraint applies when
+              [managing conversation state manually](https://platform.openai.com/docs/guides/conversation-state).
+              A reasoning item without its following message item will result in a 400 error.
 
           instructions: A system (or developer) message inserted into the model's context. When used
               along with `previous_response_id`, the instructions from a previous response


### PR DESCRIPTION
Fixes #3009

## Problem
The Responses API has an undocumented constraint where reasoning+message items must appear as consecutive pairs in the `input` array when managing conversation state manually. The most common pattern — filtering `response.output` to keep only messages — silently produces orphaned items, resulting in a 400 error (`Item 'msg_...' of type 'message' was provided without its required preceding item of type 'reasoning'`) on the next turn.

This broke OpenClaw (64.9k forks) on `gpt-5.3-codex`. The issue affects all SDKs (Python, JS, Go, Java, .NET) and is an API-level constraint.

## Solution
Document the reasoning+message pairing constraint in the `input` parameter docstring across all `create`, `parse`, and `compact` method variants (both sync and async). The warning explains that reasoning items must always be immediately followed by their corresponding message item in the input when managing conversation state manually.

## Testing
No code logic was changed — only docstrings. The fix is purely informational to prevent users from hitting this undocumented constraint.
