### PR TITLE
docs: fix vector store helper paths

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -510,9 +510,9 @@ The polling methods are:
 client.beta.threads.create_and_run_poll(...)
 client.beta.threads.runs.create_and_poll(...)
 client.beta.threads.runs.submit_tool_outputs_and_poll(...)
-client.beta.vector_stores.files.upload_and_poll(...)
-client.beta.vector_stores.files.create_and_poll(...)
-client.beta.vector_stores.file_batches.create_and_poll(...)
-client.beta.vector_stores.file_batches.upload_and_poll(...)
+client.vector_stores.files.upload_and_poll(...)
+client.vector_stores.files.create_and_poll(...)
+client.vector_stores.file_batches.create_and_poll(...)
+client.vector_stores.file_batches.upload_and_poll(...)
 client.videos.create_and_poll(...)
 ```


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fix the helper examples in `helpers.md` to use `client.vector_stores...` instead of `client.beta.vector_stores...`.

This matches the generated client surface in `src/openai/_client.py` and `api.md`, where vector stores are exposed as a top-level client resource rather than under `beta`.

Fixes #2451

## Additional context & links

I also did a local sanity check against the repo source to confirm:
- `OpenAI(...).vector_stores` exists
- `OpenAI(...).beta.vector_stores` does not exist

I did not change generated client code, only the outdated helper documentation.
