### PR TITLE
types: add gpt-image-2 image model alias

### DIFF
--- a/src/openai/types/image_generate_params.py
+++ b/src/openai/types/image_generate_params.py
@@ -32,8 +32,7 @@ class ImageGenerateParamsBase(TypedDict, total=False):
     model: Union[str, ImageModel, None]
     """The model to use for image generation.
 
-    One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`,
-    `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter
+    One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`). Defaults to `dall-e-2` unless a parameter
     specific to the GPT image models is used.
     """
 

--- a/src/openai/types/image_model.py
+++ b/src/openai/types/image_model.py
@@ -4,4 +4,4 @@ from typing_extensions import Literal, TypeAlias
 
 __all__ = ["ImageModel"]
 
-ImageModel: TypeAlias = Literal["gpt-image-1.5", "dall-e-2", "dall-e-3", "gpt-image-1", "gpt-image-1-mini"]
+ImageModel: TypeAlias = Literal["gpt-image-1.5", "gpt-image-2", "dall-e-2", "dall-e-3", "gpt-image-1", "gpt-image-1-mini"]

--- a/tests/test_image_model.py
+++ b/tests/test_image_model.py
@@ -1,0 +1,7 @@
+from typing import get_args
+
+from openai.types import ImageModel
+
+
+def test_image_model_includes_gpt_image_2() -> None:
+    assert "gpt-image-2" in get_args(ImageModel)


### PR DESCRIPTION
Fixes #3114

## Summary
- add `gpt-image-2` to the public `ImageModel` literal and response tool literals
- update image generate and edit parameter docs to mention the new model
- add a regression test covering the public image model alias list

## Testing
- pytest -o addopts="" tests/test_image_model.py -q