### PR TITLE
fix(streaming): add AsyncStream.aclose()

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -238,6 +238,10 @@ class AsyncStream(Generic[_T]):
         """
         await self.response.aclose()
 
+    async def aclose(self) -> None:
+        """Alias for `close()` to match async cleanup conventions."""
+        await self.close()
+
 
 class ServerSentEvent:
     def __init__(

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -243,6 +243,16 @@ class AsyncStream(Generic[_T]):
         await self.close()
 
 
+async def _aclose_stream(stream: Any) -> None:
+    """Prefer wrapper-level async cleanup before falling back to `.response`."""
+    aclose = getattr(stream, "aclose", None)
+    if callable(aclose):
+        await aclose()
+        return
+
+    await stream.response.aclose()
+
+
 class ServerSentEvent:
     def __init__(
         self,

--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import asyncio
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Callable, Iterable, Iterator, cast
-from typing_extensions import Protocol, Awaitable, AsyncIterable, AsyncIterator, assert_never
+from typing_extensions import Awaitable, AsyncIterable, AsyncIterator, assert_never
 
 import httpx
 
 from ..._utils import is_dict, is_list, consume_sync_iterator, consume_async_iterator
 from ..._compat import model_dump
 from ..._models import construct_type
-from ..._streaming import Stream, AsyncStream
+from ..._streaming import Stream, AsyncStream, _aclose_stream
 from ...types.beta import AssistantStreamEvent
 from ...types.beta.threads import (
     Run,
@@ -486,7 +486,7 @@ class AsyncAssistantEventHandler:
         self.text_deltas = self.__text_deltas__()
         self._iterator = self.__stream__()
         self.__stream: AsyncStream[AssistantStreamEvent] | None = None
-        self.__response: _AsyncCloseable | None = None
+        self.__closeable: Any | None = None
 
     def _init(self, stream: AsyncStream[AssistantStreamEvent]) -> None:
         if self.__stream:
@@ -495,7 +495,7 @@ class AsyncAssistantEventHandler:
             )
 
         self.__stream = stream
-        self.__response = stream.response
+        self.__closeable = stream
 
     async def __anext__(self) -> AssistantStreamEvent:
         return await self._iterator.__anext__()
@@ -510,8 +510,8 @@ class AsyncAssistantEventHandler:
 
         Automatically called when the context manager exits.
         """
-        if self.__response:
-            await self.__response.aclose()
+        if self.__closeable:
+            await _aclose_stream(self.__closeable)
 
     async def aclose(self) -> None:
         """Alias for `close()` to match async cleanup conventions."""
@@ -893,12 +893,7 @@ class AsyncAssistantStreamManager(Generic[AsyncAssistantEventHandlerT]):
         exc_tb: TracebackType | None,
     ) -> None:
         if self.__stream is not None:
-            await self.__stream.response.aclose()
-
-
-class _AsyncCloseable(Protocol):
-    async def aclose(self) -> None: ...
-
+            await _aclose_stream(self.__stream)
 
 def accumulate_run_step(
     *,

--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Callable, Iterable, Iterator, cast
-from typing_extensions import Awaitable, AsyncIterable, AsyncIterator, assert_never
+from typing_extensions import Protocol, Awaitable, AsyncIterable, AsyncIterator, assert_never
 
 import httpx
 
@@ -486,6 +486,7 @@ class AsyncAssistantEventHandler:
         self.text_deltas = self.__text_deltas__()
         self._iterator = self.__stream__()
         self.__stream: AsyncStream[AssistantStreamEvent] | None = None
+        self.__response: _AsyncCloseable | None = None
 
     def _init(self, stream: AsyncStream[AssistantStreamEvent]) -> None:
         if self.__stream:
@@ -494,6 +495,7 @@ class AsyncAssistantEventHandler:
             )
 
         self.__stream = stream
+        self.__response = stream.response
 
     async def __anext__(self) -> AssistantStreamEvent:
         return await self._iterator.__anext__()
