### PR TITLE
feat: expose to_strict_json_schema as public API

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -96,7 +96,7 @@ __all__ = [
 if not _t.TYPE_CHECKING:
     from ._utils._resources_proxy import resources as resources
 
-from .lib import azure as _azure, pydantic_function_tool as pydantic_function_tool
+from .lib import azure as _azure, pydantic_function_tool as pydantic_function_tool, to_strict_json_schema as to_strict_json_schema
 from .version import VERSION as VERSION
 from .lib.azure import AzureOpenAI as AzureOpenAI, AsyncAzureOpenAI as AsyncAzureOpenAI
 from .lib._old_api import *

--- a/src/openai/lib/__init__.py
+++ b/src/openai/lib/__init__.py
@@ -1,2 +1,3 @@
 from ._tools import pydantic_function_tool as pydantic_function_tool
+from ._pydantic import to_strict_json_schema as to_strict_json_schema
 from ._parsing import ResponseFormatT as ResponseFormatT

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -12,6 +12,11 @@ from openai.lib._pydantic import to_strict_json_schema
 from .schema_types.query import Query
 
 
+def test_to_strict_json_schema_public_api() -> None:
+    """Test that to_strict_json_schema is accessible as a public API via openai.to_strict_json_schema."""
+    assert openai.to_strict_json_schema is to_strict_json_schema
+
+
 def test_most_types() -> None:
     if not PYDANTIC_V1:
         assert openai.pydantic_function_tool(Query)["function"] == snapshot(


### PR DESCRIPTION
## Summary

Exposes the internal `to_strict_json_schema` function as a public API so users can generate strict JSON schemas from Pydantic models without relying on private module paths (e.g., `openai.lib._pydantic`).

## Changes

- **`src/openai/lib/__init__.py`** - Added `to_strict_json_schema` export
- **`src/openai/__init__.py`** - Added `to_strict_json_schema` to top-level exports (accessible via `openai.to_strict_json_schema`)
- **`tests/lib/test_pydantic.py`** - Added test verifying public API accessibility

## Motivation

Closes #2093. Users currently need to import from `openai.lib._pydantic` (a private module) to access `to_strict_json_schema`. This PR makes it a first-class public API, accessible as `openai.to_strict_json_schema`, following the same pattern as `openai.pydantic_function_tool`.