### PR TITLE
fix: correct typo "th" to "the" in StreamAlreadyConsumed error message

### DIFF
--- a/src/openai/_response.py
+++ b/src/openai/_response.py
@@ -587,7 +587,7 @@ class StreamAlreadyConsumed(OpenAIError):
     been streamed.
 
     This can happen if you use a method like `.iter_lines()` and then attempt
-    to read th entire response body afterwards, e.g.
+    to read the entire response body afterwards, e.g.
 
     ```py
     response = await client.post(...)


### PR DESCRIPTION
## Summary
- Fixes a typo in the `StreamAlreadyConsumed` error message: "read th entire" → "read the entire"

## Related issue
- N/A (trivial typo fix)

## Guideline alignment
- Reviewed CONTRIBUTING.md
- Single-character fix in error message documentation
- No behavioral changes

## Validation
- N/A (documentation-only change)