### PR TITLE
Add helper to reuse response.output as follow-up input

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -23,6 +23,7 @@ from .response_text_config import ResponseTextConfig
 from .tool_choice_function import ToolChoiceFunction
 from ..shared.responses_model import ResponsesModel
 from .tool_choice_apply_patch import ToolChoiceApplyPatch
+from .response_input_item_param import ResponseInputItemParam
 
 __all__ = ["Response", "IncompleteDetails", "ToolChoice", "Conversation"]
 
@@ -319,3 +320,17 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    def output_as_input(self) -> List[ResponseInputItemParam]:
+        """Serialize `output` items into valid follow-up `input` items.
+
+        This is useful when you are manually managing conversation state instead of
+        passing `previous_response_id`. It preserves API field names, omits fields
+        that were not set by the API, and strips `None` values that the API would
+        reject on subsequent `responses.create()` calls.
+        """
+
+        return cast(
+            List[ResponseInputItemParam],
+            [item.to_dict(mode="json", exclude_none=True) for item in self.output],
+        )

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -8,6 +8,8 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai._compat import parse_obj
+from openai.types.responses import Response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +41,79 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_output_as_input() -> None:
+    response = parse_obj(
+        Response,
+        {
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 1,
+            "model": "o4-mini",
+            "output": [
+                {
+                    "id": "rs_123",
+                    "type": "reasoning",
+                    "summary": [
+                        {
+                            "text": "The previous answer established the capital of France.",
+                            "type": "summary_text",
+                        }
+                    ],
+                },
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Paris.",
+                            "annotations": [],
+                        }
+                    ],
+                },
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        },
+    )
+
+    reasoning_dump = response.output[0].model_dump()
+    assert reasoning_dump["content"] is None
+    assert reasoning_dump["encrypted_content"] is None
+    assert reasoning_dump["status"] is None
+
+    assert response.output_as_input() == [
+        {
+            "id": "rs_123",
+            "type": "reasoning",
+            "summary": [
+                {
+                    "text": "The previous answer established the capital of France.",
+                    "type": "summary_text",
+                }
+            ],
+        },
+        {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "phase": "final_answer",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Paris.",
+                    "annotations": [],
+                }
+            ],
+        },
+    ]
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
- add `Response.output_as_input()` to serialize `response.output` into follow-up `input` items with API field names and `None` values stripped
- keep `model_dump()` behavior unchanged while giving manual conversation-state users a safe round-trip helper
- add a regression covering the reasoning item shape that currently fabricates `None` fields under `model_dump()`

## Testing
- `python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `$env:PYTHONPATH=''src''; python -m pytest -o addopts="" tests/lib/responses/test_responses.py -q -k output_as_input`

Closes #3008.