### PR TITLE
fix: correct context_management type from 'type' to 'compaction' in tests

### DIFF
--- a/tests/api_resources/test_responses.py
+++ b/tests/api_resources/test_responses.py
@@ -32,7 +32,7 @@ class TestResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -120,7 +120,7 @@ class TestResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -444,7 +444,7 @@ class TestAsyncResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -532,7 +532,7 @@ class TestAsyncResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],


### PR DESCRIPTION
## Problem

The tests in `tests/api_resources/test_responses.py` were using an incorrect value `type` for the `context_management` `type` field, which should be `compaction` according to the API specification.

## Solution

Replace the 4 occurrences of the hard-coded `type` with `compaction` in `tests/api_resources/test_responses.py`. This is a minimal, targeted fix that only changes the test expectations to match the correct API behavior.

## Verification

- Reviewed the diff to confirm only the 4 intended lines were changed.
- Confirmed the modified file is the only changed file in this commit.

Closes #2868.