### PR TITLE
fix: log retry count at INFO level (#2404)

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1102,13 +1102,8 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
         self, *, retries_taken: int, max_retries: int, options: FinalRequestOptions, response: httpx.Response | None
     ) -> None:
         remaining_retries = max_retries - retries_taken
-        if remaining_retries == 1:
-            log.debug("1 retry left")
-        else:
-            log.debug("%i retries left", remaining_retries)
-
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
-        log.info("Retrying request to %s in %f seconds", options.url, timeout)
+        log.info("Retrying request to %s in %f seconds (retry %d of %d)", options.url, timeout, retries_taken, max_retries)
 
         time.sleep(timeout)
 
@@ -1713,13 +1708,8 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
         self, *, retries_taken: int, max_retries: int, options: FinalRequestOptions, response: httpx.Response | None
     ) -> None:
         remaining_retries = max_retries - retries_taken
-        if remaining_retries == 1:
-            log.debug("1 retry left")
-        else:
-            log.debug("%i retries left", remaining_retries)
-
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
-        log.info("Retrying request to %s in %f seconds", options.url, timeout)
+        log.info("Retrying request to %s in %f seconds (retry %d of %d)", options.url, timeout, retries_taken, max_retries)
 
         await anyio.sleep(timeout)
 


### PR DESCRIPTION
## Fixes #2404

Replace debug-only `X retries left` logs with a single INFO-level log that includes `retry N of M` in the existing `Retrying request to ...` message. No increase in log verbosity — same INFO call, richer context.

### Changes
- `_sleep_for_retry()` (sync): upgraded `log.info()` to include `retries_taken` and `max_retries`
- `_sleep_for_retry()` (async): same change
- Removed redundant `log.debug("1 retry left")` / `log.debug("X retries left")` calls

Both methods updated, covering both sync and async client paths.