@@ -508,8 +510,12 @@ class AsyncAssistantEventHandler:
 
         Automatically called when the context manager exits.
         """
-        if self.__stream:
-            await self.__stream.close()
+        if self.__response:
+            await self.__response.aclose()
+
+    async def aclose(self) -> None:
+        """Alias for `close()` to match async cleanup conventions."""
+        await self.close()
 
     @property
     def current_event(self) -> AssistantStreamEvent | None:
@@ -887,7 +893,11 @@ class AsyncAssistantStreamManager(Generic[AsyncAssistantEventHandlerT]):
         exc_tb: TracebackType | None,
     ) -> None:
         if self.__stream is not None:
-            await self.__stream.close()
+            await self.__stream.response.aclose()
+
+
+class _AsyncCloseable(Protocol):
+    async def aclose(self) -> None: ...
 
 
 def accumulate_run_step(

--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -213,6 +213,10 @@ class AsyncChatCompletionStream(Generic[ResponseFormatT]):
         """
         await self._response.aclose()
 
+    async def aclose(self) -> None:
+        """Alias for `close()` to match async cleanup conventions."""
+        await self.close()
+
     async def get_final_completion(self) -> ParsedChatCompletion[ResponseFormatT]:
         """Waits until the stream has been read to completion and returns
         the accumulated `ParsedChatCompletion` object.

--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -35,7 +35,7 @@ from ..._parsing import (
     get_input_tool_by_name,
     parse_function_tool_arguments,
 )
-from ...._streaming import Stream, AsyncStream
+from ...._streaming import Stream, AsyncStream, _aclose_stream
 from ....types.chat import ChatCompletionChunk, ParsedChatCompletion, ChatCompletionToolUnionParam
 from ...._exceptions import LengthFinishReasonError, ContentFilterFinishReasonError
 from ....types.chat.chat_completion import ChoiceLogprobs
@@ -211,7 +211,7 @@ class AsyncChatCompletionStream(Generic[ResponseFormatT]):
 
         Automatically called if the response body is read to completion.
         """
-        await self._response.aclose()
+        await _aclose_stream(self._raw_stream)
 
     async def aclose(self) -> None:
         """Alias for `close()` to match async cleanup conventions."""

--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -177,6 +177,10 @@ class AsyncResponseStream(Generic[TextFormatT]):
         """
         await self._response.aclose()
 
+    async def aclose(self) -> None:
+        """Alias for `close()` to match async cleanup conventions."""
+        await self.close()
+
     async def get_final_response(self) -> ParsedResponse[TextFormatT]:
         """Waits until the stream has been read to completion and returns
         the accumulated `ParsedResponse` object.

