### PR TITLE
Add Response.as_input() helper for stateless follow-ups

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -23,6 +23,7 @@ from .response_text_config import ResponseTextConfig
 from .tool_choice_function import ToolChoiceFunction
 from ..shared.responses_model import ResponsesModel
 from .tool_choice_apply_patch import ToolChoiceApplyPatch
+from .response_input_item_param import ResponseInputItemParam
 
 __all__ = ["Response", "IncompleteDetails", "ToolChoice", "Conversation"]
 
@@ -319,3 +320,12 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    def as_input(self) -> List[ResponseInputItemParam]:
+        """Convert `output` items into valid `input` items for a subsequent response.
+
+        This is useful when manually managing conversation state with the Responses
+        API. The returned items use API field names and omit `None` values that are
+        present on response models but rejected by the input schema.
+        """
+        return [cast(ResponseInputItemParam, output.to_dict(exclude_none=True)) for output in self.output]

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -8,6 +8,7 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +40,87 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_as_input_strips_response_only_none_fields() -> None:
+    response = Response.construct(
+        id="resp_123",
+        created_at=1754925861,
+        model="gpt-4o-mini-2024-07-18",
+        object="response",
+        output=[
+            {
+                "id": "rs_123",
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "thinking"}],
+                "content": None,
+                "encrypted_content": None,
+                "status": "completed",
+            },
+            {
+                "id": "msg_123",
+                "type": "message",
+                "status": "completed",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "annotations": [],
+                        "logprobs": [],
+                        "text": "Hello",
+                    }
+                ],
+                "phase": None,
+            },
+            {
+                "id": "fc_123",
+                "type": "function_call",
+                "call_id": "call_123",
+                "name": "tool_name",
+                "arguments": "{}",
+                "namespace": None,
+                "status": "completed",
+            },
+        ],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    assert response.output[0].model_dump(by_alias=True)["content"] is None
+    assert response.output[1].model_dump(by_alias=True)["phase"] is None
+    assert response.output[2].model_dump(by_alias=True)["namespace"] is None
+
+    assert response.as_input() == [
+        {
+            "id": "rs_123",
+            "summary": [{"text": "thinking", "type": "summary_text"}],
+            "type": "reasoning",
+            "status": "completed",
+        },
+        {
+            "id": "msg_123",
+            "content": [
+                {
+                    "annotations": [],
+                    "text": "Hello",
+                    "type": "output_text",
+                    "logprobs": [],
+                }
+            ],
+            "role": "assistant",
+            "status": "completed",
+            "type": "message",
+        },
+        {
+            "arguments": "{}",
+            "call_id": "call_123",
+            "name": "tool_name",
+            "type": "function_call",
+            "id": "fc_123",
+            "status": "completed",
+        },
+    ]
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
- add `Response.as_input()` to convert `response.output` into valid follow-up `input` items
- serialize with API field names while dropping `None` response-only fields that the input schema rejects
- add a focused regression covering reasoning, assistant message, and function-call output items

Fixes #3008.

## Validation
- `PYTHONPATH=src python -m pytest -o addopts="" tests/lib/responses/test_responses.py -q`
- `python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `git diff --check`