### PR TITLE
Nightly OSS: Streaming: JSONDecodeError when SSE events contain only meta-fields (retry, id, event)

### DIFF
--- a/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
+++ b/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
@@ -1,0 +1,13 @@
+Implemented the fix for [openai/openai-python#2722](https://github.com/openai/openai-python/issues/2722).
+
+Changed:
+- [src/openai/_streaming.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/src/openai/_streaming.py:66): sync/async stream iteration now skips SSE frames with empty or whitespace-only `data` before JSON parsing.
+- [tests/test_streaming.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/tests/test_streaming.py:219): added regression coverage for `retry`, `id`, `event`, and empty `data` frames.
+- [NIGHTLY_REPORT.md](/home/runner/work/oss-nightly-control/oss-nightly-control/target/NIGHTLY_REPORT.md:1): written as requested.
+
+Verification passed:
+- `.venv/bin/python -m pytest tests/test_streaming.py -q` (`22 passed`)
+- `.venv/bin/python -m ruff check src/openai/_streaming.py tests/test_streaming.py`
+- `.venv/bin/python -m ruff format --check src/openai/_streaming.py tests/test_streaming.py`
+
+I did not commit, push, fork, or open a PR. Existing untracked `.codex-nightly-prompt.md` and `uv.lock` remain unmodified from the workflow state.

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,6 +63,9 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
+                if not sse.data.strip():
+                    continue
+
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
@@ -172,6 +175,9 @@ class AsyncStream(Generic[_T]):
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
                     break
+
+                if not sse.data.strip():
+                    continue
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -216,6 +216,31 @@ async def test_multi_byte_character_multiple_chunks(
     assert sse.json() == {"content": "известни"}
 
 
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_stream_skips_events_without_data(
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"retry: 3000\n"
+        yield b"\n"
+        yield b"id: msg_123\n"
+        yield b"event: ping\n"
+        yield b"\n"
+        yield b"event: ping\n"
+        yield b"data: \n"
+        yield b"\n"
+        yield b'data: {"content":"hello"}\n'
+        yield b"\n"
+        yield b"data: [DONE]\n"
+        yield b"\n"
+
+    stream = make_stream(content=body(), sync=sync, client=client, async_client=async_client)
+
+    assert await collect_stream(stream) == [{"content": "hello"}]
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk
@@ -246,3 +271,23 @@ def make_event_iterator(
     return AsyncStream(
         cast_to=object, client=async_client, response=httpx.Response(200, content=to_aiter(content))
     )._iter_events()
+
+
+def make_stream(
+    content: Iterator[bytes],
+    *,
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> Stream[object] | AsyncStream[object]:
+    if sync:
+        return Stream(cast_to=object, client=client, response=httpx.Response(200, content=content))
+
+    return AsyncStream(cast_to=object, client=async_client, response=httpx.Response(200, content=to_aiter(content)))
+
+
+async def collect_stream(stream: Stream[object] | AsyncStream[object]) -> list[object]:
+    if isinstance(stream, AsyncStream):
+        return [item async for item in stream]
+
+    return list(stream)


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2722.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
