### PR TITLE
fix: validate http_client type in AsyncAPIClient

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1498,7 +1498,7 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             custom_headers=custom_headers,
             _strict_response_validation=_strict_response_validation,
         )
-        if http_client is not None and not isinstance(http_client, httpx.AsyncClient):
+        if http_client is not None and not isinstance(cast(Any, http_client), httpx.AsyncClient):
             raise TypeError(
                 f"Expected http_client to be an instance of httpx.AsyncClient, but got {type(http_client)} instead. "
                 "If you are using AsyncOpenAI, you must pass an asynchronous HTTP client."

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1498,6 +1498,12 @@ class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):
             custom_headers=custom_headers,
             _strict_response_validation=_strict_response_validation,
         )
+        if http_client is not None and not isinstance(http_client, httpx.AsyncClient):
+            raise TypeError(
+                f"Expected http_client to be an instance of httpx.AsyncClient, but got {type(http_client)} instead. "
+                "If you are using AsyncOpenAI, you must pass an asynchronous HTTP client."
+            )
+
         self._client = http_client or AsyncHttpxClientWrapper(
             base_url=base_url,
             # cast to a valid type because mypy doesn't understand our type narrowing


### PR DESCRIPTION
Fixes #1095

## Problem
When a user passes a synchronous `httpx.Client` to `AsyncOpenAI` via the `http_client` parameter, the library crashes during a request with a cryptic `TypeError: object Response can't be used in 'await' expression`. This happens because the SDK expects an asynchronous client and tries to `await` the result of `.send()`, which in a sync client returns a `Response` object instead of a coroutine.

## Solution
Added a type validation check in `AsyncAPIClient.__init__`. If an `http_client` is provided, we now explicitly verify that it is an instance of `httpx.AsyncClient`. If not, we raise a clear `TypeError` during initialization.

## Changes
- `src/openai/_base_client.py`: Added `isinstance` check for `http_client` in `AsyncAPIClient.__init__`.

## Verification
- Verified that passing a sync client now raises a helpful `TypeError` instead of crashing later with a cryptic one.