### PR TITLE
docs: add docstrings to parsing helpers and streaming events

### DIFF
--- a/src/openai/lib/_parsing/_completions.py
+++ b/src/openai/lib/_parsing/_completions.py
@@ -65,6 +65,11 @@ def select_strict_chat_completion_tools(
 def validate_input_tools(
     tools: Iterable[ChatCompletionToolUnionParam] | Omit = omit,
 ) -> Iterable[ChatCompletionFunctionToolParam] | Omit:
+    """Validate that all *tools* are strict function tools suitable for auto-parsing.
+
+    Raises :class:`ValueError` if any tool is not of type ``function`` or does not
+    have ``strict`` set to ``True``.
+    """
     if not is_given(tools):
         return omit
 
@@ -89,6 +94,16 @@ def parse_chat_completion(
     input_tools: Iterable[ChatCompletionToolUnionParam] | Omit,
     chat_completion: ChatCompletion | ParsedChatCompletion[object],
 ) -> ParsedChatCompletion[ResponseFormatT]:
+    """Parse a raw :class:`ChatCompletion` into a :class:`ParsedChatCompletion`.
+
+    Tool call arguments are deserialized using the corresponding *input_tools*
+    definitions, and ``message.content`` is parsed according to *response_format*
+    when a rich (class) format is provided.
+
+    Raises :class:`~openai.LengthFinishReasonError` if any choice has
+    ``finish_reason="length"`` and :class:`~openai.ContentFilterFinishReasonError`
+    if ``finish_reason="content_filter"``.
+    """
     if is_given(input_tools):
         input_tools = [t for t in input_tools]
     else:
@@ -165,12 +180,23 @@ def parse_chat_completion(
 def get_input_tool_by_name(
     *, input_tools: list[ChatCompletionToolUnionParam], name: str
 ) -> ChatCompletionFunctionToolParam | None:
+    """Look up the first function tool in *input_tools* whose name matches *name*.
+
+    Returns ``None`` if no matching tool is found.
+    """
     return next((t for t in input_tools if t["type"] == "function" and t.get("function", {}).get("name") == name), None)
 
 
 def parse_function_tool_arguments(
     *, input_tools: list[ChatCompletionToolUnionParam], function: Function | ParsedFunction
 ) -> object | None:
+    """Deserialize the JSON ``arguments`` of a function tool call.
+
+    If the matching input tool wraps a Pydantic model, the arguments are
+    validated and returned as a model instance.  For other strict tools the
+    raw JSON is decoded.  Returns ``None`` when no matching tool is found or
+    the tool is not strict.
+    """
     input_tool = get_input_tool_by_name(input_tools=input_tools, name=function.name)
     if not input_tool:
         return None
@@ -192,6 +218,11 @@ def maybe_parse_content(
     response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
     message: ChatCompletionMessage | ParsedChatCompletionMessage[object],
 ) -> ResponseFormatT | None:
+    """Parse the message content into *response_format* if applicable.
+
+    Returns ``None`` when *response_format* is not a rich type, the message
+    has no content, or the message contains a refusal.
+    """
     if has_rich_response_format(response_format) and message.content and not message.refusal:
         return _parse_content(response_format, message.content)
 
@@ -203,6 +234,11 @@ def has_parseable_input(
     response_format: type | ResponseFormatParam | Omit,
     input_tools: Iterable[ChatCompletionToolUnionParam] | Omit = omit,
 ) -> bool:
+    """Return ``True`` if the request configuration contains anything that can be auto-parsed.
+
+    This is the case when *response_format* is a rich type (e.g. a Pydantic model)
+    or at least one of the *input_tools* is a parseable strict function tool.
+    """
     if has_rich_response_format(response_format):
         return True
 
@@ -216,6 +252,7 @@ def has_parseable_input(
 def has_rich_response_format(
     response_format: type[ResponseFormatT] | ResponseFormatParam | Omit,
 ) -> TypeGuard[type[ResponseFormatT]]:
+    """Return ``True`` if *response_format* is a class type (not a dict param or omitted)."""
     if not is_given(response_format):
         return False
 
@@ -226,10 +263,12 @@ def has_rich_response_format(
 
 
 def is_response_format_param(response_format: object) -> TypeGuard[ResponseFormatParam]:
+    """Return ``True`` if *response_format* is a dictionary-style response format parameter."""
     return is_dict(response_format)
 
 
 def is_parseable_tool(input_tool: ChatCompletionToolUnionParam) -> bool:
+    """Return ``True`` if *input_tool* is a strict function tool that can be auto-parsed."""
     if input_tool["type"] != "function":
         return False
 
@@ -256,6 +295,11 @@ def _parse_content(response_format: type[ResponseFormatT], content: str) -> Resp
 def type_to_response_format_param(
     response_format: type | completion_create_params.ResponseFormat | Omit,
 ) -> ResponseFormatParam | Omit:
+    """Convert a *response_format* type into the ``json_schema`` parameter dict expected by the API.
+
+    If *response_format* is already a dict parameter it is returned as-is. Pydantic models
+    and ``@pydantic.dataclass`` types are converted to a strict JSON schema.
+    """
     if not is_given(response_format):
         return omit
 

--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -36,6 +36,12 @@ TextFormatT = TypeVar(
 
 
 def type_to_text_format_param(type_: type) -> ResponseFormatTextConfigParam:
+    """Convert a Python type into a :class:`ResponseFormatTextConfigParam` for the Responses API.
+
+    Delegates to :func:`type_to_response_format_param` and reshapes the resulting
+    ``json_schema`` dict into the text-format configuration expected by the
+    Responses API.
+    """
     response_format_dict = type_to_response_format_param(type_)
     assert is_given(response_format_dict)
     response_format_dict = cast(ResponseFormat, response_format_dict)  # pyright: ignore[reportUnnecessaryCast]
@@ -56,6 +62,12 @@ def parse_response(
     input_tools: Iterable[ToolParam] | Omit | None,
     response: Response | ParsedResponse[object],
 ) -> ParsedResponse[TextFormatT]:
+    """Parse a raw :class:`Response` into a :class:`ParsedResponse`.
+
+    Text output items are parsed according to *text_format* (when it is a
+    class type), and function call arguments are deserialized using the
+    matching definitions in *input_tools*.
+    """
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
     for output in response.output:
@@ -139,6 +151,12 @@ def parse_response(
 
 
 def parse_text(text: str, text_format: type[TextFormatT] | Omit) -> TextFormatT | None:
+    """Deserialize *text* as JSON into an instance of *text_format*.
+
+    Returns ``None`` when *text_format* is not given. Supports both
+    :class:`pydantic.BaseModel` subclasses and ``@pydantic.dataclass`` types
+    (Pydantic v2 only for the latter).
+    """
     if not is_given(text_format):
         return None
 
@@ -155,6 +173,10 @@ def parse_text(text: str, text_format: type[TextFormatT] | Omit) -> TextFormatT 
 
 
 def get_input_tool_by_name(*, input_tools: Iterable[ToolParam], name: str) -> FunctionToolParam | None:
+    """Look up the first function tool in *input_tools* whose name matches *name*.
+
+    Returns ``None`` if no matching tool is found.
+    """
     for tool in input_tools:
         if tool["type"] == "function" and tool.get("name") == name:
             return tool
@@ -167,6 +189,13 @@ def parse_function_tool_arguments(
     input_tools: Iterable[ToolParam] | Omit | None,
     function_call: ParsedResponseFunctionToolCall | ResponseFunctionToolCall,
 ) -> object:
+    """Deserialize the JSON ``arguments`` of a Responses API function call.
+
+    If the matching input tool wraps a Pydantic model, the arguments are
+    validated and returned as a model instance.  For other strict tools the
+    raw JSON is decoded.  Returns ``None`` when no matching tool is found or
+    the tool is not strict.
+    """
     if input_tools is None or not is_given(input_tools):
         return None
 

--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -14,6 +14,12 @@ _T = TypeVar("_T")
 
 
 def to_strict_json_schema(model: type[pydantic.BaseModel] | pydantic.TypeAdapter[Any]) -> dict[str, Any]:
+    """Convert a pydantic model or TypeAdapter into a strict JSON schema.
+
+    The resulting schema is mutated in place to conform to the ``strict`` format
+    required by the API (e.g. ``additionalProperties: false``, all properties
+    listed in ``required``).
+    """
     if inspect.isclass(model) and is_basemodel_type(model):
         schema = model_json_schema(model)
     elif (not PYDANTIC_V1) and isinstance(model, pydantic.TypeAdapter):
@@ -116,6 +122,10 @@ def _ensure_strict_json_schema(
 
 
 def resolve_ref(*, root: dict[str, object], ref: str) -> object:
+    """Resolve a JSON ``$ref`` pointer (e.g. ``#/definitions/Foo``) against *root*.
+
+    Only local references starting with ``#/`` are supported.
+    """
     if not ref.startswith("#/"):
         raise ValueError(f"Unexpected $ref format {ref!r}; Does not start with #/")
 
@@ -130,6 +140,7 @@ def resolve_ref(*, root: dict[str, object], ref: str) -> object:
 
 
 def is_basemodel_type(typ: type) -> TypeGuard[type[pydantic.BaseModel]]:
+    """Return ``True`` if *typ* is a class that is a subclass of :class:`pydantic.BaseModel`."""
     if not inspect.isclass(typ):
         return False
     return issubclass(typ, pydantic.BaseModel)
@@ -147,6 +158,7 @@ def is_dict(obj: object) -> TypeGuard[dict[str, object]]:
 
 
 def has_more_than_n_keys(obj: dict[str, object], n: int) -> bool:
+    """Check if *obj* contains more than *n* keys without iterating the entire dict."""
     i = 0
     for _ in obj.keys():
         i += 1

--- a/src/openai/lib/_tools.py
+++ b/src/openai/lib/_tools.py
@@ -27,6 +27,8 @@ class PydanticFunctionTool(Dict[str, Any]):
 
 
 class ResponsesPydanticFunctionTool(Dict[str, Any]):
+    """Dictionary wrapper that carries a Pydantic model for Responses API function tools."""
+
     model: type[pydantic.BaseModel]
 
     def __init__(self, tool: ResponsesFunctionToolParam, model: type[pydantic.BaseModel]) -> None:
@@ -43,6 +45,12 @@ def pydantic_function_tool(
     name: str | None = None,  # inferred from class name by default
     description: str | None = None,  # inferred from class docstring by default
 ) -> ChatCompletionFunctionToolParam:
+    """Create a :class:`ChatCompletionFunctionToolParam` from a Pydantic model.
+
+    The tool ``name`` defaults to the model class name and ``description``
+    defaults to the model's docstring.  A strict JSON schema is generated
+    automatically from the model.
+    """
     if description is None:
         # note: we intentionally don't use `.getdoc()` to avoid
         # including pydantic's docstrings

--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -4,6 +4,15 @@ from ..._utils import is_dict, is_list
 
 
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
+    """Merge a server-sent *delta* dict into the accumulated *acc* dict in place.
+
+    Strings and numbers are concatenated/summed, nested dicts are merged
+    recursively, and list entries are matched by their ``index`` key.
+    The ``index`` and ``type`` keys are always overwritten rather than
+    accumulated.
+
+    Returns the mutated *acc*.
+    """
     for key, delta_value in delta.items():
         if key not in acc:
             acc[key] = delta_value

--- a/src/openai/lib/streaming/chat/_events.py
+++ b/src/openai/lib/streaming/chat/_events.py
@@ -8,6 +8,8 @@ from ....types.chat import ChatCompletionChunk, ChatCompletionTokenLogprob
 
 
 class ChunkEvent(BaseModel):
+    """Emitted for every raw chunk received from the Chat Completions streaming API."""
+
     type: Literal["chunk"]
 
     chunk: ChatCompletionChunk
@@ -28,6 +30,8 @@ class ContentDeltaEvent(BaseModel):
 
 
 class ContentDoneEvent(GenericModel, Generic[ResponseFormatT]):
+    """Emitted when the full content string for a choice is complete."""
+
     type: Literal["content.done"]
 
     content: str
@@ -36,6 +40,8 @@ class ContentDoneEvent(GenericModel, Generic[ResponseFormatT]):
 
 
 class RefusalDeltaEvent(BaseModel):
+    """Emitted when a new refusal text delta is received."""
+
     type: Literal["refusal.delta"]
 
     delta: str
@@ -44,12 +50,16 @@ class RefusalDeltaEvent(BaseModel):
 
 
 class RefusalDoneEvent(BaseModel):
+    """Emitted when the full refusal string for a choice is complete."""
+
     type: Literal["refusal.done"]
 
     refusal: str
 
 
 class FunctionToolCallArgumentsDeltaEvent(BaseModel):
+    """Emitted when a new function tool call arguments delta is received."""
+
     type: Literal["tool_calls.function.arguments.delta"]
 
     name: str
@@ -67,6 +77,8 @@ class FunctionToolCallArgumentsDeltaEvent(BaseModel):
 
 
 class FunctionToolCallArgumentsDoneEvent(BaseModel):
+    """Emitted when the function tool call arguments string is complete."""
+
     type: Literal["tool_calls.function.arguments.done"]
 
     name: str
@@ -81,6 +93,8 @@ class FunctionToolCallArgumentsDoneEvent(BaseModel):
 
 
 class LogprobsContentDeltaEvent(BaseModel):
+    """Emitted when new content logprob tokens are received."""
+
     type: Literal["logprobs.content.delta"]
 
     content: List[ChatCompletionTokenLogprob]
@@ -89,12 +103,16 @@ class LogprobsContentDeltaEvent(BaseModel):
 
 
 class LogprobsContentDoneEvent(BaseModel):
+    """Emitted when the full content logprobs list is complete."""
+
     type: Literal["logprobs.content.done"]
 
     content: List[ChatCompletionTokenLogprob]
 
 
 class LogprobsRefusalDeltaEvent(BaseModel):
+    """Emitted when new refusal logprob tokens are received."""
+
     type: Literal["logprobs.refusal.delta"]
 
     refusal: List[ChatCompletionTokenLogprob]
@@ -103,6 +121,8 @@ class LogprobsRefusalDeltaEvent(BaseModel):
 
 
 class LogprobsRefusalDoneEvent(BaseModel):
+    """Emitted when the full refusal logprobs list is complete."""
+
     type: Literal["logprobs.refusal.done"]
 
     refusal: List[ChatCompletionTokenLogprob]


### PR DESCRIPTION
## Summary

Adds docstrings to public functions and classes in the hand-written `lib/` modules that were missing them. These are the parsing utilities, pydantic schema helpers, and streaming event types that SDK users interact with when using structured outputs and streaming.

**Files changed (6):**

- `src/openai/lib/_pydantic.py` — `to_strict_json_schema`, `resolve_ref`, `is_basemodel_type`, `has_more_than_n_keys`
- `src/openai/lib/_tools.py` — `ResponsesPydanticFunctionTool`, `pydantic_function_tool`
- `src/openai/lib/_parsing/_completions.py` — `validate_input_tools`, `parse_chat_completion`, `get_input_tool_by_name`, `parse_function_tool_arguments`, `maybe_parse_content`, `has_parseable_input`, `has_rich_response_format`, `is_response_format_param`, `is_parseable_tool`, `type_to_response_format_param`
- `src/openai/lib/_parsing/_responses.py` — `type_to_text_format_param`, `parse_response`, `parse_text`, `get_input_tool_by_name`, `parse_function_tool_arguments`
- `src/openai/lib/streaming/_deltas.py` — `accumulate_delta`
- `src/openai/lib/streaming/chat/_events.py` — `ChunkEvent`, `ContentDoneEvent`, `RefusalDeltaEvent`, `RefusalDoneEvent`, `FunctionToolCallArgumentsDeltaEvent`, `FunctionToolCallArgumentsDoneEvent`, `LogprobsContentDeltaEvent`, `LogprobsContentDoneEvent`, `LogprobsRefusalDeltaEvent`, `LogprobsRefusalDoneEvent`

No logic, behavior, or test changes. Pure documentation.

## Checklist

- [x] Only docstring additions — no logic or behavior changes
- [x] Matches existing docstring style in the codebase
- [x] Passes `ruff check` on all changed files
- [x] Under 200 lines changed (122 insertions)