### PR TITLE
docs: fix vector store polling helper paths

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -510,9 +510,9 @@ The polling methods are:
 client.beta.threads.create_and_run_poll(...)
 client.beta.threads.runs.create_and_poll(...)
 client.beta.threads.runs.submit_tool_outputs_and_poll(...)
-client.beta.vector_stores.files.upload_and_poll(...)
-client.beta.vector_stores.files.create_and_poll(...)
-client.beta.vector_stores.file_batches.create_and_poll(...)
-client.beta.vector_stores.file_batches.upload_and_poll(...)
+client.vector_stores.files.upload_and_poll(...)
+client.vector_stores.files.create_and_poll(...)
+client.vector_stores.file_batches.create_and_poll(...)
+client.vector_stores.file_batches.upload_and_poll(...)
 client.videos.create_and_poll(...)
 ```


### PR DESCRIPTION
The polling-helper list in `helpers.md` still points to `client.beta.vector_stores`, which raises an `AttributeError` on current SDKs. Update all four examples to the supported `client.vector_stores` namespace.

Refs #2451 (already closed with migration guidance).

Validation: verified all four helper paths against the synchronous and asynchronous SDK source; `git diff --check` passes. Security review found no concerns in the four documentation-only replacements.