### PR TITLE
Fixes #3008 Responses API: multi-turn conversations 400 on turn 2 when passing response.output back as input

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -174,6 +174,15 @@ class BaseModel(pydantic.BaseModel):
             warnings=warnings,
         )
 
+    def as_input(self) -> dict[str, object]:
+        """Return a dict representation of this model suitable for use as input in a subsequent API request.
+
+        By default this is equivalent to :meth:`to_dict`. Subclasses that include
+        output-only fields (e.g. ``status``, ``created_by``, ``encrypted_content``)
+        override this method to strip those fields before returning.
+        """
+        return self.to_dict()
+
     def to_json(
         self,
         *,

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -324,11 +324,10 @@ class Response(BaseModel):
         """Return the response output items as a list of input-ready dicts for use in a subsequent turn.
 
         This is the recommended way to build multi-turn conversations manually.
-        It calls ``as_input()`` on items that have that method (e.g.
-        :class:`ResponseOutputMessage`, :class:`ResponseReasoningItem`,
-        :class:`ResponseFunctionToolCall`), stripping output-only fields like
-        ``status`` and ``encrypted_content`` that the API rejects as input.
-        For all other output item types, ``to_dict()`` is used as a fallback.
+        It calls ``as_input()`` on each output item, stripping output-only fields
+        like ``status``, ``created_by``, and ``encrypted_content`` that the API
+        rejects as input. For any item type that does not implement ``as_input()``,
+        ``to_dict()`` is used as a fallback.
 
         Example::
 

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 from typing_extensions import Literal, TypeAlias
 
 from .tool import Tool
@@ -319,3 +319,31 @@ class Response(BaseModel):
                         texts.append(content.text)
 
         return "".join(texts)
+
+    def output_as_input(self) -> List[Dict[str, Any]]:
+        """Return the response output items as a list of input-ready dicts for use in a subsequent turn.
+
+        This is the recommended way to build multi-turn conversations manually.
+        It calls ``as_input()`` on items that have that method (e.g.
+        :class:`ResponseOutputMessage`, :class:`ResponseReasoningItem`,
+        :class:`ResponseFunctionToolCall`), stripping output-only fields like
+        ``status`` and ``encrypted_content`` that the API rejects as input.
+        For all other output item types, ``to_dict()`` is used as a fallback.
+
+        Example::
+
+            conversation: list[dict] = []
+            for msg in ["What is the capital of France?", "And Germany?"]:
+                conversation.append({"role": "user", "content": msg})
+                response = client.responses.create(
+                    model="o4-mini", input=conversation, max_output_tokens=200,
+                )
+                conversation.extend(response.output_as_input())
+        """
+        result: List[Dict[str, Any]] = []
+        for item in self.output:
+            if hasattr(item, "as_input"):
+                result.append(item.as_input())
+            else:
+                result.append(item.to_dict())
+        return result

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -324,10 +324,9 @@ class Response(BaseModel):
         """Return the response output items as a list of input-ready dicts for use in a subsequent turn.
 
         This is the recommended way to build multi-turn conversations manually.
-        It calls ``as_input()`` on each output item, stripping output-only fields
-        like ``status``, ``created_by``, and ``encrypted_content`` that the API
-        rejects as input. For any item type that does not implement ``as_input()``,
-        ``to_dict()`` is used as a fallback.
+        Each output item's ``as_input()`` method is called, which strips output-only
+        fields like ``status``, ``created_by``, and ``encrypted_content`` that the
+        API rejects as input.
 
         Example::
 
@@ -339,10 +338,4 @@ class Response(BaseModel):
                 )
                 conversation.extend(response.output_as_input())
         """
-        result: List[Dict[str, Any]] = []
-        for item in self.output:
-            if hasattr(item, "as_input"):
-                result.append(item.as_input())
-            else:
-                result.append(item.to_dict())
-        return result
+        return [item.as_input() for item in self.output]

--- a/src/openai/types/responses/response_apply_patch_tool_call.py
+++ b/src/openai/types/responses/response_apply_patch_tool_call.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Union, Optional
+from typing import Any, Dict, Union, Optional
 from typing_extensions import Literal, Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -82,3 +82,13 @@ class ResponseApplyPatchToolCall(BaseModel):
 
     created_by: Optional[str] = None
     """The ID of the entity that created this tool call."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_apply_patch_tool_call_output.py
