### PR TITLE
fix: make image generation input params optional

### DIFF
--- a/src/openai/types/responses/response_input_item_param.py
+++ b/src/openai/types/responses/response_input_item_param.py
@@ -176,10 +176,10 @@ class ImageGenerationCall(TypedDict, total=False):
     id: Required[str]
     """The unique ID of the image generation call."""
 
-    result: Required[Optional[str]]
+    result: Optional[str]
     """The generated image encoded in base64."""
 
-    status: Required[Literal["in_progress", "completed", "generating", "failed"]]
+    status: Literal["in_progress", "completed", "generating", "failed"]
     """The status of the image generation call."""
 
     type: Required[Literal["image_generation_call"]]

--- a/src/openai/types/responses/response_input_param.py
+++ b/src/openai/types/responses/response_input_param.py
@@ -177,10 +177,10 @@ class ImageGenerationCall(TypedDict, total=False):
     id: Required[str]
     """The unique ID of the image generation call."""
 
-    result: Required[Optional[str]]
+    result: Optional[str]
     """The generated image encoded in base64."""
 
-    status: Required[Literal["in_progress", "completed", "generating", "failed"]]
+    status: Literal["in_progress", "completed", "generating", "failed"]
     """The status of the image generation call."""
 
     type: Required[Literal["image_generation_call"]]

--- a/tests/lib/responses/test_image_generation_call_input_param_types.py
+++ b/tests/lib/responses/test_image_generation_call_input_param_types.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing_extensions import assert_type
 
+from openai._utils import maybe_transform
 from openai.types.responses.response_input_param import ImageGenerationCall as ImageGenerationCallParam
+from openai.types.responses.response_create_params import ResponseCreateParamsNonStreaming
 from openai.types.responses.response_input_item_param import ImageGenerationCall as ImageGenerationCallItemParam
 
 
@@ -22,3 +24,18 @@ def test_image_generation_call_input_params_can_omit_result_and_status() -> None
     assert "status" in ImageGenerationCallParam.__optional_keys__
     assert_type(input_item["id"], str)
     assert_type(input_param["id"], str)
+
+
+def test_image_generation_call_input_params_transform_without_result_and_status() -> None:
+    payload = maybe_transform(
+        {
+            "model": "gpt-4.1-mini",
+            "input": [{"id": "ig_123", "type": "image_generation_call"}],
+        },
+        ResponseCreateParamsNonStreaming,
+    )
+
+    assert payload == {
+        "model": "gpt-4.1-mini",
+        "input": [{"id": "ig_123", "type": "image_generation_call"}],
+    }

--- a/tests/lib/responses/test_image_generation_call_input_param_types.py
+++ b/tests/lib/responses/test_image_generation_call_input_param_types.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing_extensions import assert_type
+
+from openai.types.responses.response_input_param import ImageGenerationCall as ImageGenerationCallParam
+from openai.types.responses.response_input_item_param import ImageGenerationCall as ImageGenerationCallItemParam
+
+
+def test_image_generation_call_input_params_can_omit_result_and_status() -> None:
+    input_item: ImageGenerationCallItemParam = {"id": "ig_123", "type": "image_generation_call"}
+    input_param: ImageGenerationCallParam = {"id": "ig_456", "type": "image_generation_call"}
+
+    assert input_item == {"id": "ig_123", "type": "image_generation_call"}
+    assert input_param == {"id": "ig_456", "type": "image_generation_call"}
+    assert "result" not in ImageGenerationCallItemParam.__required_keys__
+    assert "status" not in ImageGenerationCallItemParam.__required_keys__
+    assert "result" in ImageGenerationCallItemParam.__optional_keys__
+    assert "status" in ImageGenerationCallItemParam.__optional_keys__
+    assert "result" not in ImageGenerationCallParam.__required_keys__
+    assert "status" not in ImageGenerationCallParam.__required_keys__
+    assert "result" in ImageGenerationCallParam.__optional_keys__
+    assert "status" in ImageGenerationCallParam.__optional_keys__
+    assert_type(input_item["id"], str)
+    assert_type(input_param["id"], str)


### PR DESCRIPTION
## Summary
- make the Responses ImageGenerationCall input TypedDicts treat esult and status as optional keys
- add a focused regression test covering the TypedDict required/optional key sets

Closes #2648.

## Validation
- python -m pytest -o addopts='' tests/lib/responses/test_image_generation_call_input_param_types.py -q
- python -m ruff check src/openai/types/responses/response_input_item_param.py src/openai/types/responses/response_input_param.py tests/lib/responses/test_image_generation_call_input_param_types.py
- git diff --check