### PR TITLE
Add Response.output_as_input for multi-turn follow-ups

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -18,6 +18,7 @@ from .tool_choice_custom import ToolChoiceCustom
 from .response_input_item import ResponseInputItem
 from .tool_choice_allowed import ToolChoiceAllowed
 from .tool_choice_options import ToolChoiceOptions
+from .response_input_param import ResponseInputParam
 from .response_output_item import ResponseOutputItem
 from .response_text_config import ResponseTextConfig
 from .tool_choice_function import ToolChoiceFunction
@@ -319,3 +320,16 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    @property
+    def output_as_input(self) -> ResponseInputParam:
+        """Convenience property that turns `output` into safe follow-up `input` items.
+
+        The returned items are JSON-serializable and omit `None`-valued fields so
+        they can be passed directly to `client.responses.create(input=...)` for
+        manual multi-turn conversation state.
+        """
+        return cast(
+            ResponseInputParam,
+            [output.to_dict(mode="json", exclude_none=True) for output in self.output],
+        )

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -8,6 +8,8 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai._compat import parse_obj
+from openai.types.responses import Response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +41,68 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_output_as_input() -> None:
+    response = parse_obj(
+        Response,
+        {
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "model": "gpt-4.1",
+            "output": [
+                {
+                    "id": "rs_123",
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Paris"}],
+                    "content": None,
+                    "encrypted_content": None,
+                    "status": None,
+                },
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "phase": None,
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "annotations": [],
+                            "logprobs": [],
+                            "text": "Paris",
+                        }
+                    ],
+                },
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        },
+    )
+
+    assert response.output_as_input == [
+        {
+            "id": "rs_123",
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Paris"}],
+        },
+        {
+            "id": "msg_123",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "logprobs": [],
+                    "text": "Paris",
+                }
+            ],
+        },
+    ]
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
- add `Response.output_as_input` as a convenience for feeding a prior response's `output` back into `client.responses.create(input=...)`
- serialize each output item with `exclude_none=True` so optional null fields don't get sent back on manual follow-up turns
- add a focused regression covering reasoning and assistant message items

Closes #3008.

## Testing
- `PYTHONPATH=src python -m pytest -o addopts="" tests/lib/responses/test_responses.py -q`
- `python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `git diff --check`