### PR TITLE
fix(models): retry after pydantic schema rebuild error

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -36,6 +36,7 @@ from typing_extensions import (
 )
 
 import pydantic
+from pydantic.errors import PydanticUserError
 from pydantic.fields import FieldInfo
 
 from ._types import (
@@ -442,7 +443,11 @@ def _get_extra_fields_type(cls: type[pydantic.BaseModel]) -> type | None:
         # TODO
         return None
 
-    schema = cls.__pydantic_core_schema__
+    try:
+        schema = cls.__pydantic_core_schema__
+    except PydanticUserError:
+        cls.model_rebuild(force=True, raise_errors=False)
+        schema = cls.__pydantic_core_schema__
     if schema["type"] == "model":
         fields = schema["schema"]
         if fields["type"] == "model-fields":

--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -36,7 +36,13 @@ from typing_extensions import (
 )
 
 import pydantic
-from pydantic.errors import PydanticUserError
+
+try:
+    from pydantic.errors import PydanticUserError
+except ImportError:  # pydantic v1 does not export PydanticUserError
+    class PydanticUserError(Exception):  # type: ignore[no-redef]
+        pass
+
 from pydantic.fields import FieldInfo
 
 from ._types import (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from openai._utils import PropertyInfo
 from openai._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
-from openai._models import DISCRIMINATOR_CACHE, BaseModel, construct_type
+from openai._models import DISCRIMINATOR_CACHE, BaseModel, _get_extra_fields_type, construct_type
 
 
 class BasicModel(BaseModel):
@@ -155,6 +155,43 @@ def test_unknown_fields() -> None:
     assert cast(Any, m2).unknown == {"foo_bar": True}
 
     assert model_dump(m2) == {"foo": "foo", "unknown": {"foo_bar": True}}
+
+
+@pytest.mark.skipif(PYDANTIC_V1, reason="pydantic v2 only")
+def test_get_extra_fields_type_rebuilds_after_pydantic_user_error() -> None:
+    schema = {
+        "type": "model",
+        "schema": {
+            "type": "model-fields",
+            "extras_schema": {"cls": str},
+        },
+    }
+
+    class Meta(type):
+        _schema_calls = 0
+        _rebuild_calls = 0
+
+        @property
+        def __pydantic_core_schema__(cls) -> dict[str, object]:
+            type(cls)._schema_calls += 1
+            if type(cls)._schema_calls == 1:
+                raise pydantic.errors.PydanticUserError(
+                    "schema unavailable",
+                    code="schema-unavailable",
+                )
+            return schema
+
+        def model_rebuild(cls, *, force: bool, raise_errors: bool) -> bool:
+            type(cls)._rebuild_calls += 1
+            assert force is True
+            assert raise_errors is False
+            return True
+
+    class FakeModel(metaclass=Meta):
+        pass
+
+    assert _get_extra_fields_type(cast(Any, FakeModel)) is str
+    assert Meta._rebuild_calls == 1
 
 
 def test_strict_validation_unknown_fields() -> None:


### PR DESCRIPTION
## Summary
- catch PydanticUserError when reading deferred pydantic core schema metadata
- retry after model_rebuild(force=True, raise_errors=False) before inspecting extras schema
- add a regression test that exercises the rebuild fallback path with a synthetic model class

## Testing
- python3 -m py_compile src/openai/_models.py tests/test_models.py
- python3 -m pytest tests/test_models.py -k rebuilds_after_pydantic_user_error *(fails locally: ModuleNotFoundError: No module named 'pytest_asyncio')*