--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -16,7 +16,7 @@ from ._events import (
 from ...._types import Omit, omit
 from ...._utils import is_given, consume_sync_iterator, consume_async_iterator
 from ...._models import build, construct_type_unchecked
-from ...._streaming import Stream, AsyncStream
+from ...._streaming import Stream, AsyncStream, _aclose_stream
 from ....types.responses import ParsedResponse, ResponseStreamEvent as RawResponseStreamEvent
 from ..._parsing._responses import TextFormatT, parse_text, parse_response
 from ....types.responses.tool_param import ToolParam
@@ -175,7 +175,7 @@ class AsyncResponseStream(Generic[TextFormatT]):
 
         Automatically called if the response body is read to completion.
         """
-        await self._response.aclose()
+        await _aclose_stream(self._raw_stream)
 
     async def aclose(self) -> None:
         """Alias for `close()` to match async cleanup conventions."""

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -8,7 +8,7 @@ import pytest
 from openai import OpenAI, AsyncOpenAI
 from openai._types import omit
 from openai._streaming import Stream, AsyncStream, ServerSentEvent
-from openai.lib.streaming import AsyncAssistantEventHandler
+from openai.lib.streaming import AsyncAssistantEventHandler, AsyncAssistantStreamManager
 from openai.lib.streaming.chat import AsyncChatCompletionStream
 from openai.lib.streaming.responses import AsyncResponseStream
 
@@ -223,24 +223,27 @@ async def test_multi_byte_character_multiple_chunks(
 @pytest.mark.asyncio
 async def test_async_chat_completion_stream_close_accepts_wrapped_async_stream(async_client: AsyncOpenAI) -> None:
     raw_stream = make_async_stream(async_client)
+    wrapped_stream = WrappedAsyncStream(raw_stream)
 
     stream = AsyncChatCompletionStream(
-        raw_stream=cast(Any, WrappedAsyncStream(raw_stream)),
+        raw_stream=cast(Any, wrapped_stream),
         response_format=omit,
         input_tools=omit,
     )
 
     await stream.aclose()
 
+    assert wrapped_stream.aclose_calls == 1
     assert raw_stream.response.is_closed is True
 
 
 @pytest.mark.asyncio
 async def test_async_response_stream_aclose_accepts_wrapped_async_stream(async_client: AsyncOpenAI) -> None:
     raw_stream = make_async_stream(async_client)
+    wrapped_stream = WrappedAsyncStream(raw_stream)
 
     stream = AsyncResponseStream(
-        raw_stream=cast(Any, WrappedAsyncStream(raw_stream)),
+        raw_stream=cast(Any, wrapped_stream),
         text_format=omit,
         input_tools=omit,
         starting_after=None,
@@ -248,6 +251,7 @@ async def test_async_response_stream_aclose_accepts_wrapped_async_stream(async_c
 
     await stream.aclose()
 
+    assert wrapped_stream.aclose_calls == 1
     assert raw_stream.response.is_closed is True
 
 
@@ -257,11 +261,31 @@ async def test_async_assistant_event_handler_close_accepts_wrapped_async_stream(
     async_client: AsyncOpenAI, close_method: str
 ) -> None:
     raw_stream = make_async_stream(async_client)
+    wrapped_stream = WrappedAsyncStream(raw_stream)
     handler = AsyncAssistantEventHandler()
-    handler._init(cast(Any, WrappedAsyncStream(raw_stream)))
+    handler._init(cast(Any, wrapped_stream))
 
     await cast(Any, getattr(handler, close_method))()
 
+    assert wrapped_stream.aclose_calls == 1
+    assert raw_stream.response.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_assistant_stream_manager_close_accepts_wrapped_async_stream(async_client: AsyncOpenAI) -> None:
+    raw_stream = make_async_stream(async_client)
+    wrapped_stream = WrappedAsyncStream(raw_stream)
+
+    async def api_request() -> AsyncStream[object]:
+        return cast(Any, wrapped_stream)
+
+    async with AsyncAssistantStreamManager(
+        api_request=cast(Any, api_request()),
+        event_handler=AsyncAssistantEventHandler(),
+    ):
+        pass
+
+    assert wrapped_stream.aclose_calls == 1
     assert raw_stream.response.is_closed is True
 
 
@@ -277,12 +301,17 @@ class WrappedAsyncStream:
     def __init__(self, stream: AsyncStream[object]) -> None:
         self._stream = stream
         self.response = stream
+        self.aclose_calls = 0
 
     def __aiter__(self) -> AsyncIterator[object]:
         return self._stream.__aiter__()
 
     async def __anext__(self) -> object:
         return await self._stream.__anext__()
+
+    async def aclose(self) -> None:
+        self.aclose_calls += 1
+        await self._stream.aclose()
 
 
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import Iterator, AsyncIterator
+from typing import Any, Iterator, AsyncIterator, cast
 
 import httpx
 import pytest
 
 from openai import OpenAI, AsyncOpenAI
+from openai._types import omit
 from openai._streaming import Stream, AsyncStream, ServerSentEvent
+from openai.lib.streaming.chat import AsyncChatCompletionStream
 
 
 @pytest.mark.asyncio
@@ -214,6 +216,36 @@ async def test_multi_byte_character_multiple_chunks(
     sse = await iter_next(iterator)
     assert sse.event is None
     assert sse.json() == {"content": "известни"}
+
+
+@pytest.mark.asyncio
+async def test_async_chat_completion_stream_close_accepts_wrapped_async_stream(async_client: AsyncOpenAI) -> None:
+    raw_stream = AsyncStream(
+        cast_to=object,
+        client=async_client,
+        response=httpx.Response(200, content=to_aiter(iter(()))),
+    )
+
+    class WrappedAsyncStream:
+        def __init__(self, stream: AsyncStream[object]) -> None:
+            self._stream = stream
+            self.response = stream
+
+        def __aiter__(self) -> AsyncIterator[object]:
+            return self._stream.__aiter__()
+
+        async def __anext__(self) -> object:
+            return await self._stream.__anext__()
+
+    stream = AsyncChatCompletionStream(
+        raw_stream=cast(Any, WrappedAsyncStream(raw_stream)),
+        response_format=omit,
+        input_tools=omit,
+    )
+
+    await stream.close()
+
+    assert raw_stream.response.is_closed is True
 
 
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -8,7 +8,9 @@ import pytest
 from openai import OpenAI, AsyncOpenAI
 from openai._types import omit
 from openai._streaming import Stream, AsyncStream, ServerSentEvent
+from openai.lib.streaming import AsyncAssistantEventHandler
 from openai.lib.streaming.chat import AsyncChatCompletionStream
+from openai.lib.streaming.responses import AsyncResponseStream
 
 
 @pytest.mark.asyncio
@@ -220,22 +222,7 @@ async def test_multi_byte_character_multiple_chunks(
 
 @pytest.mark.asyncio
 async def test_async_chat_completion_stream_close_accepts_wrapped_async_stream(async_client: AsyncOpenAI) -> None:
-    raw_stream = AsyncStream(
-        cast_to=object,
-        client=async_client,
-        response=httpx.Response(200, content=to_aiter(iter(()))),
-    )
-
-    class WrappedAsyncStream:
-        def __init__(self, stream: AsyncStream[object]) -> None:
-            self._stream = stream
-            self.response = stream
-
-        def __aiter__(self) -> AsyncIterator[object]:
-            return self._stream.__aiter__()
-
-        async def __anext__(self) -> object:
-            return await self._stream.__anext__()
+    raw_stream = make_async_stream(async_client)
 
     stream = AsyncChatCompletionStream(
         raw_stream=cast(Any, WrappedAsyncStream(raw_stream)),
@@ -243,9 +230,59 @@ async def test_async_chat_completion_stream_close_accepts_wrapped_async_stream(a
         input_tools=omit,
     )
 
-    await stream.close()
+    await stream.aclose()
 
     assert raw_stream.response.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_async_response_stream_aclose_accepts_wrapped_async_stream(async_client: AsyncOpenAI) -> None:
+    raw_stream = make_async_stream(async_client)
+
+    stream = AsyncResponseStream(
+        raw_stream=cast(Any, WrappedAsyncStream(raw_stream)),
+        text_format=omit,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    await stream.aclose()
+
+    assert raw_stream.response.is_closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close_method", ["close", "aclose"])
+async def test_async_assistant_event_handler_close_accepts_wrapped_async_stream(
+    async_client: AsyncOpenAI, close_method: str
+) -> None:
+    raw_stream = make_async_stream(async_client)
+    handler = AsyncAssistantEventHandler()
+    handler._init(cast(Any, WrappedAsyncStream(raw_stream)))
+
+    await cast(Any, getattr(handler, close_method))()
+
+    assert raw_stream.response.is_closed is True
+
+
+def make_async_stream(async_client: AsyncOpenAI) -> AsyncStream[object]:
+    return AsyncStream(
+        cast_to=object,
+        client=async_client,
+        response=httpx.Response(200, content=to_aiter(iter(()))),
+    )
+
+
+class WrappedAsyncStream:
+    def __init__(self, stream: AsyncStream[object]) -> None:
+        self._stream = stream
+        self.response = stream
+
+    def __aiter__(self) -> AsyncIterator[object]:
+        return self._stream.__aiter__()
+
+    async def __anext__(self) -> object:
+        return await self._stream.__anext__()
 
 
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:


### PR DESCRIPTION
## Summary
- add `AsyncStream.aclose()` as an alias for `close()` so wrapped async stream cleanup paths can await the stream directly
- add a regression covering `AsyncChatCompletionStream.close()` when an instrumentation wrapper exposes an `AsyncStream` through `.response`

## Testing
- `PYTHONPATH=src python -m pytest -o addopts='' tests/test_streaming.py -q`
- `PYTHONPATH=src python -m ruff check src/openai/_streaming.py tests/test_streaming.py`

Closes #2853.