### PR TITLE
fix: handle empty OPENAI_BASE_URL and top-level Responses API error fields

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -147,7 +147,7 @@ class OpenAI(SyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 
@@ -466,7 +466,7 @@ class AsyncOpenAI(AsyncAPIClient):
         self.websocket_base_url = websocket_base_url
 
         if base_url is None:
-            base_url = os.environ.get("OPENAI_BASE_URL")
+            base_url = os.environ.get("OPENAI_BASE_URL") or None
         if base_url is None:
             base_url = f"https://api.openai.com/v1"
 

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,7 +63,7 @@ class Stream(Generic[_T]):
             if sse.event and sse.event.startswith("thread."):
                 data = sse.json()
 
-                if sse.event == "error" and is_mapping(data) and data.get("error"):
+                if sse.event == "error" and is_mapping(data) and (data.get("error") or data.get("message")):
                     message = None
                     error = data.get("error")
                     if is_mapping(error):
@@ -80,7 +80,7 @@ class Stream(Generic[_T]):
                 yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
             else:
                 data = sse.json()
-                if is_mapping(data) and data.get("error"):
+                if is_mapping(data) and (data.get("error") or data.get("message")):
                     message = None
                     error = data.get("error")
                     if is_mapping(error):
@@ -165,7 +165,7 @@ class AsyncStream(Generic[_T]):
             if sse.event and sse.event.startswith("thread."):
                 data = sse.json()
 
-                if sse.event == "error" and is_mapping(data) and data.get("error"):
+                if sse.event == "error" and is_mapping(data) and (data.get("error") or data.get("message")):
                     message = None
                     error = data.get("error")
                     if is_mapping(error):
@@ -182,7 +182,7 @@ class AsyncStream(Generic[_T]):
                 yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
             else:
                 data = sse.json()
-                if is_mapping(data) and data.get("error"):
+                if is_mapping(data) and (data.get("error") or data.get("message")):
                     message = None
                     error = data.get("error")
                     if is_mapping(error):

--- a/src/openai/types/responses/response_text_delta_event.py
+++ b/src/openai/types/responses/response_text_delta_event.py
@@ -37,7 +37,7 @@ class ResponseTextDeltaEvent(BaseModel):
     item_id: str
     """The ID of the output item that the text delta was added to."""
 
-    logprobs: List[Logprob]
+    logprobs: Optional[List[Logprob]] = None
     """The log probabilities of the tokens in the delta."""
 
     output_index: int


### PR DESCRIPTION
Fixes #2927 and #2487.

## Fix 1 — Empty OPENAI_BASE_URL breaks the client (`_client.py`)

If `OPENAI_BASE_URL=""` is set, `os.environ.get("OPENAI_BASE_URL")` returns `""` not `None`, so the fallback to the default endpoint never triggers. Changed to `os.environ.get("OPENAI_BASE_URL") or None` so empty strings are treated as unset.

## Fix 2 — Streaming error events silently ignored (`_streaming.py`)

Per the Responses API spec, streaming error events send `message` at the top level — not inside a nested `"error"` key. The old condition `data.get("error")` never matched spec-compliant errors. Updated to `(data.get("error") or data.get("message"))` so both formats are handled correctly.