### PR TITLE
fix(responses): handle null text values in output_text property

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -315,7 +315,7 @@ class Response(BaseModel):
         for output in self.output:
             if output.type == "message":
                 for content in output.content:
-                    if content.type == "output_text":
+                    if content.type == "output_text" and content.text:
                         texts.append(content.text)
 
         return "".join(texts)


### PR DESCRIPTION
## Summary

Fixes #3011

When using the OpenAI Responses API with certain models like `openai/gpt-oss-safeguard-120b`, the response can contain `output_text` content items where the `text` field is null instead of a string. This causes the `output_text` property to raise a `TypeError` when accessed, as it attempts to concatenate None values.

## Changes

Added a null check before appending `content.text` to the texts list:

```python
# Before
if content.type == "output_text":
    texts.append(content.text)

# After  
if content.type == "output_text" and content.text:
    texts.append(content.text)
```

## Testing

The fix ensures that when `text` is null, it is simply skipped rather than causing a `TypeError` during string concatenation.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code follows the project's style guidelines