### PR TITLE
Nightly OSS: Encountering a 500 error when calling responses.parse on a schema containing decimal.Decimal fields.

### DIFF
--- a/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
+++ b/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
@@ -1,0 +1,11 @@
+Implemented a small test-only contribution.
+
+Changed [tests/lib/responses/test_responses.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/tests/lib/responses/test_responses.py) to add coverage for `responses.parse` with a Pydantic model containing `decimal.Decimal` fields, asserting parsed JSON string values become `Decimal` instances in `response.output_parsed`.
+
+Also added [NIGHTLY_REPORT.md](/home/runner/work/oss-nightly-control/oss-nightly-control/target/NIGHTLY_REPORT.md) with summary, tests, and risk notes. I avoided duplicating the broader schema fix because upstream PR [openai/openai-python#2733](https://github.com/openai/openai-python/pull/2733) is already active for issue [#2718](https://github.com/openai/openai-python/issues/2718).
+
+Verification run:
+
+`uv run --with pytest --with pytest-asyncio --with respx --with inline-snapshot pytest tests/lib/responses/test_responses.py -o addopts=''`
+
+Result: `6 passed`.

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from decimal import Decimal
+from typing import Optional
 from typing_extensions import TypeVar
 
 import pytest
 from respx import MockRouter
+from pydantic import BaseModel
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
@@ -39,6 +42,32 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+@pytest.mark.respx(base_url=base_url)
+def test_parse_pydantic_model_decimal_fields(client: OpenAI, respx_mock: MockRouter) -> None:
+    class DecimalExtraction(BaseModel):
+        premium: Optional[Decimal] = None
+        amount: Optional[Decimal] = None
+
+    response = make_snapshot_request(
+        lambda c: c.responses.parse(
+            model="gpt-4o-mini",
+            input="The premium is $5,000.00 and the total amount is $5,500.50",
+            text_format=DecimalExtraction,
+        ),
+        content_snapshot=snapshot(
+            '{"id": "resp_decimal", "object": "response", "created_at": 1754925861, "status": "completed", "background": false, "error": null, "incomplete_details": null, "instructions": null, "max_output_tokens": null, "max_tool_calls": null, "model": "gpt-4o-mini-2024-07-18", "output": [{"id": "msg_decimal", "type": "message", "status": "completed", "content": [{"type": "output_text", "annotations": [], "logprobs": [], "text": "{\\"premium\\":\\"5000.00\\",\\"amount\\":\\"5500.50\\"}"}], "role": "assistant"}], "parallel_tool_calls": true, "previous_response_id": null, "prompt_cache_key": null, "reasoning": {"effort": null, "summary": null}, "safety_identifier": null, "service_tier": "default", "store": true, "temperature": 1.0, "text": {"format": {"type": "json_schema", "name": "DecimalExtraction", "schema": {}, "strict": true}, "verbosity": "medium"}, "tool_choice": "auto", "tools": [], "top_logprobs": 0, "top_p": 1.0, "truncation": "disabled", "usage": {"input_tokens": 14, "input_tokens_details": {"cached_tokens": 0}, "output_tokens": 14, "output_tokens_details": {"reasoning_tokens": 0}, "total_tokens": 28}, "user": null, "metadata": {}}'
+        ),
+        path="/responses",
+        mock_client=client,
+        respx_mock=respx_mock,
+    )
+
+    parsed = response.output_parsed
+    assert parsed is not None
+    assert parsed.premium == Decimal("5000.00")
+    assert parsed.amount == Decimal("5500.50")
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2718.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
