### PR TITLE
Pin setup-rye in GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
 
       - name: Install dependencies
         run: rye sync --all-features
@@ -48,13 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
 
       - name: Install dependencies
         run: rye sync --all-features
@@ -89,13 +85,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
 
       - name: Bootstrap
         run: ./scripts/bootstrap
@@ -112,13 +106,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
       - name: Install dependencies
         run: |
           rye sync --all-features

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -22,14 +22,12 @@ jobs:
           repo: ${{ github.event.repository.full_name }}
           stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
 
-      - name: Install Rye
+      - name: Set up Rye
         if: ${{ steps.release.outputs.releases_created }}
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
 
       - name: Publish to PyPI
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -20,13 +20,11 @@ jobs:
           # Ensure we can check out the pull request base in the script below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
       - name: Install dependencies
         run: |
           rye sync --all-features
@@ -49,14 +47,12 @@ jobs:
         with:
           path: openai-python
 
-      - name: Install Rye
-        working-directory: openai-python
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
+          working-directory: openai-python
 
       - name: Install dependencies
         working-directory: openai-python
@@ -85,4 +81,3 @@ jobs:
       - name: Run integration type checks
         working-directory: openai-agents-python
         run: make mypy
-

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -13,13 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install Rye
-        run: |
-          curl -sSf https://rye.astral.sh/get | bash
-          echo "$HOME/.rye/shims" >> $GITHUB_PATH
-        env:
-          RYE_VERSION: '0.44.0'
-          RYE_INSTALL_OPTION: '--yes'
+      - name: Set up Rye
+        uses: eifinger/setup-rye@c694239a43768373e87d0103d7f547027a23f3c8
+        with:
+          version: '0.44.0'
+          enable-cache: true
 
       - name: Publish to PyPI
         run: |


### PR DESCRIPTION
## Why

PR #3083 was merged into `next` by mistake. This PR replays the same workflow changes against the default branch, `main`.

## Changes

Replace manual Rye installation in GitHub Actions workflows with `eifinger/setup-rye` pinned to a full commit SHA.

This updates the Rye setup steps in:
- `.github/workflows/ci.yml`
- `.github/workflows/create-releases.yml`
- `.github/workflows/detect-breaking-changes.yml`
- `.github/workflows/publish-pypi.yml`

Changes included:
- replace `curl -sSf https://rye.astral.sh/get | bash` bootstrap steps
- pin `eifinger/setup-rye` to `c694239a43768373e87d0103d7f547027a23f3c8`
- keep Rye explicitly pinned to `0.44.0`
- enable action-level caching
- preserve existing workflow conditions
- set `working-directory: openai-python` for the nested checkout in `detect-breaking-changes.yml`

## Verification

- confirmed the cherry-pick applied cleanly on top of `main`
- confirmed the workflow diffs match the prior merged change
- confirmed the updated workflow files contain the pinned `setup-rye` references and expected `working-directory` entries

Supersedes #3083 for the `main` branch target.

