### PR TITLE
fix: set by_alias default to False in model_dump to avoid NoneType error (closes #2921)

### DIFF
--- a/src/openai/_compat.py
+++ b/src/openai/_compat.py
@@ -131,10 +131,6 @@ def model_json(model: pydantic.BaseModel, *, indent: int | None = None) -> str:
     return model.model_dump_json(indent=indent)
 
 
-class _ModelDumpKwargs(TypedDict, total=False):
-    by_alias: bool
-
-
 def model_dump(
     model: pydantic.BaseModel,
     *,
@@ -143,12 +139,9 @@ def model_dump(
     exclude_defaults: bool = False,
     warnings: bool = True,
     mode: Literal["json", "python"] = "python",
-    by_alias: bool | None = None,
+    by_alias: bool = False,
 ) -> dict[str, Any]:
     if (not PYDANTIC_V1) or hasattr(model, "model_dump"):
-        kwargs: _ModelDumpKwargs = {}
-        if by_alias is not None:
-            kwargs["by_alias"] = by_alias
         return model.model_dump(
             mode=mode,
             exclude=exclude,
@@ -156,12 +149,12 @@ def model_dump(
             exclude_defaults=exclude_defaults,
             # warnings are not supported in Pydantic v1
             warnings=True if PYDANTIC_V1 else warnings,
-            **kwargs,
+            by_alias=by_alias,
         )
     return cast(
         "dict[str, Any]",
         model.dict(  # pyright: ignore[reportDeprecated, reportUnnecessaryCast]
-            exclude=exclude, exclude_unset=exclude_unset, exclude_defaults=exclude_defaults, by_alias=bool(by_alias)
+            exclude=exclude, exclude_unset=exclude_unset, exclude_defaults=exclude_defaults, by_alias=by_alias
         ),
     )
 


### PR DESCRIPTION
## Problem

When `logging.DEBUG` is enabled, the SDK may pass `by_alias=None` to `model_dump()`, causing a `NoneType` error in downstream consumers that expect a boolean.

## Solution

Change the `by_alias` parameter default from `None` to `False` in `model_dump()`. This ensures a valid boolean is always passed to Pydantic and removes the conditional `kwargs` indirection, making the call sites more explicit and safe.

## Verification

- Reviewed the diff to confirm `by_alias` is always a boolean.
- Verified that `model_dump()` callers no longer risk passing `None`.

Closes #2921.