### PR TITLE
fix: add Responses follow-up input helper

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -18,6 +18,7 @@ from .tool_choice_custom import ToolChoiceCustom
 from .response_input_item import ResponseInputItem
 from .tool_choice_allowed import ToolChoiceAllowed
 from .tool_choice_options import ToolChoiceOptions
+from .response_input_param import ResponseInputParam, ResponseInputItemParam
 from .response_output_item import ResponseOutputItem
 from .response_text_config import ResponseTextConfig
 from .tool_choice_function import ToolChoiceFunction
@@ -319,3 +320,11 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    def output_as_input(self) -> ResponseInputParam:
+        """Convert `output` into a valid `input` payload for a follow-up response request.
+
+        This preserves the API response field names while dropping unset and `None`
+        values that should not be echoed back to `/responses`.
+        """
+        return [cast(ResponseInputItemParam, item.to_dict(mode="json", exclude_none=True)) for item in self.output]

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -7,7 +7,9 @@ from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
-from openai._utils import assert_signatures_in_sync
+from openai._utils import maybe_transform, assert_signatures_in_sync
+from openai.types.responses import Response, ResponseOutputText, ResponseOutputMessage, ResponseReasoningItem
+from openai.types.responses.response_create_params import ResponseCreateParamsNonStreaming
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -61,3 +63,57 @@ def test_parse_method_definition_in_sync(sync: bool, client: OpenAI, async_clien
         checking_client.responses.parse,
         exclude_params={"tools"},
     )
+
+
+def test_output_as_input_excludes_response_only_none_fields() -> None:
+    response = Response.construct(
+        output=[
+            ResponseReasoningItem.construct(
+                id="rs_123",
+                type="reasoning",
+                summary=[{"text": "Summarized reasoning", "type": "summary_text"}],
+            ),
+            ResponseOutputMessage.construct(
+                id="msg_123",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    ResponseOutputText.construct(
+                        annotations=[],
+                        text="Paris",
+                        type="output_text",
+                    )
+                ],
+            ),
+        ]
+    )
+
+    assert response.output[0].model_dump()["status"] is None
+    assert response.output[0].model_dump()["encrypted_content"] is None
+    assert response.output[1].model_dump()["phase"] is None
+    assert response.output[1].content[0].model_dump()["logprobs"] is None
+
+    input_items = response.output_as_input()
+    request_body = maybe_transform(
+        {"model": "o4-mini", "input": input_items},
+        ResponseCreateParamsNonStreaming,
+    )
+
+    expected_input = [
+        {
+            "id": "rs_123",
+            "type": "reasoning",
+            "summary": [{"text": "Summarized reasoning", "type": "summary_text"}],
+        },
+        {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [{"annotations": [], "text": "Paris", "type": "output_text"}],
+        },
+    ]
+
+    assert input_items == expected_input
+    assert request_body == {"model": "o4-mini", "input": expected_input}


### PR DESCRIPTION
## Summary
- add `Response.output_as_input()` to convert parsed `response.output` items into a follow-up `input` payload
- drop unset and `None` response-only fields so `/responses` does not receive fabricated `status`, `encrypted_content`, `phase`, or `logprobs` entries
- add a regression that covers the reasoning-plus-message follow-up shape from the issue

Fixes the null-field serialization portion of #3008.
The separate reasoning/message pairing constraint is still tracked in #3009.

## Testing
- `python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `$env:PYTHONPATH=''src''; python -m pytest -o addopts="" tests/lib/responses/test_responses.py -q`