### PR TITLE
docs: fix reusing wording in Azure client docstrings

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -277,7 +277,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
         _extra_kwargs: Mapping[str, Any] = {},
     ) -> Self:
         """
-        Create a new client instance re-using the same options given to the current client with optional overriding.
+        Create a new client instance reusing the same options given to the current client with optional overriding.
         """
         return super().copy(
             api_key=api_key,
@@ -558,7 +558,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
         _extra_kwargs: Mapping[str, Any] = {},
     ) -> Self:
         """
-        Create a new client instance re-using the same options given to the current client with optional overriding.
+        Create a new client instance reusing the same options given to the current client with optional overriding.
         """
         return super().copy(
             api_key=api_key,


### PR DESCRIPTION
Correct `re-using` to `reusing` in the synchronous and asynchronous Azure client `copy()` docstrings. Validation: syntax-tree comparison confirmed executable code is unchanged; whitespace and custom-code budget checks passed. Focused security review found no issues.