### PR TITLE
feat: add request/response body logging at DEBUG level

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1000,6 +1000,10 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
 
             log.debug("Sending HTTP Request: %s %s", request.method, request.url)
 
+            if log.isEnabledFor(logging.DEBUG):
+                if request.content:
+                    log.debug("Request body: %s", request.content.decode("utf-8", errors="replace"))
+
             response = None
             try:
                 response = self._client.send(
@@ -1045,6 +1049,10 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
                 response.headers,
             )
             log.debug("request_id: %s", response.headers.get("x-request-id"))
+
+            if log.isEnabledFor(logging.DEBUG):
+                if not stream and not self._should_stream_response_body(request=request):
+                    log.debug("Response body: %s", response.text)
 
             try:
                 response.raise_for_status()
@@ -1599,6 +1607,10 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
 
             log.debug("Sending HTTP Request: %s %s", request.method, request.url)
 
+            if log.isEnabledFor(logging.DEBUG):
+                if request.content:
+                    log.debug("Request body: %s", request.content.decode("utf-8", errors="replace"))
+
             response = None
             try:
                 response = await self._client.send(
@@ -1644,6 +1656,10 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
                 response.headers,
             )
             log.debug("request_id: %s", response.headers.get("x-request-id"))
+
+            if log.isEnabledFor(logging.DEBUG):
+                if not stream and not self._should_stream_response_body(request=request):
+                    log.debug("Response body: %s", response.text)
 
             try:
                 response.raise_for_status()


### PR DESCRIPTION
## Summary

Adds optional logging of HTTP request and response bodies at DEBUG level to aid debugging, addressing #1522.

- Logs request body before sending and response body after receiving
- Gated behind `log.isEnabledFor(logging.DEBUG)` to avoid performance impact when not enabled
- Skips response body logging for streaming responses to prevent reading the stream prematurely
- Applied to both sync (`SyncAPIClient`) and async (`AsyncAPIClient`) code paths

## Usage

```python
import logging
logging.basicConfig()
logging.getLogger("openai._base_client").setLevel(logging.DEBUG)

client = openai.OpenAI()
client.chat.completions.create(model="gpt-4", messages=[{"role": "user", "content": "hi"}])
# DEBUG logs will now include request/response bodies
```

## Test plan

- [ ] Verify request body appears in DEBUG logs when logging level is set
- [ ] Verify response body appears in DEBUG logs for non-streaming requests
- [ ] Verify no body logging when log level is INFO or higher
- [ ] Verify streaming responses do not log response body
- [ ] Verify no performance regression when DEBUG logging is disabled

Closes #1522