### PR TITLE
Nightly OSS: responses.parse() throws a PydanticSerializationUnexpectedValue error in v2.21.0

### DIFF
--- a/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
+++ b/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
@@ -1,0 +1,13 @@
+Implemented a small fix for [openai/openai-python#2872](https://github.com/openai/openai-python/issues/2872).
+
+Changed:
+- [src/openai/lib/_parsing/_responses.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/src/openai/lib/_parsing/_responses.py): `parse_response()` now constructs parsed response models with the actual `text_format` type, avoiding unresolved `TypeVar` serialization warnings.
+- [tests/lib/responses/test_responses.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/tests/lib/responses/test_responses.py): added a regression test for `to_dict()` after parsing a Pydantic model.
+- [NIGHTLY_REPORT.md](/home/runner/work/oss-nightly-control/oss-nightly-control/target/NIGHTLY_REPORT.md): added the required summary.
+
+Verification passed:
+- `pytest tests/lib/responses/test_responses.py`
+- `ruff check` on touched files
+- `pyright` on touched files
+
+I did not run the full suite or Pydantic v1 nox session because this environment does not have `rye` installed. Untracked `.codex-nightly-prompt.md` and `uv.lock` were already present and left untouched.

--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, List, Iterable, cast
+from typing import TYPE_CHECKING, Any, List, Iterable, cast
 from typing_extensions import TypeVar, assert_never
 
 import pydantic
@@ -56,6 +56,15 @@ def parse_response(
     input_tools: Iterable[ToolParam] | Omit | None,
     response: Response | ParsedResponse[object],
 ) -> ParsedResponse[TextFormatT]:
+    if is_given(text_format):
+        parsed_response_type = ParsedResponse[text_format]
+        parsed_response_output_text_type = ParsedResponseOutputText[text_format]
+        parsed_response_output_message_type = ParsedResponseOutputMessage[text_format]
+    else:
+        parsed_response_type = ParsedResponse[None]
+        parsed_response_output_text_type = ParsedResponseOutputText[None]
+        parsed_response_output_message_type = ParsedResponseOutputMessage[None]
+
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
     for output in response.output:
@@ -68,7 +77,7 @@ def parse_response(
 
                 content_list.append(
                     construct_type_unchecked(
-                        type_=ParsedResponseOutputText[TextFormatT],
+                        type_=cast(Any, parsed_response_output_text_type),
                         value={
                             **item.to_dict(),
                             "parsed": parse_text(item.text, text_format=text_format),
@@ -78,7 +87,7 @@ def parse_response(
 
             output_list.append(
                 construct_type_unchecked(
-                    type_=ParsedResponseOutputMessage[TextFormatT],
+                    type_=cast(Any, parsed_response_output_message_type),
                     value={
                         **output.to_dict(),
                         "content": content_list,
@@ -130,7 +139,7 @@ def parse_response(
             output_list.append(output)
 
     return construct_type_unchecked(
-        type_=ParsedResponse[TextFormatT],
+        type_=cast(Any, parsed_response_type),
         value={
             **response.to_dict(),
             "output": output_list,

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from typing import Any, cast
 from typing_extensions import TypeVar
 
 import pytest
 from respx import MockRouter
+from pydantic import BaseModel
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
+from openai._types import omit
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +44,44 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_parsed_response_serializes_without_pydantic_warnings() -> None:
+    class GuardrailDecision(BaseModel):
+        triggered: bool
+        reason: str
+
+    output: list[dict[str, Any]] = [
+        {
+            "id": "msg_123",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "annotations": [],
+                    "logprobs": [],
+                    "text": '{"triggered": false, "reason": "ok"}',
+                }
+            ],
+        }
+    ]
+    response = Response.construct(
+        id="resp_123",
+        object="response",
+        created_at=0,
+        model="gpt-5-mini",
+        output=output,
+        parallel_tool_calls=True,
+        tools=[],
+    )
+
+    parsed = parse_response(text_format=GuardrailDecision, input_tools=omit, response=response)
+    dumped = cast(Any, parsed.to_dict())
+
+    assert parsed.output_parsed == GuardrailDecision(triggered=False, reason="ok")
+    assert dumped["output"][0]["content"][0]["parsed"] == {"triggered": False, "reason": "ok"}
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2872.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
