### PR TITLE
Nightly OSS: BadRequestError: Unknown parameter 'input[2].parsed_arguments' when invoking OpenAI Responses API via LangGraph with tool bindings

### DIFF
--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -384,7 +384,7 @@ async def _async_transform_recursive(
         return data
 
     if isinstance(data, pydantic.BaseModel):
-        return model_dump(data, exclude_unset=True, mode="json")
+        return model_dump(data, exclude_unset=True, mode="json", exclude=getattr(data, "__api_exclude__", None))
 
     annotated_type = _get_annotated_type(annotation)
     if annotated_type is None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -17,6 +17,8 @@ from openai._utils import (
 )
 from openai._compat import PYDANTIC_V1
 from openai._models import BaseModel
+from openai.types.responses.parsed_response import ParsedResponseFunctionToolCall
+from openai.types.responses.response_create_params import ResponseCreateParamsNonStreaming
 
 _T = TypeVar("_T")
 
@@ -277,6 +279,32 @@ class MyModel(BaseModel):
 async def test_pydantic_model_to_dictionary(use_async: bool) -> None:
     assert cast(Any, await transform(MyModel(foo="hi!"), Any, use_async)) == {"foo": "hi!"}
     assert cast(Any, await transform(MyModel.construct(foo="hi!"), Any, use_async)) == {"foo": "hi!"}
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_pydantic_model_uses_api_exclude(use_async: bool) -> None:
+    call = ParsedResponseFunctionToolCall(
+        arguments='{"location":"San Francisco"}',
+        call_id="call_123",
+        name="get_weather",
+        type="function_call",
+        parsed_arguments={"location": "San Francisco"},
+    )
+
+    params = await transform({"input": [call], "model": "gpt-5.1"}, ResponseCreateParamsNonStreaming, use_async)
+
+    assert cast(Any, params) == {
+        "input": [
+            {
+                "arguments": '{"location":"San Francisco"}',
+                "call_id": "call_123",
+                "name": "get_weather",
+                "type": "function_call",
+            }
+        ],
+        "model": "gpt-5.1",
+    }
 
 
 @parametrize


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2720.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
