### PR TITLE
Add helpers for reusing Responses output as input

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -209,6 +209,21 @@ class BaseModel(pydantic.BaseModel):
             warnings=warnings,
         )
 
+    def as_input(self) -> dict[str, object]:
+        """Generate a JSON-safe representation suitable for reusing this model as API input.
+
+        This excludes fields that were not set by the API, omits `None` values that
+        can be invalid when echoed back to the API, and respects SDK-only helper
+        fields marked via `__api_exclude__`.
+        """
+        return self.model_dump(
+            mode="json",
+            by_alias=True,
+            exclude_unset=True,
+            exclude_none=True,
+            exclude=getattr(self, "__api_exclude__", None),
+        )
+
     @override
     def __str__(self) -> str:
         # mypy complains about an invalid self arg

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -23,6 +23,7 @@ from .response_text_config import ResponseTextConfig
 from .tool_choice_function import ToolChoiceFunction
 from ..shared.responses_model import ResponsesModel
 from .tool_choice_apply_patch import ToolChoiceApplyPatch
+from .response_input_item_param import ResponseInputItemParam
 
 __all__ = ["Response", "IncompleteDetails", "ToolChoice", "Conversation"]
 
@@ -319,3 +320,12 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    @property
+    def output_as_input(self) -> List[ResponseInputItemParam]:
+        """Convenience property that converts `output` into follow-up input items.
+
+        This preserves the original output ordering while omitting unset and `None`
+        fields that can be invalid when echoed back to the API.
+        """
+        return [cast(ResponseInputItemParam, item.as_input()) for item in self.output]

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import json
 from typing_extensions import TypeVar
 
+import httpx
 import pytest
 from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai._models import construct_type_unchecked
+from openai.types.responses.response import Response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +43,94 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_output_as_input_omits_null_response_fields(client: OpenAI, respx_mock: MockRouter) -> None:
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp_turn_1",
+            "object": "response",
+            "created_at": 0,
+            "model": "o4-mini",
+            "output": [
+                {
+                    "id": "rs_123",
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "Reasoning summary"}],
+                },
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "annotations": [],
+                            "logprobs": [],
+                            "text": "Paris",
+                        }
+                    ],
+                },
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        },
+    )
+
+    expected_input = [
+        {
+            "id": "rs_123",
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Reasoning summary"}],
+        },
+        {
+            "id": "msg_123",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "logprobs": [],
+                    "text": "Paris",
+                }
+            ],
+        },
+    ]
+
+    assert response.output[0].as_input() == expected_input[0]
+    assert response.output[1].as_input() == expected_input[1]
+    assert response.output_as_input == expected_input
+
+    captured_request_body: dict[str, object] = {}
+
+    def capture_request(request: httpx.Request) -> httpx.Response:
+        nonlocal captured_request_body
+        captured_request_body = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_turn_2",
+                "object": "response",
+                "created_at": 1,
+                "model": "o4-mini",
+                "output": [],
+                "parallel_tool_calls": True,
+                "tool_choice": "auto",
+                "tools": [],
+            },
+        )
+
+    respx_mock.post("/responses").mock(side_effect=capture_request)
+
+    client.responses.create(model="o4-mini", input=response.output_as_input)
+
+    assert captured_request_body["input"] == expected_input
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
Fixes #3008.

## Summary
- add `BaseModel.as_input()` to serialize SDK models for request reuse with unset and `None` fields removed
- add `Response.output_as_input` to convert `response.output` into follow-up `input` items
- add a regression covering the manual two-turn Responses flow and the emitted `/responses` request body

## Testing
- `PYTHONPATH=src python -m pytest -o addopts="" tests/lib/responses/test_responses.py -q`
- `PYTHONPATH=src python -m ruff check src/openai/_models.py src/openai/types/responses/response.py tests/lib/responses/test_responses.py`