### PR TITLE
feat: restore beta.vector_stores alias and fix vision README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ With an image URL:
 
 ```python
 prompt = "What is in this image?"
-img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/440px-2023_06_08_Raccoon1.jpg"
 
 response = client.responses.create(
     model="gpt-5.2",

--- a/src/openai/resources/beta/beta.py
+++ b/src/openai/resources/beta/beta.py
@@ -28,6 +28,14 @@ from .threads.threads import (
     ThreadsWithStreamingResponse,
     AsyncThreadsWithStreamingResponse,
 )
+from ..vector_stores import (
+    VectorStores,
+    AsyncVectorStores,
+    VectorStoresWithRawResponse,
+    AsyncVectorStoresWithRawResponse,
+    VectorStoresWithStreamingResponse,
+    AsyncVectorStoresWithStreamingResponse,
+)
 from ...resources.chat import Chat, AsyncChat
 from .realtime.realtime import (
     Realtime,
@@ -59,6 +67,11 @@ class Beta(SyncAPIResource):
     def threads(self) -> Threads:
         """Build Assistants that can call models and use tools."""
         return Threads(self._client)
+
+    @cached_property
+    def vector_stores(self) -> VectorStores:
+        """Backwards-compatible access to Assistants v2 vector stores."""
+        return self._client.vector_stores
 
     @cached_property
     def with_raw_response(self) -> BetaWithRawResponse:
@@ -104,6 +117,11 @@ class AsyncBeta(AsyncAPIResource):
         return AsyncThreads(self._client)
 
     @cached_property
+    def vector_stores(self) -> AsyncVectorStores:
+        """Backwards-compatible access to Assistants v2 vector stores."""
+        return self._client.vector_stores
+
+    @cached_property
     def with_raw_response(self) -> AsyncBetaWithRawResponse:
         """
         This property can be used as a prefix for any HTTP method call to return
@@ -141,6 +159,10 @@ class BetaWithRawResponse:
         """Build Assistants that can call models and use tools."""
         return ThreadsWithRawResponse(self._beta.threads)
 
+    @cached_property
+    def vector_stores(self) -> VectorStoresWithRawResponse:
+        return VectorStoresWithRawResponse(self._beta.vector_stores)
+
 
 class AsyncBetaWithRawResponse:
     def __init__(self, beta: AsyncBeta) -> None:
@@ -159,6 +181,10 @@ class AsyncBetaWithRawResponse:
     def threads(self) -> AsyncThreadsWithRawResponse:
         """Build Assistants that can call models and use tools."""
         return AsyncThreadsWithRawResponse(self._beta.threads)
+
+    @cached_property
+    def vector_stores(self) -> AsyncVectorStoresWithRawResponse:
+        return AsyncVectorStoresWithRawResponse(self._beta.vector_stores)
 
 
 class BetaWithStreamingResponse:
@@ -179,6 +205,10 @@ class BetaWithStreamingResponse:
         """Build Assistants that can call models and use tools."""
         return ThreadsWithStreamingResponse(self._beta.threads)
 
+    @cached_property
+    def vector_stores(self) -> VectorStoresWithStreamingResponse:
+        return VectorStoresWithStreamingResponse(self._beta.vector_stores)
+
 
 class AsyncBetaWithStreamingResponse:
     def __init__(self, beta: AsyncBeta) -> None:
@@ -197,3 +227,7 @@ class AsyncBetaWithStreamingResponse:
     def threads(self) -> AsyncThreadsWithStreamingResponse:
         """Build Assistants that can call models and use tools."""
         return AsyncThreadsWithStreamingResponse(self._beta.threads)
+
+    @cached_property
+    def vector_stores(self) -> AsyncVectorStoresWithStreamingResponse:
+        return AsyncVectorStoresWithStreamingResponse(self._beta.vector_stores)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -157,6 +157,11 @@ class TestOpenAI:
         assert copied.admin_api_key == "another My Admin API Key"
         assert client.admin_api_key == "My Admin API Key"
 
+    def test_beta_vector_stores_alias(self, client: OpenAI) -> None:
+        assert client.beta.vector_stores is client.vector_stores
+        assert client.beta.with_raw_response.vector_stores._vector_stores is client.vector_stores
+        assert client.beta.with_streaming_response.vector_stores._vector_stores is client.vector_stores
+
     def test_copy_default_options(self, client: OpenAI) -> None:
         # options that have a default are overridden correctly
         copied = client.copy(max_retries=7)
@@ -1419,6 +1424,11 @@ class TestAsyncOpenAI:
         copied = async_client.copy(admin_api_key="another My Admin API Key")
         assert copied.admin_api_key == "another My Admin API Key"
         assert async_client.admin_api_key == "My Admin API Key"
+
+    def test_beta_vector_stores_alias(self, async_client: AsyncOpenAI) -> None:
+        assert async_client.beta.vector_stores is async_client.vector_stores
+        assert async_client.beta.with_raw_response.vector_stores._vector_stores is async_client.vector_stores
+        assert async_client.beta.with_streaming_response.vector_stores._vector_stores is async_client.vector_stores
 
     def test_copy_default_options(self, async_client: AsyncOpenAI) -> None:
         # options that have a default are overridden correctly


### PR DESCRIPTION
## Summary
- restore client.beta.vector_stores as a backwards-compatible alias to client.vector_stores for sync and async clients
- add alias support for with_raw_response and with_streaming_response beta wrappers
- add targeted tests covering the alias behavior
- update the README vision image URL to a smaller thumbnail to avoid download-size failures

## Why
- addresses compatibility gap reported in issue #2451
- resolves practical README example failures reported in issue #2776

Closes #2451
Closes #2776