### PR TITLE
Nightly OSS: json_schema structured output type not supported in gpt-4o assistants

### DIFF
--- a/tests/lib/test_assistants.py
+++ b/tests/lib/test_assistants.py
@@ -1,9 +1,58 @@
 from __future__ import annotations
 
+import json
+
+import httpx
 import pytest
+from respx import MockRouter
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai.types.shared_params.response_format_json_schema import ResponseFormatJSONSchema
+
+
+def test_assistant_create_sends_json_schema_response_format(client: OpenAI, respx_mock: MockRouter) -> None:
+    response_format: ResponseFormatJSONSchema = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "project_spending",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "authority_name": {"type": "string"},
+                    "project_count": {"type": "integer"},
+                },
+                "required": ["authority_name", "project_count"],
+                "additionalProperties": False,
+            },
+            "strict": True,
+        },
+    }
+    route = respx_mock.post("/assistants").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": "asst_123",
+                "created_at": 1,
+                "model": "gpt-4o",
+                "object": "assistant",
+                "tools": [],
+                "response_format": response_format,
+            },
+        )
+    )
+
+    with pytest.warns(DeprecationWarning):
+        assistant = client.beta.assistants.create(  # pyright: ignore[reportDeprecated]
+            model="gpt-4o",
+            response_format=response_format,
+        )
+
+    assert assistant.response_format is not None
+    assert json.loads(route.calls.last.request.content) == {
+        "model": "gpt-4o",
+        "response_format": response_format,
+    }
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/1857.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
