### PR TITLE
Make ResponseOutputMessageParam.id optional

### DIFF
--- a/src/openai/types/responses/response_output_message_param.py
+++ b/src/openai/types/responses/response_output_message_param.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Union, Iterable, Optional
-from typing_extensions import Literal, Required, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, TypeAlias, TypedDict, NotRequired
 
 from .response_output_text_param import ResponseOutputTextParam
 from .response_output_refusal_param import ResponseOutputRefusalParam
@@ -16,7 +16,7 @@ Content: TypeAlias = Union[ResponseOutputTextParam, ResponseOutputRefusalParam]
 class ResponseOutputMessageParam(TypedDict, total=False):
     """An output message from the model."""
 
-    id: Required[str]
+    id: NotRequired[str]
     """The unique ID of the output message."""
 
     content: Required[Iterable[Content]]

--- a/tests/test_response_output_message_param.py
+++ b/tests/test_response_output_message_param.py
@@ -1,0 +1,18 @@
+from openai.types.responses import ResponseOutputMessageParam
+
+
+def make_assistant_message() -> ResponseOutputMessageParam:
+    return {
+        "content": [{"annotations": [], "text": "hello", "type": "output_text"}],
+        "role": "assistant",
+        "status": "completed",
+        "type": "message",
+    }
+
+
+def test_response_output_message_param_id_is_optional() -> None:
+    message = make_assistant_message()
+
+    assert "id" not in message
+    assert "id" not in ResponseOutputMessageParam.__required_keys__
+    assert "id" in ResponseOutputMessageParam.__optional_keys__


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- make `ResponseOutputMessageParam.id` optional so assistant messages can be resent without an OpenAI-generated message id
- add a focused regression that checks both the `TypedDict` required/optional key sets and a typed helper that omits `id`

## Additional context & links
- Closes #2501
- Validation:
  - `.venv\\Scripts\\python -m pytest tests/test_response_output_message_param.py -n 0`
  - `.venv\\Scripts\\pyright -p pyproject.toml src\\openai\\types\\responses\\response_output_message_param.py tests\\test_response_output_message_param.py`
  - `.venv\\Scripts\\ruff check src\\openai\\types\\responses\\response_output_message_param.py tests\\test_response_output_message_param.py`