### PR TITLE
Add Response.output_as_input helper for manual replay

### DIFF
--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import TYPE_CHECKING, List, Union, Optional, cast
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -25,6 +25,9 @@ from ..shared.responses_model import ResponsesModel
 from .tool_choice_apply_patch import ToolChoiceApplyPatch
 
 __all__ = ["Response", "IncompleteDetails", "ToolChoice", "Conversation"]
+
+if TYPE_CHECKING:
+    from .response_input_item_param import ResponseInputItemParam
 
 
 class IncompleteDetails(BaseModel):
@@ -319,3 +322,15 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    @property
+    def output_as_input(self) -> List["ResponseInputItemParam"]:
+        """Convenience property that serializes `output` items into valid `input` items.
+
+        This is useful when manually managing conversation state with
+        `responses.create()` and resending a prior response's `output`.
+        """
+        return [
+            cast("ResponseInputItemParam", item.to_dict(mode="json", exclude_none=True))
+            for item in self.output
+        ]

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -8,6 +8,7 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +40,61 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_output_as_input() -> None:
+    response = Response.construct(
+        id="resp_123",
+        created_at=0.0,
+        model="o4-mini",
+        object="response",
+        output=[
+            {
+                "id": "rs_123",
+                "type": "reasoning",
+                "summary": [],
+            },
+            {
+                "id": "msg_123",
+                "type": "message",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "annotations": [],
+                        "logprobs": [],
+                        "text": "Paris",
+                    }
+                ],
+                "role": "assistant",
+            },
+        ],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    assert response.output_as_input == [
+        {
+            "id": "rs_123",
+            "type": "reasoning",
+            "summary": [],
+        },
+        {
+            "id": "msg_123",
+            "type": "message",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "logprobs": [],
+                    "text": "Paris",
+                }
+            ],
+            "role": "assistant",
+        },
+    ]
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
- add `Response.output_as_input` to serialize `response.output` into valid `responses.create(input=...)` items
- strip null-only response fields by reusing `to_dict(mode="json", exclude_none=True)` on each output item
- add a focused regression covering reasoning + assistant message replay

## Validation
- `PYTHONPATH=src python -m pytest -o addopts="" tests/lib/responses/test_responses.py::test_output_as_input -q`
- `PYTHONPATH=src python -m pytest -o addopts="" tests/lib/responses/test_responses.py::test_output_text -q`
- `python -m ruff check src/openai/types/responses/response.py tests/lib/responses/test_responses.py`
- `git diff --check`

Fixes #3008.