### PR TITLE
Nightly OSS: Azure OpenAI - `model` parameter in request body causes failures when deployment name differs from model name

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -61,8 +61,13 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
         *,
         retries_taken: int = 0,
     ) -> httpx.Request:
-        if options.url in _deployments_endpoints and is_mapping(options.json_data):
-            model = options.json_data.get("model")
+        json_data = options.json_data
+        if options.url in _deployments_endpoints and is_mapping(json_data):
+            model = json_data.get("model")
+            if "model" in json_data:
+                options = model_copy(options)
+                options.json_data = {key: value for key, value in json_data.items() if key != "model"}
+
             if model is not None and "/deployments" not in str(self.base_url.path):
                 options.url = f"/deployments/{model}{options.url}"
 

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Union, cast
 from typing_extensions import Literal, Protocol
@@ -259,6 +260,18 @@ class TestAzureLogging:
             {"model": "deployment-body"},
             "https://example-resource.azure.openai.com/openai/deployments/deployment-body/chat/completions?api-version=2024-02-01",
         ),
+        # AzureOpenAI: Image deployment names can differ from model names.
+        (
+            AzureOpenAI(
+                api_version="2024-02-01",
+                api_key="example API key",
+                azure_endpoint="https://example-resource.azure.openai.com",
+            ),
+            "https://example-resource.azure.openai.com/openai/",
+            "/images/generations",
+            {"model": "gpt-image-1-5", "prompt": "A sunset over mountains"},
+            "https://example-resource.azure.openai.com/openai/deployments/gpt-image-1-5/images/generations?api-version=2024-02-01",
+        ),
         # AzureOpenAI: Deployment specified
         (
             AzureOpenAI(
@@ -386,6 +399,7 @@ def test_prepare_url_deployment_endpoint(
         )
     )
     assert req.url == expected
+    assert "model" not in json.loads(req.content)
     assert client.base_url == base_url
 
 


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2892.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
