### PR TITLE
docs: fix continuously wording in streaming comment

### DIFF
--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -379,7 +379,7 @@ class ChatCompletionStreamState(Generic[ResponseFormatT]):
                                     choice_snapshot.message,
                                     # we don't want to serialise / deserialise our custom properties
                                     # as they won't appear in the delta and we don't want to have to
-                                    # continuosly reparse the content
+                                    # continuously reparse the content
                                     exclude=cast(
                                         # cast required as mypy isn't smart enough to infer `True` here to `Literal[True]`
                                         IncEx,


### PR DESCRIPTION
## Summary
- fix `continuosly` -> `continuously` in a streaming comment under `src/openai/lib/`

## Related issue
- N/A (trivial comment fix)

## Guideline alignment
- Reviewed https://github.com/openai/openai-python/blob/main/CONTRIBUTING.md and kept the change in the hand-maintained `src/openai/lib/` area.

## Validation/testing note
- Not run (comment-only change)
