### PR TITLE
fix(lib): prevent memory leak by removing TypeVar subscript in construct_type_unchecked (#3084)

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -78,7 +78,7 @@ def parse_response(
 
             output_list.append(
                 construct_type_unchecked(
-                    type_=ParsedResponseOutputMessage[TextFormatT],
+                    type_=ParsedResponseOutputMessage,
                     value={
                         **output.to_dict(),
                         "content": content_list,
@@ -130,7 +130,7 @@ def parse_response(
             output_list.append(output)
 
     return construct_type_unchecked(
-        type_=ParsedResponse[TextFormatT],
+        type_=ParsedResponse,
         value={
             **response.to_dict(),
             "output": output_list,


### PR DESCRIPTION
## Summary

When using  client with structured outputs,  is called with TypeVar-subscripted generics like . Since  is an unresolved module-level TypeVar at runtime, Pydantic cannot resolve it, causing  to always return . This prevents  caching, allocating a new / (heavy Rust objects) on **every**  call — a unbounded memory leak.

## Changes

- Replaced  with 
- Replaced  with 
- Replaced  with 

Non-parameterized base classes resolve correctly at runtime and Pydantic can cache their schemas.

## Testing

Run a workload with structured outputs under memory profiling. Before fix: unbounded growth of SchemaValidator objects. After fix: stable memory usage.

Fixes #3084