### PR TITLE
fix: treat empty OPENAI_BASE_URL as unset and fall back to default

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -162,7 +162,7 @@ class OpenAI(SyncAPIClient):
 
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url is None:
+        if not base_url:
             base_url = f"https://api.openai.com/v1"
 
         super().__init__(
@@ -537,7 +537,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url is None:
+        if not base_url:
             base_url = f"https://api.openai.com/v1"
 
         super().__init__(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,11 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_empty_base_url_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = OpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
+
     @pytest.mark.parametrize(
         "client",
         [
@@ -1733,6 +1738,11 @@ class TestAsyncOpenAI:
         with update_env(OPENAI_BASE_URL="http://localhost:5000/from/env"):
             client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
+
+    async def test_empty_base_url_env_falls_back_to_default(self) -> None:
+        with update_env(OPENAI_BASE_URL=""):
+            client = AsyncOpenAI(api_key=api_key, _strict_response_validation=True)
+            assert client.base_url == "https://api.openai.com/v1/"
 
     @pytest.mark.parametrize(
         "client",


### PR DESCRIPTION
## Summary

- When `OPENAI_BASE_URL=""` (empty string), `os.environ.get("OPENAI_BASE_URL")` returns `""` instead of `None`, so the fallback to the default API endpoint (`https://api.openai.com/v1`) never triggers. This causes an invalid base URL to be used.
- Changed the guard from `if base_url is None` to `if not base_url` so that both `None` and empty string correctly fall through to the default endpoint.
- Applied the fix to both `OpenAI` (sync) and `AsyncOpenAI` classes.
- Added tests for both classes to verify empty `OPENAI_BASE_URL` falls back to the default.

Closes #2927

## Test plan

- [x] New test `test_empty_base_url_env_falls_back_to_default` for `OpenAI` (sync) passes
- [x] New test `test_empty_base_url_env_falls_back_to_default` for `AsyncOpenAI` passes
- [x] Existing `test_base_url_env` tests still pass (non-empty env var still works)
- [x] AST validation passes on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)