### PR TITLE
Nightly OSS: timeout not respected openai client

### DIFF
--- a/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
+++ b/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
@@ -1,0 +1,12 @@
+Implemented a small contribution for issue https://github.com/openai/openai-python/issues/2599.
+
+Changed:
+- `README.md`: clarified that timeouts are passed to `httpx` per request operation, not as a wall-clock deadline across retries, and that `max_retries=0` makes timeout failures stop after the first attempt.
+- `tests/test_client.py`: added sync and async regression tests verifying `timeout=1.0` is passed through and timeout errors are not retried when retries are disabled.
+- `NIGHTLY_REPORT.md`: added the required task summary.
+
+Verification:
+- `uv run pytest -q tests/test_client.py -k 'timeout_errors_are_not_retried_when_retries_are_disabled or request_timeout or client_timeout_option or http_client_timeout_option'` passed: 8 tests.
+- `uv run ruff check tests/test_client.py` passed.
+
+No commit, fork, push, or PR was created. Note: `.codex-nightly-prompt.md` and `uv.lock` were already untracked in the worktree; I left them alone.

--- a/README.md
+++ b/README.md
@@ -729,9 +729,11 @@ client.with_options(timeout=5.0).chat.completions.create(
 )
 ```
 
-On timeout, an `APITimeoutError` is thrown.
+On timeout, an `APITimeoutError` is thrown. Timeout values are passed through to `httpx`, which
+applies them per request operation, not as a wall-clock deadline across all retry attempts.
 
-Note that requests that time out are [retried twice by default](#retries).
+Note that requests that time out are [retried twice by default](#retries). To make a timeout error
+fail after the first attempt, set `max_retries=0`.
 
 ## Advanced
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -929,6 +929,28 @@ class TestOpenAI:
 
         assert _get_open_connections(client) == 0
 
+    @pytest.mark.respx(base_url=base_url)
+    def test_timeout_errors_are_not_retried_when_retries_are_disabled(
+        self, respx_mock: MockRouter, client: OpenAI
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(side_effect=httpx.TimeoutException("Test timeout error"))
+
+        with pytest.raises(APITimeoutError):
+            client.with_options(max_retries=0, timeout=1.0).chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-5.4",
+            )
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 1
+        timeout = httpx.Timeout(**calls[0].request.extensions["timeout"])  # type: ignore
+        assert timeout == httpx.Timeout(1.0)
+
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)
     def test_retrying_status_errors_doesnt_leak(self, respx_mock: MockRouter, client: OpenAI) -> None:
@@ -1999,6 +2021,28 @@ class TestAsyncOpenAI:
             ).__aenter__()
 
         assert _get_open_connections(async_client) == 0
+
+    @pytest.mark.respx(base_url=base_url)
+    async def test_timeout_errors_are_not_retried_when_retries_are_disabled(
+        self, respx_mock: MockRouter, async_client: AsyncOpenAI
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(side_effect=httpx.TimeoutException("Test timeout error"))
+
+        with pytest.raises(APITimeoutError):
+            await async_client.with_options(max_retries=0, timeout=1.0).chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-5.4",
+            )
+
+        calls = cast("list[MockRequestCall]", respx_mock.calls)
+        assert len(calls) == 1
+        timeout = httpx.Timeout(**calls[0].request.extensions["timeout"])  # type: ignore
+        assert timeout == httpx.Timeout(1.0)
 
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2599.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