+++ b/src/openai/types/responses/response_apply_patch_tool_call_output.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -31,3 +31,13 @@ class ResponseApplyPatchToolCallOutput(BaseModel):
 
     output: Optional[str] = None
     """Optional textual output returned by the apply patch tool."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_compaction_item.py
+++ b/src/openai/types/responses/response_compaction_item.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -24,3 +24,12 @@ class ResponseCompactionItem(BaseModel):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_computer_tool_call_output_item.py
+++ b/src/openai/types/responses/response_computer_tool_call_output_item.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -50,3 +50,13 @@ class ResponseComputerToolCallOutputItem(BaseModel):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_custom_tool_call_output_item.py
+++ b/src/openai/types/responses/response_custom_tool_call_output_item.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from typing_extensions import Literal
 
 from .response_custom_tool_call_output import ResponseCustomToolCallOutput
@@ -23,3 +23,13 @@ class ResponseCustomToolCallOutputItem(ResponseCustomToolCallOutput):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_function_shell_tool_call.py
+++ b/src/openai/types/responses/response_function_shell_tool_call.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 from typing_extensions import Literal, Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -57,3 +57,13 @@ class ResponseFunctionShellToolCall(BaseModel):
 
     created_by: Optional[str] = None
     """The ID of the entity that created this tool call."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_function_shell_tool_call_output.py
+++ b/src/openai/types/responses/response_function_shell_tool_call_output.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 from typing_extensions import Literal, Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -86,3 +86,13 @@ class ResponseFunctionShellToolCallOutput(BaseModel):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_function_tool_call.py
+++ b/src/openai/types/responses/response_function_tool_call.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -39,3 +39,12 @@ class ResponseFunctionToolCall(BaseModel):
     One of `in_progress`, `completed`, or `incomplete`. Populated when items are
     returned via API.
     """
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        This strips output-only fields (``status``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        return data

--- a/src/openai/types/responses/response_function_tool_call_output_item.py
+++ b/src/openai/types/responses/response_function_tool_call_output_item.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 from typing_extensions import Literal, Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -41,3 +41,13 @@ class ResponseFunctionToolCallOutputItem(BaseModel):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_output_message.py
+++ b/src/openai/types/responses/response_output_message.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Any, Dict, List, Union, Optional
 from typing_extensions import Literal, Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -42,3 +42,12 @@ class ResponseOutputMessage(BaseModel):
     sending follow-up requests, preserve and resend phase on all assistant messages
     — dropping it can degrade performance. Not used for user messages.
     """
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        This strips output-only fields that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        return data

--- a/src/openai/types/responses/response_reasoning_item.py
+++ b/src/openai/types/responses/response_reasoning_item.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -60,3 +60,14 @@ class ResponseReasoningItem(BaseModel):
     One of `in_progress`, `completed`, or `incomplete`. Populated when items are
     returned via API.
     """
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        This strips output-only fields (``status``, ``encrypted_content``) that the
+        API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("encrypted_content", None)
+        return data

--- a/src/openai/types/responses/response_tool_search_call.py
+++ b/src/openai/types/responses/response_tool_search_call.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -29,3 +29,13 @@ class ResponseToolSearchCall(BaseModel):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``status``, ``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("status", None)
+        data.pop("created_by", None)
+        return data

--- a/src/openai/types/responses/response_tool_search_output_item.py
+++ b/src/openai/types/responses/response_tool_search_output_item.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 from typing_extensions import Literal
 
 from .tool import Tool
@@ -30,3 +30,12 @@ class ResponseToolSearchOutputItem(BaseModel):
 
     created_by: Optional[str] = None
     """The identifier of the actor that created the item."""
+
+    def as_input(self) -> Dict[str, Any]:
+        """Return a dict representation of this item suitable for use as input in a subsequent response.
+
+        Strips output-only fields (``created_by``) that the API does not accept as input.
+        """
+        data = self.to_dict()
+        data.pop("created_by", None)
+        return data


### PR DESCRIPTION
## Problem

Reusing `response.output` items as input via `model_dump()` caused 400 errors in the OpenAI API:

- `ResponseOutputMessage` included `status` (required field, not valid input)
- `ResponseReasoningItem` included `status: None` and `encrypted_content: None`
- `ResponseFunctionToolCall` also included `status`
- This made the API reject requests with:

  400: Unknown parameter: input[i].status

## Solution

This PR introduces:

- `as_input()` on:
  - `ResponseOutputMessage` (strips `status`)
  - `ResponseReasoningItem` (strips `status` and `encrypted_content`)
  - `ResponseFunctionToolCall` (strips `status`)
- `output_as_input()` on `Response` as a convenience method that:
  - calls `as_input()` on supported items
  - falls back to `to_dict()` for others

### Example Usage

```python
conversation = []
for msg in ["What is the capital of France?", "And Germany?"]:
    conversation.append({"role": "user", "content": msg})
    response = client.responses.create(
        model="o4-mini",
        input=conversation,
        max_output_tokens=200,
    )
    conversation.extend(response.output_as_input())  # no more 400s