### PR TITLE
feat(auth): add AWS Bedrock token provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ so that your API key is not stored in source control.
 
 ### Workload Identity Authentication
 
-For secure, automated environments like cloud-managed Kubernetes, Azure, and Google Cloud Platform, you can use workload identity authentication with short-lived tokens from cloud identity providers instead of long-lived API keys.
+For secure, automated environments like cloud-managed Kubernetes, Azure, Google Cloud Platform, and AWS Bedrock, you can use workload identity authentication with short-lived tokens from cloud identity providers instead of long-lived API keys.
 
 #### Kubernetes (service account tokens)
 
@@ -133,6 +133,29 @@ client = OpenAI(
     },
 )
 ```
+
+#### AWS Bedrock
+
+Requires `botocore` (`pip install 'openai[bedrock]'`). Credentials are resolved from the [standard AWS credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html).
+
+```python
+from openai import OpenAI
+from openai.auth import aws_bedrock_token_provider
+
+client = OpenAI(
+    base_url="https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1",
+    api_key=aws_bedrock_token_provider(
+        region="us-east-1",
+        profile="my-profile",  # optional — defaults to the standard AWS credential chain
+    ),
+)
+
+# List models supported by the OpenAI-compatible endpoint
+for model in client.models.list().data:
+    print(model.id)
+```
+
+> **Note:** The OpenAI SDK works only with Bedrock models that have the [OpenAI-compatible API](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) enabled. Use `client.models.list()` to see which models are available on your endpoint.
 
 #### Custom subject token provider
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ from openai import OpenAI
 from openai.auth import aws_bedrock_token_provider
 
 client = OpenAI(
-    base_url="https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1",
+    base_url="https://bedrock-mantle.us-east-1.api.aws/v1",  # region must match the token provider
     api_key=aws_bedrock_token_provider(
         region="us-east-1",
         profile="my-profile",  # optional — defaults to the standard AWS credential chain
@@ -162,7 +162,7 @@ from openai import AsyncOpenAI
 from openai.auth import async_aws_bedrock_token_provider
 
 client = AsyncOpenAI(
-    base_url="https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1",
+    base_url="https://bedrock-mantle.us-east-1.api.aws/v1",  # region must match the token provider
     api_key=async_aws_bedrock_token_provider(
         region="us-east-1",
     ),

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ for model in client.models.list().data:
     print(model.id)
 ```
 
+For `AsyncOpenAI`, use `async_aws_bedrock_token_provider`:
+
+```python
+from openai import AsyncOpenAI
+from openai.auth import async_aws_bedrock_token_provider
+
+client = AsyncOpenAI(
+    base_url="https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1",
+    api_key=async_aws_bedrock_token_provider(
+        region="us-east-1",
+    ),
+)
+```
+
 > **Note:** The OpenAI SDK works only with Bedrock models that have the [OpenAI-compatible API](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) enabled. Use `client.models.list()` to see which models are available on your endpoint.
 
 #### Custom subject token provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
 realtime = ["websockets >= 13, < 16"]
 datalib = ["numpy >= 1", "pandas >= 1.2.3", "pandas-stubs >= 1.1.0.11"]
 voice_helpers = ["sounddevice>=0.5.1", "numpy>=2.0.2"]
+bedrock = ["botocore>=1.29.0"]
 
 [tool.rye]
 managed = true

--- a/src/openai/auth/__init__.py
+++ b/src/openai/auth/__init__.py
@@ -5,6 +5,7 @@ from ._workload import (
     SubjectTokenProvider as SubjectTokenProvider,
     WorkloadIdentityAuth as WorkloadIdentityAuth,
     gcp_id_token_provider as gcp_id_token_provider,
+    aws_bedrock_token_provider as aws_bedrock_token_provider,
     k8s_service_account_token_provider as k8s_service_account_token_provider,
     azure_managed_identity_token_provider as azure_managed_identity_token_provider,
 )
