### PR TITLE
fix(streaming): remove unreachable error check in thread event handler

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -67,7 +67,7 @@ class Stream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):
@@ -177,7 +177,7 @@ class AsyncStream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and data.get("error"):
                         message = None
                         error = data.get("error")
                         if is_mapping(error):


### PR DESCRIPTION
## Summary

Fixes #2796

In both `Stream.__stream__` and `AsyncStream.__stream__`, the error handling block inside the `thread.` event branch contains the condition `sse.event == "error"`. Since this check is nested inside `if sse.event.startswith("thread.")`, and the string `"error"` never starts with `"thread."`, this condition is always `False` — making the entire error-handling block dead code.

This appears to be a regression from a prior refactoring (mentioned in the issue as commit `abc25966`) where the error check was incorrectly moved inside the `thread.` branch.

## Changes

- Remove the unreachable `sse.event == "error" and` predicate from the error condition in both sync and async stream handlers
- Thread events that carry error payloads in their data will now correctly raise `APIError`
- The non-thread error path in the `else` branch is unchanged