### PR TITLE
fix(responses): handle null text in output_text

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -315,7 +315,7 @@ class Response(BaseModel):
         for output in self.output:
             if output.type == "message":
                 for content in output.content:
-                    if content.type == "output_text":
+                    if content.type == "output_text" and content.text is not None:
                         texts.append(content.text)
 
         return "".join(texts)

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -41,6 +41,25 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     )
 
 
+@pytest.mark.respx(base_url=base_url)
+@pytest.mark.parametrize("client", [False], indirect=True)  # loose validation
+def test_output_text_ignores_null_content_text(client: OpenAI, respx_mock: MockRouter) -> None:
+    response = make_snapshot_request(
+        lambda c: c.responses.create(
+            model="gpt-4o-mini",
+            input="Say hello",
+        ),
+        content_snapshot=snapshot(
+            '{"id": "resp_3011", "object": "response", "created_at": 1757000000, "status": "completed", "background": false, "error": null, "incomplete_details": null, "instructions": null, "max_output_tokens": null, "max_tool_calls": null, "model": "gpt-4o-mini-2024-07-18", "output": [{"id": "msg_3011", "type": "message", "status": "completed", "content": [{"type": "output_text", "annotations": [], "logprobs": [], "text": null}, {"type": "output_text", "annotations": [], "logprobs": [], "text": "hello"}], "role": "assistant"}], "parallel_tool_calls": true, "previous_response_id": null, "prompt_cache_key": null, "reasoning": {"effort": null, "summary": null}, "safety_identifier": null, "service_tier": "default", "store": true, "temperature": 1.0, "text": {"format": {"type": "text"}, "verbosity": "medium"}, "tool_choice": "auto", "tools": [], "top_logprobs": 0, "top_p": 1.0, "truncation": "disabled", "usage": {"input_tokens": 10, "input_tokens_details": {"cached_tokens": 0}, "output_tokens": 1, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 11}, "user": null, "metadata": {}}'
+        ),
+        path="/responses",
+        mock_client=client,
+        respx_mock=respx_mock,
+    )
+
+    assert response.output_text == "hello"
+
+
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 def test_stream_method_definition_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
     checking_client: OpenAI | AsyncOpenAI = client if sync else async_client

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -60,6 +60,25 @@ def test_output_text_ignores_null_content_text(client: OpenAI, respx_mock: MockR
     assert response.output_text == "hello"
 
 
+@pytest.mark.respx(base_url=base_url)
+@pytest.mark.parametrize("client", [False], indirect=True)  # loose validation
+def test_output_text_ignores_missing_content_text(client: OpenAI, respx_mock: MockRouter) -> None:
+    response = make_snapshot_request(
+        lambda c: c.responses.create(
+            model="gpt-4o-mini",
+            input="Say hello",
+        ),
+        content_snapshot=snapshot(
+            '{"id": "resp_3011_missing", "object": "response", "created_at": 1757000000, "status": "completed", "background": false, "error": null, "incomplete_details": null, "instructions": null, "max_output_tokens": null, "max_tool_calls": null, "model": "gpt-4o-mini-2024-07-18", "output": [{"id": "msg_3011_missing", "type": "message", "status": "completed", "content": [{"type": "output_text", "annotations": [], "logprobs": []}, {"type": "output_text", "annotations": [], "logprobs": [], "text": "hello"}], "role": "assistant"}], "parallel_tool_calls": true, "previous_response_id": null, "prompt_cache_key": null, "reasoning": {"effort": null, "summary": null}, "safety_identifier": null, "service_tier": "default", "store": true, "temperature": 1.0, "text": {"format": {"type": "text"}, "verbosity": "medium"}, "tool_choice": "auto", "tools": [], "top_logprobs": 0, "top_p": 1.0, "truncation": "disabled", "usage": {"input_tokens": 10, "input_tokens_details": {"cached_tokens": 0}, "output_tokens": 1, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 11}, "user": null, "metadata": {}}'
+        ),
+        path="/responses",
+        mock_client=client,
+        respx_mock=respx_mock,
+    )
+
+    assert response.output_text == "hello"
+
+
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 def test_stream_method_definition_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
     checking_client: OpenAI | AsyncOpenAI = client if sync else async_client


### PR DESCRIPTION
Fixes #3011.

## Summary
- skip `output_text` content items whose `text` field is `null` when aggregating `Response.output_text`
- keep the existing concatenation behavior for valid string entries
- add a loose-validation response test that mirrors the API shape from the issue and proves `output_text` now ignores the null item instead of crashing

## Validation
- `.\.venv\Scripts\python -m pytest tests/lib/responses/test_responses.py -k "output_text" -o addopts='' -vv`
- `.\.venv\Scripts\python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `.\.venv\Scripts\python -m ruff format --check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`