### PR TITLE
docs(examples): add Azure OpenAI image generation example

### DIFF
--- a/examples/azure_image.py
+++ b/examples/azure_image.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+"""Azure OpenAI image generation example using a GPT-Image deployment.
+
+Shows both ``images.generate`` and ``images.edit`` against an Azure deployment
+of one of the GPT-Image family models (``gpt-image-1``, ``gpt-image-1-mini``,
+``gpt-image-1.5``, ``gpt-image-2``).
+
+For Azure, you supply the *deployment name* as the ``model`` argument — the
+SDK still accepts that as ``str`` even when the deployment name isn't in the
+``ImageModel`` literal.
+
+Reference:
+    https://learn.microsoft.com/azure/ai-foundry/openai/how-to/dall-e
+"""
+
+from __future__ import annotations
+
+import os
+import base64
+from pathlib import Path
+
+from openai import AzureOpenAI
+
+# https://learn.microsoft.com/azure/ai-services/openai/reference#api-versions
+api_version = "2024-10-21"
+
+# Deployment name you created in the Azure portal for your GPT-Image model.
+deployment = os.environ.get("AZURE_OPENAI_IMAGE_DEPLOYMENT", "gpt-image-2")
+
+client = AzureOpenAI(
+    api_version=api_version,
+    # AZURE_OPENAI_ENDPOINT (e.g. "https://<resource>.openai.azure.com")
+    # AZURE_OPENAI_API_KEY  -- both read from the environment by default.
+)
+
+
+def generate() -> Path:
+    """Generate a single 1024x1024 ``low`` quality image and save it to disk."""
+    result = client.images.generate(
+        model=deployment,
+        prompt="a cute corgi puppy sitting on grass, studio lighting",
+        n=1,
+        size="1024x1024",
+        quality="low",
+    )
+
+    assert result.data and result.data[0].b64_json, "expected base64 image data"
+    out = Path("azure_image_generated.png")
+    out.write_bytes(base64.b64decode(result.data[0].b64_json))
+    print(f"generated -> {out.resolve()}")
+
+    # The GPT-Image family returns token usage details. Older models (dall-e-*)
+    # return ``usage=None``.
+    if result.usage is not None:
+        print(
+            f"usage: input={result.usage.input_tokens} "
+            f"output={result.usage.output_tokens} "
+            f"total={result.usage.total_tokens}"
+        )
+    return out
+
+
+def edit(source: Path) -> None:
+    """Edit an existing image with a text prompt."""
+    with source.open("rb") as f:
+        result = client.images.edit(
+            model=deployment,
+            image=f,
+            prompt="add a small red bow tie",
+            size="1024x1024",
+            quality="low",
+            n=1,
+        )
+
+    assert result.data and result.data[0].b64_json, "expected base64 image data"
+    out = Path("azure_image_edited.png")
+    out.write_bytes(base64.b64decode(result.data[0].b64_json))
+    print(f"edited    -> {out.resolve()}")
+
+
+def main() -> None:
+    generated = generate()
+    edit(generated)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/azure_image.py
+++ b/examples/azure_image.py
@@ -29,8 +29,12 @@ deployment = os.environ.get("AZURE_OPENAI_IMAGE_DEPLOYMENT", "gpt-image-2")
 
 client = AzureOpenAI(
     api_version=api_version,
-    # AZURE_OPENAI_ENDPOINT (e.g. "https://<resource>.openai.azure.com")
-    # AZURE_OPENAI_API_KEY  -- both read from the environment by default.
+    # Reads credentials from the environment by default:
+    #   AZURE_OPENAI_ENDPOINT  e.g. "https://<resource>.openai.azure.com"
+    #   AZURE_OPENAI_API_KEY
+    # You can also pass them explicitly, e.g.:
+    #   azure_endpoint="https://example-endpoint.openai.azure.com",
+    #   api_key="...",
 )
 
 
@@ -44,9 +48,12 @@ def generate() -> Path:
         quality="low",
     )
 
-    assert result.data and result.data[0].b64_json, "expected base64 image data"
+    image = result.data[0] if result.data else None
+    if image is None or image.b64_json is None:
+        raise RuntimeError("response did not include base64 image data")
+
     out = Path("azure_image_generated.png")
-    out.write_bytes(base64.b64decode(result.data[0].b64_json))
+    out.write_bytes(base64.b64decode(image.b64_json))
     print(f"generated -> {out.resolve()}")
 
     # The GPT-Image family returns token usage details. Older models (dall-e-*)
@@ -72,9 +79,12 @@ def edit(source: Path) -> None:
             n=1,
         )
 
-    assert result.data and result.data[0].b64_json, "expected base64 image data"
+    image = result.data[0] if result.data else None
+    if image is None or image.b64_json is None:
+        raise RuntimeError("response did not include base64 image data")
+
     out = Path("azure_image_edited.png")
-    out.write_bytes(base64.b64decode(result.data[0].b64_json))
+    out.write_bytes(base64.b64decode(image.b64_json))
     print(f"edited    -> {out.resolve()}")
 
 


### PR DESCRIPTION
<!-- I understand this repo is auto-generated; submitting this against examples/
     (which CONTRIBUTING.md explicitly states is not touched by the generator). -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds `examples/azure_image.py` — a small end-to-end script that calls `images.generate` and `images.edit` against an Azure deployment of a GPT-Image family model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, or the newly-public `gpt-image-2`).

The existing `examples/azure.py` only covers `chat.completions` and pins `api_version="2023-07-01-preview"`, which predates the `/images/*` endpoints. This new example:

- Uses `api_version="2024-10-21"` (the latest GA version supporting the image endpoints).
- Reads the deployment name from `AZURE_OPENAI_IMAGE_DEPLOYMENT` and defaults to `gpt-image-2`.
- Uses `quality="low"` so it remains cheap to run against any GPT-Image deployment.
- Demonstrates decoding the returned `b64_json` to a `.png` and shows how to surface the `usage` token counts that the GPT-Image models return.
- Demonstrates `images.edit` with the generated file as input.

`CONTRIBUTING.md` says "All files in the `examples/` directory are not modified by the generator and can be freely edited or added to" — this PR only adds a new file under `examples/`, no generated code touched.

Ran `ruff check` and `ruff format --check` against the new file; both pass.

## Additional context & links

- Azure docs for the GPT-Image model family: <https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/dall-e>
- Azure API versioning: <https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-versions>
- Related issue (Literal / docstring sync for `gpt-image-2`): #3114
