### PR TITLE
fix: resolve unbounded memory leak from TypeVar parameterized ParsedResponse types

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -68,7 +68,7 @@ def parse_response(
 
                 content_list.append(
                     construct_type_unchecked(
-                        type_=ParsedResponseOutputText[TextFormatT],
+                        type_=ParsedResponseOutputText,
                         value={
                             **item.to_dict(),
                             "parsed": parse_text(item.text, text_format=text_format),
@@ -78,7 +78,7 @@ def parse_response(
 
             output_list.append(
                 construct_type_unchecked(
-                    type_=ParsedResponseOutputMessage[TextFormatT],
+                    type_=ParsedResponseOutputMessage,
                     value={
                         **output.to_dict(),
                         "content": content_list,
@@ -130,7 +130,7 @@ def parse_response(
             output_list.append(output)
 
     return construct_type_unchecked(
-        type_=ParsedResponse[TextFormatT],
+        type_=ParsedResponse,
         value={
             **response.to_dict(),
             "output": output_list,


### PR DESCRIPTION
## Root Cause

`ParsedResponse[TextFormatT]` where `TextFormatT` is a free module-level TypeVar causes pydantic's `model_rebuild` to always return `False`. This prevents `MockCoreSchema._built_memo` from caching, causing a new `SchemaValidator`/`SchemaSerializer` (heavy Rust object) to be allocated on **every** `responses.parse()` call — accumulating without bound.

## Fix

Use non-parameterized base classes which are functionally identical at runtime but allow `model_rebuild` to succeed and cache the built schemas:

```python
# Before (leaks memory)
construct_type_unchecked(type_=ParsedResponse[TextFormatT], ...)
construct_type_unchecked(type_=ParsedResponseOutputText[TextFormatT], ...)
construct_type_unchecked(type_=ParsedResponseOutputMessage[TextFormatT], ...)

# After (caches properly)
construct_type_unchecked(type_=ParsedResponse, ...)
construct_type_unchecked(type_=ParsedResponseOutputText, ...)
construct_type_unchecked(type_=ParsedResponseOutputMessage, ...)
```

## Impact
- 3 lines changed, minimal risk
- Matches the approach suggested in the issue

Fixes #3084