### PR TITLE
types: add gpt-image-2 to ImageModel literal

### DIFF
--- a/src/openai/types/image_edit_params.py
+++ b/src/openai/types/image_edit_params.py
@@ -15,7 +15,7 @@ class ImageEditParamsBase(TypedDict, total=False):
     image: Required[Union[FileTypes, SequenceNotStr[FileTypes]]]
     """The image(s) to edit. Must be a supported image file or an array of images.
 
-    For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and
+    For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-2`, and
     `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg` file less than
     50MB. You can provide up to 16 images. `chatgpt-image-latest` follows the same
     input constraints as GPT image models.
@@ -46,7 +46,7 @@ class ImageEditParamsBase(TypedDict, total=False):
     """
     Control how much effort the model will exert to match the style and features,
     especially facial features, of input images. This parameter is only supported
-    for `gpt-image-1` and `gpt-image-1.5` and later models, unsupported for
+    for `gpt-image-1.5` and later models (including `gpt-image-2`), unsupported for
     `gpt-image-1-mini`. Supports `high` and `low`. Defaults to `low`.
     """
 

--- a/src/openai/types/image_generate_params.py
+++ b/src/openai/types/image_generate_params.py
@@ -33,7 +33,7 @@ class ImageGenerateParamsBase(TypedDict, total=False):
     """The model to use for image generation.
 
     One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`,
-    `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter
+    `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`). Defaults to `dall-e-2` unless a parameter
     specific to the GPT image models is used.
     """
 

--- a/src/openai/types/image_model.py
+++ b/src/openai/types/image_model.py
@@ -4,4 +4,4 @@ from typing_extensions import Literal, TypeAlias
 
 __all__ = ["ImageModel"]
 
-ImageModel: TypeAlias = Literal["gpt-image-1.5", "dall-e-2", "dall-e-3", "gpt-image-1", "gpt-image-1-mini"]
+ImageModel: TypeAlias = Literal["gpt-image-1.5", "dall-e-2", "dall-e-3", "gpt-image-1", "gpt-image-1-mini", "gpt-image-2"]

--- a/src/openai/types/responses/tool.py
+++ b/src/openai/types/responses/tool.py
@@ -257,7 +257,7 @@ class ImageGeneration(BaseModel):
     """
     Control how much effort the model will exert to match the style and features,
     especially facial features, of input images. This parameter is only supported
-    for `gpt-image-1` and `gpt-image-1.5` and later models, unsupported for
+    for `gpt-image-1.5` and later models (including `gpt-image-2`), unsupported for
     `gpt-image-1-mini`. Supports `high` and `low`. Defaults to `low`.
     """
 
@@ -267,7 +267,7 @@ class ImageGeneration(BaseModel):
     Contains `image_url` (string, optional) and `file_id` (string, optional).
     """
 
-    model: Union[str, Literal["gpt-image-1", "gpt-image-1-mini", "gpt-image-1.5"], None] = None
+    model: Union[str, Literal["gpt-image-1", "gpt-image-1-mini", "gpt-image-1.5", "gpt-image-2"], None] = None
     """The image generation model to use. Default: `gpt-image-1`."""
 
     moderation: Optional[Literal["auto", "low"]] = None

--- a/src/openai/types/responses/tool_param.py
+++ b/src/openai/types/responses/tool_param.py
@@ -257,7 +257,7 @@ class ImageGeneration(TypedDict, total=False):
     """
     Control how much effort the model will exert to match the style and features,
     especially facial features, of input images. This parameter is only supported
-    for `gpt-image-1` and `gpt-image-1.5` and later models, unsupported for
+    for `gpt-image-1.5` and later models (including `gpt-image-2`), unsupported for
     `gpt-image-1-mini`. Supports `high` and `low`. Defaults to `low`.
     """
 
@@ -267,7 +267,7 @@ class ImageGeneration(TypedDict, total=False):
     Contains `image_url` (string, optional) and `file_id` (string, optional).
     """
 
-    model: Union[str, Literal["gpt-image-1", "gpt-image-1-mini", "gpt-image-1.5"]]
+    model: Union[str, Literal["gpt-image-1", "gpt-image-1-mini", "gpt-image-1.5", "gpt-image-2"]]
     """The image generation model to use. Default: `gpt-image-1`."""
 
     moderation: Literal["auto", "low"]


### PR DESCRIPTION
Adds missing support for gpt-image-2 model which GA'd on 2026-04-21 for Azure OpenAI.

Fixes #3114

## Changes
- Add 'gpt-image-2' to ImageModel Literal
- Update ImageGeneration.model Literals in responses/tool.py and tool_param.py  
- Update docstrings to mention gpt-image-2 support
- Clarify input_fidelity support for gpt-image-1.5 and later models

## Verification
- Type-checker will now recognize gpt-image-2 as valid
- IDE autocomplete will include gpt-image-2
- Documentation accurately reflects supported models