### PR TITLE
Add a safe follow-up input helper for Responses output

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Any, List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -23,6 +23,7 @@ from .response_text_config import ResponseTextConfig
 from .tool_choice_function import ToolChoiceFunction
 from ..shared.responses_model import ResponsesModel
 from .tool_choice_apply_patch import ToolChoiceApplyPatch
+from .response_input_item_param import ResponseInputItemParam
 
 __all__ = ["Response", "IncompleteDetails", "ToolChoice", "Conversation"]
 
@@ -319,3 +320,16 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    @property
+    def output_as_input(self) -> List[ResponseInputItemParam]:
+        """Convenience property that converts `output` items into follow-up `input` items.
+
+        This omits unset and `None` fields so the returned items can be passed back
+        to `responses.create(..., input=...)` for a subsequent turn.
+        """
+
+        return [
+            cast(ResponseInputItemParam, output.to_dict(mode="json", exclude_none=True))
+            for output in cast(List[Any], self.output)
+        ]

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import cast
 from typing_extensions import TypeVar
 
 import pytest
@@ -8,6 +9,7 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response, ResponseReasoningItem
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +41,69 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_output_as_input_omits_null_only_response_fields() -> None:
+    response = Response.construct(
+        id="resp_123",
+        created_at=1754925861,
+        model="o4-mini",
+        object="response",
+        output=[
+            {
+                "id": "rs_123",
+                "summary": [{"text": "Reasoning summary", "type": "summary_text"}],
+                "type": "reasoning",
+            },
+            {
+                "id": "msg_123",
+                "type": "message",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "annotations": [],
+                        "text": "Paris.",
+                    }
+                ],
+                "role": "assistant",
+            },
+        ],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    reasoning_item = cast(ResponseReasoningItem, response.output[0])
+    assert reasoning_item.model_dump() == {
+        "id": "rs_123",
+        "summary": [{"text": "Reasoning summary", "type": "summary_text"}],
+        "type": "reasoning",
+        "content": None,
+        "encrypted_content": None,
+        "status": None,
+    }
+
+    assert response.output_as_input == [
+        {
+            "id": "rs_123",
+            "summary": [{"text": "Reasoning summary", "type": "summary_text"}],
+            "type": "reasoning",
+        },
+        {
+            "id": "msg_123",
+            "type": "message",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "Paris.",
+                }
+            ],
+            "role": "assistant",
+        },
+    ]
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
- add `Response.output_as_input` to convert `response.output` into safe follow-up `input` items
- omit unset and `None` fields so reasoning items no longer serialize invalid null-only fields on turn 2
- add a regression test covering the exact reasoning-plus-message shape from #3008

## Validation
- `python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `python -m py_compile src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- direct `PYTHONPATH=src` Python assertions for the new helper and regression payload shape

Closes #3008.