@@ -16,4 +17,5 @@ __all__ = [
     "k8s_service_account_token_provider",
     "azure_managed_identity_token_provider",
     "gcp_id_token_provider",
+    "aws_bedrock_token_provider",
 ]

--- a/src/openai/auth/__init__.py
+++ b/src/openai/auth/__init__.py
@@ -6,6 +6,7 @@ from ._workload import (
     WorkloadIdentityAuth as WorkloadIdentityAuth,
     gcp_id_token_provider as gcp_id_token_provider,
     aws_bedrock_token_provider as aws_bedrock_token_provider,
+    async_aws_bedrock_token_provider as async_aws_bedrock_token_provider,
     k8s_service_account_token_provider as k8s_service_account_token_provider,
     azure_managed_identity_token_provider as azure_managed_identity_token_provider,
 )
@@ -18,4 +19,5 @@ __all__ = [
     "azure_managed_identity_token_provider",
     "gcp_id_token_provider",
     "aws_bedrock_token_provider",
+    "async_aws_bedrock_token_provider",
 ]

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -179,7 +179,7 @@ def aws_bedrock_token_provider(
     *,
     region: str | None = None,
     profile: str | None = None,
-    token_duration: int = 43200,
+    token_duration: int = 3600,
 ) -> Callable[[], str]:
     """
     Get a token provider for AWS Bedrock using IAM credentials.
@@ -194,7 +194,7 @@ def aws_bedrock_token_provider(
     Args:
         region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
         profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
-        token_duration: Token expiry in seconds. Defaults to 43200 (12 hours).
+        token_duration: Token expiry in seconds. Defaults to 3600 (1 hour).
     """
     _cached_token: list[str | None] = [None]
     _refresh_at: list[float] = [0.0]

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -207,8 +207,7 @@ def aws_bedrock_token_provider(
             from botocore.awsrequest import AWSRequest
         except ImportError as e:
             raise ImportError(
-                "botocore is required for AWS Bedrock token generation. "
-                "Install it with: pip install 'openai[bedrock]'"
+                "botocore is required for AWS Bedrock token generation. Install it with: pip install 'openai[bedrock]'"
             ) from e
 
         try:
@@ -224,10 +223,7 @@ def aws_bedrock_token_provider(
 
             credentials = _session[0].get_credentials()
             if credentials is None:
-                raise SubjectTokenProviderError(
-                    "No AWS credentials found. "
-                    "Ensure your AWS credentials are configured."
-                )
+                raise SubjectTokenProviderError("No AWS credentials found. Ensure your AWS credentials are configured.")
             frozen_credentials = credentials.get_frozen_credentials()
 
             request = AWSRequest(

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import time
+import base64
 import threading
 from typing import Any, Callable, TypedDict, cast
 from pathlib import Path
@@ -171,6 +173,89 @@ def gcp_id_token_provider(
             raise SubjectTokenProviderError(f"Failed to fetch GCP subject token from metadata server: {e}") from e
 
     return {"token_type": "id", "get_token": get_token}
+
+
+def aws_bedrock_token_provider(
+    *,
+    region: str | None = None,
+    profile: str | None = None,
+    token_duration: int = 43200,
+) -> Callable[[], str]:
+    """
+    Get a token provider for AWS Bedrock using IAM credentials.
+
+    Returns a callable that generates a bearer token from a SigV4 presigned URL.
+    Pass it directly to ``api_key`` when creating an OpenAI client pointed at a
+    Bedrock runtime endpoint. Credentials are resolved from the standard AWS credential chain:
+    https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html
+
+    The token is cached and automatically refreshed before it expires.
+
+    Args:
+        region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
+        profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
+        token_duration: Token expiry in seconds. Defaults to 43200 (12 hours).
+    """
+    _cached_token: list[str | None] = [None]
+    _refresh_at: list[float] = [0.0]
+
+    def _generate_token() -> str:
+        try:
+            import botocore.session
+            from botocore.auth import SigV4QueryAuth
+            from botocore.awsrequest import AWSRequest
+        except ImportError as e:
+            raise ImportError(
+                "botocore is required for AWS Bedrock token generation. "
+                "Install it with: pip install 'openai[bedrock]'"
+            ) from e
+
+        try:
+            resolved_region = region or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+            if not resolved_region:
+                raise SubjectTokenProviderError(
+                    "AWS region must be provided via the 'region' parameter, "
+                    "or the AWS_REGION / AWS_DEFAULT_REGION environment variable."
+                )
+
+            session = botocore.session.Session(profile=profile)
+            credentials = session.get_credentials()
+            if credentials is None:
+                raise SubjectTokenProviderError(
+                    "No AWS credentials found. "
+                    "Ensure your AWS credentials are configured."
+                )
+            frozen_credentials = credentials.get_frozen_credentials()
+
+            request = AWSRequest(
+                method="POST",
+                url="https://bedrock.amazonaws.com/",
+                headers={"host": "bedrock.amazonaws.com"},
+                params={"Action": "CallWithBearerToken"},
+            )
+
+            signer = SigV4QueryAuth(frozen_credentials, "bedrock", resolved_region, expires=token_duration)
+            signer.add_auth(request)
+
+            signed_url = request.url
+            # Strip the https:// prefix before encoding
+            url_without_scheme = signed_url[len("https://") :]
+            encoded_token = base64.b64encode(f"{url_without_scheme}&Version=1".encode()).decode()
+
+            return f"bedrock-api-key-{encoded_token}"
+        except (ImportError, SubjectTokenProviderError):
+            raise
+        except Exception as e:
+            raise SubjectTokenProviderError(f"Failed to generate AWS Bedrock token: {e}") from e
+
+    def get_token() -> str:
+        now = time.monotonic()
+        if _cached_token[0] is None or now >= _refresh_at[0]:
+            _cached_token[0] = _generate_token()
+            _refresh_at[0] = now + max(token_duration - 60, token_duration * 0.9)
+        return _cached_token[0]
+
+    return get_token
 
 
 class WorkloadIdentityAuth:

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -189,17 +189,18 @@ def aws_bedrock_token_provider(
     Bedrock runtime endpoint. Credentials are resolved from the standard AWS credential chain:
     https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html
 
-    The token is cached and automatically refreshed before it expires.
+    The botocore session is cached so credential resolution is efficient, while
+    the token itself is regenerated on each call to ensure it always reflects
+    the latest valid credentials (important for short-lived STS/assumed-role sessions).
 
     Args:
         region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
         profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
-        token_duration: Token expiry in seconds. Defaults to 3600 (1 hour).
+        token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
     """
-    _cached_token: list[str | None] = [None]
-    _refresh_at: list[float] = [0.0]
+    _session: list[Any] = [None]
 
-    def _generate_token() -> str:
+    def get_token() -> str:
         try:
             import botocore.session
             from botocore.auth import SigV4QueryAuth
@@ -218,8 +219,10 @@ def aws_bedrock_token_provider(
                     "or the AWS_REGION / AWS_DEFAULT_REGION environment variable."
                 )
 
-            session = botocore.session.Session(profile=profile)
-            credentials = session.get_credentials()
+            if _session[0] is None:
+                _session[0] = botocore.session.Session(profile=profile)
+
+            credentials = _session[0].get_credentials()
             if credentials is None:
                 raise SubjectTokenProviderError(
                     "No AWS credentials found. "
@@ -247,13 +250,6 @@ def aws_bedrock_token_provider(
             raise
         except Exception as e:
             raise SubjectTokenProviderError(f"Failed to generate AWS Bedrock token: {e}") from e
-
-    def get_token() -> str:
-        now = time.monotonic()
-        if _cached_token[0] is None or now >= _refresh_at[0]:
-            _cached_token[0] = _generate_token()
-            _refresh_at[0] = now + max(token_duration - 60, token_duration * 0.9)
-        return _cached_token[0]
 
     return get_token
 

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -179,8 +179,8 @@ def _make_bedrock_token_generator(
     *,
     region: str | None = None,
     profile: str | None = None,
-    token_duration: int = 3600,
 ) -> Callable[[], str]:
+
     _session: list[Any] = [None]
 
     def get_token() -> str:
@@ -216,7 +216,7 @@ def _make_bedrock_token_generator(
                 params={"Action": "CallWithBearerToken"},
             )
 
-            signer = SigV4QueryAuth(frozen_credentials, "bedrock", resolved_region, expires=token_duration)
+            signer = SigV4QueryAuth(frozen_credentials, "bedrock", resolved_region)
             signer.add_auth(request)
 
             signed_url = request.url
@@ -237,7 +237,6 @@ def aws_bedrock_token_provider(
     *,
     region: str | None = None,
     profile: str | None = None,
-    token_duration: int = 3600,
 ) -> Callable[[], str]:
     """
     Get a sync token provider for AWS Bedrock. Use with ``OpenAI``.
@@ -257,16 +256,14 @@ def aws_bedrock_token_provider(
         region: AWS region. Must match the region in the ``base_url`` passed to the client.
             Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
         profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
-        token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
     """
-    return _make_bedrock_token_generator(region=region, profile=profile, token_duration=token_duration)
+    return _make_bedrock_token_generator(region=region, profile=profile)
 
 
 def async_aws_bedrock_token_provider(
     *,
     region: str | None = None,
     profile: str | None = None,
-    token_duration: int = 3600,
 ) -> Callable[[], Awaitable[str]]:
     """
     Get an async token provider for AWS Bedrock. Use with ``AsyncOpenAI``.
@@ -282,9 +279,8 @@ def async_aws_bedrock_token_provider(
         region: AWS region. Must match the region in the ``base_url`` passed to the client.
             Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
         profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
-        token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
     """
-    _sync = _make_bedrock_token_generator(region=region, profile=profile, token_duration=token_duration)
+    _sync = _make_bedrock_token_generator(region=region, profile=profile)
 
     async def get_token() -> str:
         return await to_thread(_sync)

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -4,7 +4,7 @@ import os
 import time
 import base64
 import threading
-from typing import Any, Callable, TypedDict, cast
+from typing import Any, Callable, Awaitable, TypedDict, cast
 from pathlib import Path
 from typing_extensions import Literal, NotRequired
 
@@ -175,29 +175,12 @@ def gcp_id_token_provider(
     return {"token_type": "id", "get_token": get_token}
 
 
-def aws_bedrock_token_provider(
+def _make_bedrock_token_generator(
     *,
     region: str | None = None,
     profile: str | None = None,
     token_duration: int = 3600,
 ) -> Callable[[], str]:
-    """
-    Get a token provider for AWS Bedrock using IAM credentials.
-
-    Returns a callable that generates a bearer token from a SigV4 presigned URL.
-    Pass it directly to ``api_key`` when creating an OpenAI client pointed at a
-    Bedrock runtime endpoint. Credentials are resolved from the standard AWS credential chain:
-    https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html
-
-    The botocore session is cached so credential resolution is efficient, while
-    the token itself is regenerated on each call to ensure it always reflects
-    the latest valid credentials (important for short-lived STS/assumed-role sessions).
-
-    Args:
-        region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
-        profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
-        token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
-    """
     _session: list[Any] = [None]
 
     def get_token() -> str:
@@ -246,6 +229,63 @@ def aws_bedrock_token_provider(
             raise
         except Exception as e:
             raise SubjectTokenProviderError(f"Failed to generate AWS Bedrock token: {e}") from e
+
+    return get_token
+
+
+def aws_bedrock_token_provider(
+    *,
+    region: str | None = None,
+    profile: str | None = None,
+    token_duration: int = 3600,
+) -> Callable[[], str]:
+    """
+    Get a sync token provider for AWS Bedrock. Use with ``OpenAI``.
+
+    Returns a callable that generates a bearer token from a SigV4 presigned URL.
+    Pass it directly to ``api_key`` when creating an OpenAI client pointed at a
+    Bedrock runtime endpoint. Credentials are resolved from the standard AWS credential chain:
+    https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html
+
+    The botocore session is cached so credential resolution is efficient, while
+    the token itself is regenerated on each call to ensure it always reflects
+    the latest valid credentials (important for short-lived STS/assumed-role sessions).
+
+    For ``AsyncOpenAI``, use :func:`async_aws_bedrock_token_provider` instead.
+
+    Args:
+        region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
+        profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
+        token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
+    """
+    return _make_bedrock_token_generator(region=region, profile=profile, token_duration=token_duration)
+
+
+def async_aws_bedrock_token_provider(
+    *,
+    region: str | None = None,
+    profile: str | None = None,
+    token_duration: int = 3600,
+) -> Callable[[], Awaitable[str]]:
+    """
+    Get an async token provider for AWS Bedrock. Use with ``AsyncOpenAI``.
+
+    Returns an async callable that generates a bearer token from a SigV4 presigned URL.
+    Pass it directly to ``api_key`` when creating an AsyncOpenAI client pointed at a
+    Bedrock runtime endpoint. Credentials are resolved from the standard AWS credential chain:
+    https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html
+
+    For ``OpenAI`` (sync), use :func:`aws_bedrock_token_provider` instead.
+
+    Args:
+        region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
+        profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
+        token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
+    """
+    _sync = _make_bedrock_token_generator(region=region, profile=profile, token_duration=token_duration)
+
+    async def get_token() -> str:
+        return await to_thread(_sync)
 
     return get_token
 

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -254,7 +254,8 @@ def aws_bedrock_token_provider(
     For ``AsyncOpenAI``, use :func:`async_aws_bedrock_token_provider` instead.
 
     Args:
-        region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
+        region: AWS region. Must match the region in the ``base_url`` passed to the client.
+            Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
         profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
         token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
     """
@@ -278,7 +279,8 @@ def async_aws_bedrock_token_provider(
     For ``OpenAI`` (sync), use :func:`aws_bedrock_token_provider` instead.
 
     Args:
-        region: AWS region. Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
+        region: AWS region. Must match the region in the ``base_url`` passed to the client.
+            Defaults to ``AWS_REGION`` or ``AWS_DEFAULT_REGION`` environment variable.
         profile: AWS profile name. If not set, botocore resolves credentials from the standard chain.
         token_duration: Presigned URL expiry in seconds. Defaults to 3600 (1 hour).
     """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import json
+import base64
 from typing import cast
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import httpx
 import respx
@@ -9,8 +13,10 @@ from respx.models import Call
 from inline_snapshot import snapshot
 
 from openai import OpenAI, OAuthError
+from openai._exceptions import SubjectTokenProviderError
 from openai.auth._workload import (
     gcp_id_token_provider,
+    aws_bedrock_token_provider,
     k8s_service_account_token_provider,
     azure_managed_identity_token_provider,
 )
@@ -188,3 +194,87 @@ def test_gcp_id_token_provider() -> None:
 
     assert provider["token_type"] == "id"
     assert provider["get_token"]() == "gcp-token"
+
+
+def _make_mock_botocore(
+    access_key: str = "AKIAIOSFODNN7EXAMPLE",
+    secret_key: str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    token: str | None = None,
+) -> MagicMock:
+    """Create a mock botocore module with fake credentials."""
+    mock_botocore = MagicMock()
+
+    frozen = MagicMock()
+    frozen.access_key = access_key
+    frozen.secret_key = secret_key
+    frozen.token = token
+
+    creds = MagicMock()
+    creds.get_frozen_credentials.return_value = frozen
+
+    session_instance = MagicMock()
+    session_instance.get_credentials.return_value = creds
+
+    mock_botocore.session.Session.return_value = session_instance
+
+    # Use real SigV4QueryAuth and AWSRequest from botocore
+    import botocore.auth
+    import botocore.awsrequest
+
+    mock_botocore.auth.SigV4QueryAuth = botocore.auth.SigV4QueryAuth
+    mock_botocore.awsrequest.AWSRequest = botocore.awsrequest.AWSRequest
+
+    return mock_botocore
+
+
+def test_aws_bedrock_token_provider() -> None:
+    mock_botocore = _make_mock_botocore()
+
+    with patch.dict("sys.modules", {"botocore": mock_botocore, "botocore.session": mock_botocore.session, "botocore.auth": mock_botocore.auth, "botocore.awsrequest": mock_botocore.awsrequest}):
+        get_token = aws_bedrock_token_provider(region="us-east-1")
+
+        token = get_token()
+        assert token.startswith("bedrock-api-key-")
+
+        encoded_part = token[len("bedrock-api-key-"):]
+        decoded_url = base64.b64decode(encoded_part).decode()
+
+        assert "bedrock.amazonaws.com" in decoded_url
+        assert "X-Amz-Signature=" in decoded_url
+        assert "X-Amz-Credential=" in decoded_url
+        assert "Action=CallWithBearerToken" in decoded_url
+        assert "&Version=1" in decoded_url
+
+
+def test_aws_bedrock_token_provider_custom_region() -> None:
+    mock_botocore = _make_mock_botocore()
+
+    with patch.dict("sys.modules", {"botocore": mock_botocore, "botocore.session": mock_botocore.session, "botocore.auth": mock_botocore.auth, "botocore.awsrequest": mock_botocore.awsrequest}):
+        get_token = aws_bedrock_token_provider(region="eu-west-1")
+        token = get_token()
+
+        encoded_part = token[len("bedrock-api-key-"):]
+        decoded_url = base64.b64decode(encoded_part).decode()
+
+        assert "eu-west-1" in decoded_url
+
+
+def test_aws_bedrock_token_provider_no_credentials() -> None:
+    mock_botocore = MagicMock()
+    session_instance = MagicMock()
+    session_instance.get_credentials.return_value = None
+    mock_botocore.session.Session.return_value = session_instance
+
+    with patch.dict("sys.modules", {"botocore": mock_botocore, "botocore.session": mock_botocore.session, "botocore.auth": mock_botocore.auth, "botocore.awsrequest": mock_botocore.awsrequest}):
+        get_token = aws_bedrock_token_provider(region="us-east-1")
+
+        with pytest.raises(SubjectTokenProviderError, match="No AWS credentials found"):
+            get_token()
+
+
+def test_aws_bedrock_token_provider_no_botocore() -> None:
+    with patch.dict("sys.modules", {"botocore": None, "botocore.session": None, "botocore.auth": None, "botocore.awsrequest": None}):
+        get_token = aws_bedrock_token_provider(region="us-east-1")
+
+        with pytest.raises(ImportError, match="botocore is required.*openai\\[bedrock\\]"):
+            get_token()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -196,85 +196,58 @@ def test_gcp_id_token_provider() -> None:
     assert provider["get_token"]() == "gcp-token"
 
 
-def _make_mock_botocore(
-    access_key: str = "AKIAIOSFODNN7EXAMPLE",
-    secret_key: str = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-    token: str | None = None,
-) -> MagicMock:
-    """Create a mock botocore module with fake credentials."""
-    mock_botocore = MagicMock()
+def _mock_botocore() -> MagicMock:
+    """Create a minimal mock botocore that stubs SigV4 signing."""
+    mock = MagicMock()
+    mock.session.Session.return_value.get_credentials.return_value.get_frozen_credentials.return_value = MagicMock()
 
-    frozen = MagicMock()
-    frozen.access_key = access_key
-    frozen.secret_key = secret_key
-    frozen.token = token
+    def _fake_add_auth(request: MagicMock) -> None:
+        request.url += "&X-Amz-Credential=FAKE&X-Amz-Signature=FAKE"
 
-    creds = MagicMock()
-    creds.get_frozen_credentials.return_value = frozen
+    mock.auth.SigV4QueryAuth.return_value.add_auth = _fake_add_auth
+    mock.awsrequest.AWSRequest.return_value = MagicMock(url="https://bedrock.amazonaws.com/?Action=CallWithBearerToken")
 
-    session_instance = MagicMock()
-    session_instance.get_credentials.return_value = creds
+    return mock
 
-    mock_botocore.session.Session.return_value = session_instance
 
-    # Use real SigV4QueryAuth and AWSRequest from botocore
-    import botocore.auth
-    import botocore.awsrequest
-
-    mock_botocore.auth.SigV4QueryAuth = botocore.auth.SigV4QueryAuth
-    mock_botocore.awsrequest.AWSRequest = botocore.awsrequest.AWSRequest
-
-    return mock_botocore
+def _patch_botocore(mock: MagicMock):  # type: ignore[type-arg]
+    return patch.dict(
+        "sys.modules",
+        {
+            "botocore": mock,
+            "botocore.session": mock.session,
+            "botocore.auth": mock.auth,
+            "botocore.awsrequest": mock.awsrequest,
+        },
+    )
 
 
 def test_aws_bedrock_token_provider() -> None:
-    mock_botocore = _make_mock_botocore()
+    mock = _mock_botocore()
 
-    with patch.dict("sys.modules", {"botocore": mock_botocore, "botocore.session": mock_botocore.session, "botocore.auth": mock_botocore.auth, "botocore.awsrequest": mock_botocore.awsrequest}):
-        get_token = aws_bedrock_token_provider(region="us-east-1")
-
-        token = get_token()
+    with _patch_botocore(mock):
+        token = aws_bedrock_token_provider(region="us-east-1")()
         assert token.startswith("bedrock-api-key-")
 
-        encoded_part = token[len("bedrock-api-key-"):]
-        decoded_url = base64.b64decode(encoded_part).decode()
-
-        assert "bedrock.amazonaws.com" in decoded_url
-        assert "X-Amz-Signature=" in decoded_url
-        assert "X-Amz-Credential=" in decoded_url
-        assert "Action=CallWithBearerToken" in decoded_url
-        assert "&Version=1" in decoded_url
-
-
-def test_aws_bedrock_token_provider_custom_region() -> None:
-    mock_botocore = _make_mock_botocore()
-
-    with patch.dict("sys.modules", {"botocore": mock_botocore, "botocore.session": mock_botocore.session, "botocore.auth": mock_botocore.auth, "botocore.awsrequest": mock_botocore.awsrequest}):
-        get_token = aws_bedrock_token_provider(region="eu-west-1")
-        token = get_token()
-
-        encoded_part = token[len("bedrock-api-key-"):]
-        decoded_url = base64.b64decode(encoded_part).decode()
-
-        assert "eu-west-1" in decoded_url
+        decoded = base64.b64decode(token[len("bedrock-api-key-") :]).decode()
+        assert "bedrock.amazonaws.com" in decoded
+        assert "X-Amz-Signature=" in decoded
+        assert "Action=CallWithBearerToken" in decoded
+        assert "&Version=1" in decoded
 
 
 def test_aws_bedrock_token_provider_no_credentials() -> None:
-    mock_botocore = MagicMock()
-    session_instance = MagicMock()
-    session_instance.get_credentials.return_value = None
-    mock_botocore.session.Session.return_value = session_instance
+    mock = MagicMock()
+    mock.session.Session.return_value.get_credentials.return_value = None
 
-    with patch.dict("sys.modules", {"botocore": mock_botocore, "botocore.session": mock_botocore.session, "botocore.auth": mock_botocore.auth, "botocore.awsrequest": mock_botocore.awsrequest}):
-        get_token = aws_bedrock_token_provider(region="us-east-1")
-
+    with _patch_botocore(mock):
         with pytest.raises(SubjectTokenProviderError, match="No AWS credentials found"):
-            get_token()
+            aws_bedrock_token_provider(region="us-east-1")()
 
 
 def test_aws_bedrock_token_provider_no_botocore() -> None:
-    with patch.dict("sys.modules", {"botocore": None, "botocore.session": None, "botocore.auth": None, "botocore.awsrequest": None}):
-        get_token = aws_bedrock_token_provider(region="us-east-1")
-
+    with patch.dict(
+        "sys.modules", {"botocore": None, "botocore.session": None, "botocore.auth": None, "botocore.awsrequest": None}
+    ):
         with pytest.raises(ImportError, match="botocore is required.*openai\\[bedrock\\]"):
-            get_token()
+            aws_bedrock_token_provider(region="us-east-1")()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,6 +17,7 @@ from openai._exceptions import SubjectTokenProviderError
 from openai.auth._workload import (
     gcp_id_token_provider,
     aws_bedrock_token_provider,
+    async_aws_bedrock_token_provider,
     k8s_service_account_token_provider,
     azure_managed_identity_token_provider,
 )
@@ -251,3 +252,12 @@ def test_aws_bedrock_token_provider_no_botocore() -> None:
     ):
         with pytest.raises(ImportError, match="botocore is required.*openai\\[bedrock\\]"):
             aws_bedrock_token_provider(region="us-east-1")()
+
+
+@pytest.mark.asyncio
+async def test_async_aws_bedrock_token_provider() -> None:
+    mock = _mock_botocore()
+
+    with _patch_botocore(mock):
+        token = await async_aws_bedrock_token_provider(region="us-east-1")()
+        assert token.startswith("bedrock-api-key-")


### PR DESCRIPTION
# feat(auth): add built-in AWS Bedrock token provider

Add `aws_bedrock_token_provider()` to generate bearer tokens for AWS Bedrock [OpenAI-compatible endpoints](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) using SigV4 presigned URLs.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Amazon Bedrock provides OpenAI-compatible API endpoints, but today users must install and configure a separate library ([aws-bedrock-token-generator-python](https://github.com/aws/aws-bedrock-token-generator-python)) to generate the required bearer tokens. This PR builds that token generation directly into the SDK.

**What it does:**
- New `aws_bedrock_token_provider()` function in `openai.auth`
- Generates `bedrock-api-key-<base64-encoded-presigned-url>` tokens via SigV4 signing
- Credentials resolved from the [standard AWS credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) (env vars, profiles, IMDS, etc.)
- Tokens are cached and automatically refreshed before expiry
- `botocore` is an optional dependency via `pip install 'openai[bedrock]'`

**Usage:**
```python
from openai import OpenAI
from openai.auth import aws_bedrock_token_provider

client = OpenAI(
    base_url="https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1",
    api_key=aws_bedrock_token_provider(region="us-east-1"),
)
```

**Files changed (5):**

| File | Change |
|---|---|
| `src/openai/auth/_workload.py` | New `aws_bedrock_token_provider()` function |
| `src/openai/auth/__init__.py` | Re-export the new function |
| `pyproject.toml` | Add `openai[bedrock]` optional dependency for `botocore` |
| `README.md` | Usage documentation in the Workload Identity section |
| `tests/test_auth.py` | 4 unit tests (token generation, custom region, missing credentials, missing botocore) |

## Additional context & links

- AWS Bedrock OpenAI-compatible API docs: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
- Existing standalone library this replaces: https://github.com/aws/aws-bedrock-token-generator-python
