### PR TITLE
fix: replace broken wikimedia image URL with httpbin test image

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ With an image URL:
 
 ```python
 prompt = "What is in this image?"
-img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+img_url = "https://httpbin.org/image/jpeg"
 
 response = client.responses.create(
     model="gpt-5.2",


### PR DESCRIPTION
Good day

## Summary
The README Vision example uses a wikimedia image URL that returns HTTP 400 (likely due to Wikimedia's hotlink protection or size limit). This replaces the broken URL with a reliable test image from httpbin.org.

## Changes
- README.md: swapped broken wikimedia URL for working httpbin.org/image/jpeg

## Verification
```bash
curl -sI https://httpbin.org/image/jpeg
# HTTP/2 200, content-length: 35588
```

## Fixes
Fixes openai/openai-python#2776

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithRoof