### PR TITLE
docs: fix incorrect API path in nested params example

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ from openai import OpenAI
 
 client = OpenAI()
 
-response = client.chat.responses.create(
+response = client.responses.create(
     input=[
         {
             "role": "user",


### PR DESCRIPTION
## Description

This PR fixes an incorrect API path in the README's "Nested params" example section.

## Changes

- Changed `client.chat.responses.create` to `client.responses.create`

## Why

The Responses API is accessed via `client.responses`, not `client.chat.responses`. The `chat` namespace only contains `completions` (i.e., `client.chat.completions.create`).

This is evident from:
1. All other Responses API examples in the README correctly use `client.responses.create`
2. The Chat Completions API examples use `client.chat.completions.create`
3. The `src/openai/resources/chat/` module only exports `completions`, not `responses`

## Testing

Visual inspection of the README change. The corrected path matches the documented API structure.