### PR TITLE
Nightly OSS: `ImageGenerationCall` input param type incorrectly requires `result` and `status`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
   "httpx>=0.23.0, <1",
   "pydantic>=1.9.0, <3",
-    "typing-extensions>=4.11, <5", "typing-extensions>=4.14, <5",
+  "typing-extensions>=4.14, <5",
   "anyio>=3.5.0, <5",
   "distro>=1.7.0, <2",
   "sniffio",


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/openai/openai-python/issues/2648.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
