### PR TITLE
Nightly OSS: Moderation Endpoint Schema Mismatch for illicit and illicit_violent fields

### DIFF
--- a/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
+++ b/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
@@ -1,0 +1,12 @@
+Implemented the targeted fix.
+
+Changed [src/openai/types/moderation.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/src/openai/types/moderation.py) so `CategoryScores.illicit` and `CategoryScores.illicit_violent` are `Optional[float] = None`, matching the nullable API behavior described in issue #1786.
+
+Added [tests/test_moderation_types.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/tests/test_moderation_types.py) covering API-style alias keys with `None` values and serialization back to API names.
+
+Wrote [NIGHTLY_REPORT.md](/home/runner/work/oss-nightly-control/oss-nightly-control/target/NIGHTLY_REPORT.md).
+
+Verification passed:
+- `.venv/bin/python -m pytest tests/test_moderation_types.py`
+- `.venv/bin/python -m ruff check src/openai/types/moderation.py tests/test_moderation_types.py`
+- `.venv/bin/pyright --pythonpath .venv/bin/python src/openai/types/moderation.py tests/test_moderation_types.py`

--- a/src/openai/types/moderation.py
+++ b/src/openai/types/moderation.py
@@ -150,10 +150,10 @@ class CategoryScores(BaseModel):
     hate_threatening: float = FieldInfo(alias="hate/threatening")
     """The score for the category 'hate/threatening'."""
 
-    illicit: float
+    illicit: Optional[float] = None
     """The score for the category 'illicit'."""
 
-    illicit_violent: float = FieldInfo(alias="illicit/violent")
+    illicit_violent: Optional[float] = FieldInfo(alias="illicit/violent", default=None)
     """The score for the category 'illicit/violent'."""
 
     self_harm: float = FieldInfo(alias="self-harm")

--- a/tests/test_moderation_types.py
+++ b/tests/test_moderation_types.py
@@ -1,0 +1,41 @@
+from openai._compat import parse_obj
+from openai.types.moderation import CategoryScores
+
+
+def test_moderation_category_scores_allows_nullable_illicit_fields() -> None:
+    scores = parse_obj(
+        CategoryScores,
+        {
+            "harassment": 0.0,
+            "harassment/threatening": 0.0,
+            "hate": 0.0,
+            "hate/threatening": 0.0,
+            "illicit": None,
+            "illicit/violent": None,
+            "self-harm": 0.0,
+            "self-harm/instructions": 0.0,
+            "self-harm/intent": 0.0,
+            "sexual": 0.0,
+            "sexual/minors": 0.0,
+            "violence": 0.0,
+            "violence/graphic": 0.0,
+        },
+    )
+
+    assert scores.illicit is None
+    assert scores.illicit_violent is None
+    assert scores.to_dict() == {
+        "harassment": 0.0,
+        "harassment/threatening": 0.0,
+        "hate": 0.0,
+        "hate/threatening": 0.0,
+        "illicit": None,
+        "illicit/violent": None,
+        "self-harm": 0.0,
+        "self-harm/instructions": 0.0,
+        "self-harm/intent": 0.0,
+        "sexual": 0.0,
+        "sexual/minors": 0.0,
+        "violence": 0.0,
+        "violence/graphic": 0.0,
+    }


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/1786.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
