### PR TITLE
docs: fix typo in streaming comment

### DIFF
--- a/src/openai/lib/streaming/chat/_completions.py
+++ b/src/openai/lib/streaming/chat/_completions.py
@@ -379,7 +379,7 @@ class ChatCompletionStreamState(Generic[ResponseFormatT]):
                                     choice_snapshot.message,
                                     # we don't want to serialise / deserialise our custom properties
                                     # as they won't appear in the delta and we don't want to have to
-                                    # continuosly reparse the content
+                                    # continuously reparse the content
                                     exclude=cast(
                                         # cast required as mypy isn't smart enough to infer `True` here to `Literal[True]`
                                         IncEx,


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes a typo in `src/openai/lib/streaming/chat/_completions.py` by changing `continuosly` to `continuously` in an internal comment. `CONTRIBUTING.md` notes that files in `src/openai/lib/` are not modified by the generator.

## Additional context & links

- Related issue: N/A (trivial comment typo fix)
- Guideline alignment: https://github.com/openai/openai-python/blob/main/CONTRIBUTING.md
- Validation: Not run (comment-only change)
