### PR TITLE
Nightly OSS: Support 

### DIFF
--- a/src/openai/cli/_api/completions.py
+++ b/src/openai/cli/_api/completions.py
@@ -93,6 +93,7 @@ Mutually exclusive with `top_p`.""",
 class CLICompletionCreateArgs(BaseModel):
     model: str
     stream: bool = False
+    json_output: bool = False
 
     prompt: Optional[str] = None
     n: Omittable[int] = omit
@@ -114,6 +115,8 @@ class CLICompletions:
     def create(args: CLICompletionCreateArgs) -> None:
         if is_given(args.n) and args.n > 1 and args.stream:
             raise CLIError("Can't stream completions with n>1 with the current CLI")
+        if args.json_output and args.stream:
+            raise CLIError("Can't stream completions as JSON with the current CLI")
 
         make_request = partial(
             get_client().completions.create,
@@ -139,10 +142,14 @@ class CLICompletions:
                 cast(Stream[Completion], make_request(stream=True))  # pyright: ignore[reportUnnecessaryCast]
             )
 
-        return CLICompletions._create(make_request())
+        return CLICompletions._create(make_request(), json_output=args.json_output)
 
     @staticmethod
-    def _create(completion: Completion) -> None:
+    def _create(completion: Completion, *, json_output: bool = False) -> None:
+        if json_output:
+            sys.stdout.write(completion.to_json() + "\n")
+            return
+
         should_print_header = len(completion.choices) > 1
         for choice in completion.choices:
             if should_print_header:

--- a/src/openai/cli/_cli.py
+++ b/src/openai/cli/_cli.py
@@ -57,6 +57,7 @@ class Arguments(BaseModel):
     # internal, used so that subparsers can forward unknown arguments
     unknown_args: List[str] = []
     allow_unknown_args: bool = False
+    json_output: bool = False
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -114,6 +115,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers()
     sub_api = subparsers.add_parser("api", help="Direct API calls")
+    sub_api.add_argument(
+        "--json", help="Print supported API responses as JSON.", action="store_true", dest="json_output"
+    )
 
     register_commands(sub_api)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import json
+
+import pytest
+
+from openai.types import Completion
+from openai._compat import model_parse
+from openai.cli._cli import _parse_args, _build_parser
+from openai.cli._errors import CLIError
+from openai.cli._api.completions import CLICompletions, CLICompletionCreateArgs
+from openai.types.completion_choice import CompletionChoice
+
+
+def test_api_json_flag_is_passed_to_completion_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["openai", "api", "--json", "completions.create", "--model", "gpt-3.5-turbo-instruct"],
+    )
+
+    parsed, args, _ = _parse_args(_build_parser())
+    assert args.args_model is CLICompletionCreateArgs
+
+    completion_args = model_parse(
+        CLICompletionCreateArgs, {key: value for key, value in vars(parsed).items() if value is not None}
+    )
+    assert completion_args.json_output is True
+
+
+def test_completion_create_prints_json(capsys: pytest.CaptureFixture[str]) -> None:
+    completion = Completion(
+        id="cmpl-123",
+        choices=[CompletionChoice(finish_reason="length", index=0, text="Hello")],
+        created=1,
+        model="gpt-3.5-turbo-instruct",
+        object="text_completion",
+    )
+
+    CLICompletions._create(completion, json_output=True)
+
+    assert json.loads(capsys.readouterr().out) == {
+        "id": "cmpl-123",
+        "choices": [{"finish_reason": "length", "index": 0, "text": "Hello"}],
+        "created": 1,
+        "model": "gpt-3.5-turbo-instruct",
+        "object": "text_completion",
+    }
+
+
+def test_completion_create_rejects_streaming_json() -> None:
+    args = CLICompletionCreateArgs(model="gpt-3.5-turbo-instruct", stream=True, json_output=True)
+
+    with pytest.raises(CLIError, match="Can't stream completions as JSON"):
+        CLICompletions.create(args)


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/315.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
