### PR TITLE
Set Cache-Control no-cache when polling assistant runs

### DIFF
--- a/src/openai/resources/beta/threads/runs/runs.py
+++ b/src/openai/resources/beta/threads/runs/runs.py
@@ -1046,7 +1046,7 @@ class Runs(SyncAPIResource):
         information on Run lifecycles can be found here:
         https://platform.openai.com/docs/assistants/how-it-works/runs-and-run-steps
         """
-        extra_headers = {"X-Stainless-Poll-Helper": "true", **(extra_headers or {})}
+        extra_headers = {"X-Stainless-Poll-Helper": "true", "Cache-Control": "no-cache", **(extra_headers or {})}
 
         if is_given(poll_interval_ms):
             extra_headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
@@ -2507,7 +2507,7 @@ class AsyncRuns(AsyncAPIResource):
         information on Run lifecycles can be found here:
         https://platform.openai.com/docs/assistants/how-it-works/runs-and-run-steps
         """
-        extra_headers = {"X-Stainless-Poll-Helper": "true", **(extra_headers or {})}
+        extra_headers = {"X-Stainless-Poll-Helper": "true", "Cache-Control": "no-cache", **(extra_headers or {})}
 
         if is_given(poll_interval_ms):
             extra_headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)

--- a/tests/lib/test_assistants.py
+++ b/tests/lib/test_assistants.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+
+
+class _MockPollResponse:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+    def parse(self) -> SimpleNamespace:
+        return SimpleNamespace(status="completed")
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
@@ -48,3 +58,90 @@ def test_create_and_poll_method_definition_in_sync(sync: bool, client: OpenAI, a
         checking_client.beta.threads.runs.create_and_poll,  # pyright: ignore[reportDeprecated]
         exclude_params={"stream"},
     )
+
+
+def test_poll_adds_no_cache_header(client: OpenAI, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_headers: dict[str, str] | None = None
+
+    def mock_retrieve(
+        *,
+        thread_id: str,
+        run_id: str,
+        extra_headers: dict[str, str] | None = None,
+        extra_body: object = None,
+        extra_query: object = None,
+        timeout: object = None,
+    ) -> _MockPollResponse:
+        del thread_id, run_id, extra_body, extra_query, timeout
+        nonlocal seen_headers
+        seen_headers = dict(extra_headers or {})
+        return _MockPollResponse()
+
+    monkeypatch.setattr(client.beta.threads.runs.with_raw_response, "retrieve", mock_retrieve)
+
+    with pytest.warns(DeprecationWarning):
+        run = client.beta.threads.runs.poll("run_id", thread_id="thread_id")
+
+    assert run.status == "completed"
+    assert seen_headers is not None
+    assert seen_headers["X-Stainless-Poll-Helper"] == "true"
+    assert seen_headers["Cache-Control"] == "no-cache"
+
+
+def test_poll_allows_overriding_cache_control_header(client: OpenAI, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_headers: dict[str, str] | None = None
+
+    def mock_retrieve(
+        *,
+        thread_id: str,
+        run_id: str,
+        extra_headers: dict[str, str] | None = None,
+        extra_body: object = None,
+        extra_query: object = None,
+        timeout: object = None,
+    ) -> _MockPollResponse:
+        del thread_id, run_id, extra_body, extra_query, timeout
+        nonlocal seen_headers
+        seen_headers = dict(extra_headers or {})
+        return _MockPollResponse()
+
+    monkeypatch.setattr(client.beta.threads.runs.with_raw_response, "retrieve", mock_retrieve)
+
+    with pytest.warns(DeprecationWarning):
+        client.beta.threads.runs.poll(
+            "run_id",
+            thread_id="thread_id",
+            extra_headers={"Cache-Control": "max-age=60"},
+        )
+
+    assert seen_headers is not None
+    assert seen_headers["X-Stainless-Poll-Helper"] == "true"
+    assert seen_headers["Cache-Control"] == "max-age=60"
+
+
+async def test_async_poll_adds_no_cache_header(async_client: AsyncOpenAI, monkeypatch: pytest.MonkeyPatch) -> None:
+    seen_headers: dict[str, str] | None = None
+
+    async def mock_retrieve(
+        *,
+        thread_id: str,
+        run_id: str,
+        extra_headers: dict[str, str] | None = None,
+        extra_body: object = None,
+        extra_query: object = None,
+        timeout: object = None,
+    ) -> _MockPollResponse:
+        del thread_id, run_id, extra_body, extra_query, timeout
+        nonlocal seen_headers
+        seen_headers = dict(extra_headers or {})
+        return _MockPollResponse()
+
+    monkeypatch.setattr(async_client.beta.threads.runs.with_raw_response, "retrieve", mock_retrieve)
+
+    with pytest.warns(DeprecationWarning):
+        run = await async_client.beta.threads.runs.poll("run_id", thread_id="thread_id")
+
+    assert run.status == "completed"
+    assert seen_headers is not None
+    assert seen_headers["X-Stainless-Poll-Helper"] == "true"
+    assert seen_headers["Cache-Control"] == "no-cache"


### PR DESCRIPTION
## Summary
- add Cache-Control: no-cache to assistant run polling requests
- keep extra_headers precedence so callers can still override the header if needed
- add sync and async tests for the poll helper

## Why
client.beta.threads.runs.create_and_poll() eventually polls the same run status URL until it reaches a terminal state. Without a Cache-Control: no-cache header, caching proxies can keep serving the same status response and the helper may never observe completion.

Fixes #1673.
