### PR TITLE
Nightly OSS: Bug: `by_alias: NoneType` in openai-python v2.24.0 when logging.DEBUG is enabled

### DIFF
--- a/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
+++ b/NIGHTLY_CODEX_FINAL_ATTEMPT_1.md
@@ -1,0 +1,12 @@
+Implemented a small test-only regression contribution.
+
+Changed:
+- [tests/test_models.py](/home/runner/work/oss-nightly-control/oss-nightly-control/target/tests/test_models.py:575): adds coverage that `model_dump()` works when `by_alias` is left unset, locking the behavior needed for issue #2921.
+- [NIGHTLY_REPORT.md](/home/runner/work/oss-nightly-control/oss-nightly-control/target/NIGHTLY_REPORT.md:1): summarizes the work, tests, and remaining risk.
+
+Verified:
+- `uv run pytest tests/test_models.py -k "compat_model_dump_allows_default_by_alias or compat_method_no_error_for_warnings"`
+- `uv run pytest tests/lib/test_azure.py::TestAzureLogging::test_azure_api_key_redacted`
+- `uv run ruff check tests/test_models.py`
+
+Note: `.codex-nightly-prompt.md` and `uv.lock` were already untracked before my changes; I left them untouched.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -572,6 +572,15 @@ def test_compat_method_no_error_for_warnings() -> None:
     assert isinstance(model_dump(m, warnings=False), dict)
 
 
+def test_compat_model_dump_allows_default_by_alias() -> None:
+    class Model(BaseModel):
+        foo: Optional[str] = Field(alias="FOO", default=None)
+
+    m = Model(FOO="hello")
+
+    assert model_dump(m) == {"foo": "hello"}
+
+
 def test_to_json() -> None:
     class Model(BaseModel):
         foo: Optional[str] = Field(alias="FOO", default=None)


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2921.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
