### PR TITLE
fix: allow api_key="" to bypass credential validation for local servers

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -190,6 +190,24 @@ class _ModuleClient(OpenAI):
 
     @property  # type: ignore
     @override
+    def _api_key_explicitly_empty(self) -> bool:
+        # Unlike the regular client, the module client's `api_key` can be reassigned
+        # at any time via the `openai.api_key = ...` module attribute, after the
+        # underlying client instance was already constructed. So rather than relying
+        # on the flag captured once at construction time, check the current value
+        # directly to decide whether auth was intentionally disabled.
+        return api_key == ""
+
+    @_api_key_explicitly_empty.setter  # type: ignore
+    def _api_key_explicitly_empty(self, value: bool) -> None:  # type: ignore
+        # No-op: the getter above always derives this from the live `api_key`, so
+        # there is nothing to store. The setter only needs to exist so that
+        # `OpenAI.__init__` can assign to `self._api_key_explicitly_empty` without
+        # raising `AttributeError`.
+        pass
+
+    @property  # type: ignore
+    @override
     def admin_api_key(self) -> str | None:
         return admin_api_key
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -468,7 +468,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
     def _build_headers(self, options: FinalRequestOptions, *, retries_taken: int = 0) -> httpx.Headers:
         custom_headers = options.headers or {}
         headers_dict = _merge_mappings({**self._auth_headers(options.security), **self.default_headers}, custom_headers)
-        self._validate_headers(headers_dict, custom_headers)
+        self._validate_headers(headers_dict, custom_headers, options.security)
 
         # headers are case-insensitive while dictionaries are not.
         headers = httpx.Headers(headers_dict)
@@ -731,6 +731,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         self,
         headers: Headers,  # noqa: ARG002
         custom_headers: Headers,  # noqa: ARG002
+        security: SecurityOptions | None = None,  # noqa: ARG002
     ) -> None:
         """Validate the given default headers and custom headers.
 

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -197,6 +197,7 @@ class OpenAI(SyncAPIClient):
 
         self.workload_identity = workload_identity if provider_runtime is None else None
 
+        _api_key_explicitly_set = False
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -211,9 +212,11 @@ class OpenAI(SyncAPIClient):
             if callable(api_key):
                 self.api_key = ""
                 self._api_key_provider: Callable[[], str] | None = api_key  # type: ignore[no-redef]
+                _api_key_explicitly_set = True
             else:
                 self.api_key = api_key or ""
                 self._api_key_provider = None
+                _api_key_explicitly_set = api_key is not None
             self._workload_identity_auth = None
 
         if admin_api_key is None and provider_runtime is None:
@@ -224,6 +227,7 @@ class OpenAI(SyncAPIClient):
             provider_runtime is None
             and _enforce_credentials
             and not self.api_key
+            and not _api_key_explicitly_set
             and self._api_key_provider is None
             and workload_identity is None
             and self.admin_api_key is None
@@ -803,6 +807,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         self.workload_identity = workload_identity if provider_runtime is None else None
 
+        _api_key_explicitly_set = False
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -817,9 +822,11 @@ class AsyncOpenAI(AsyncAPIClient):
             if callable(api_key):
                 self.api_key = ""
                 self._api_key_provider: Callable[[], Awaitable[str]] | None = api_key  # type: ignore[no-redef]
+                _api_key_explicitly_set = True
             else:
                 self.api_key = api_key or ""
                 self._api_key_provider = None
+                _api_key_explicitly_set = api_key is not None
             self._workload_identity_auth = None
 
         if admin_api_key is None and provider_runtime is None:
@@ -830,6 +837,7 @@ class AsyncOpenAI(AsyncAPIClient):
             provider_runtime is None
             and _enforce_credentials
             and not self.api_key
+            and not _api_key_explicitly_set
             and self._api_key_provider is None
             and workload_identity is None
             and self.admin_api_key is None

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -197,7 +197,7 @@ class OpenAI(SyncAPIClient):
 
         self.workload_identity = workload_identity if provider_runtime is None else None
 
-        _api_key_explicitly_set = False
+        _api_key_explicitly_set = api_key is not None
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -212,11 +212,9 @@ class OpenAI(SyncAPIClient):
             if callable(api_key):
                 self.api_key = ""
                 self._api_key_provider: Callable[[], str] | None = api_key  # type: ignore[no-redef]
-                _api_key_explicitly_set = True
             else:
                 self.api_key = api_key or ""
                 self._api_key_provider = None
-                _api_key_explicitly_set = api_key is not None
             self._workload_identity_auth = None
 
         if admin_api_key is None and provider_runtime is None:
@@ -807,7 +805,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         self.workload_identity = workload_identity if provider_runtime is None else None
 
-        _api_key_explicitly_set = False
+        _api_key_explicitly_set = api_key is not None
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -822,11 +820,9 @@ class AsyncOpenAI(AsyncAPIClient):
             if callable(api_key):
                 self.api_key = ""
                 self._api_key_provider: Callable[[], Awaitable[str]] | None = api_key  # type: ignore[no-redef]
-                _api_key_explicitly_set = True
             else:
                 self.api_key = api_key or ""
                 self._api_key_provider = None
-                _api_key_explicitly_set = api_key is not None
             self._workload_identity_auth = None
 
         if admin_api_key is None and provider_runtime is None:

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -198,6 +198,13 @@ class OpenAI(SyncAPIClient):
         self.workload_identity = workload_identity if provider_runtime is None else None
 
         _api_key_explicitly_set = api_key is not None
+        # Tracks whether the caller explicitly passed a literal `api_key=""`, as opposed
+        # to it defaulting to an empty string because no credentials were configured, or
+        # a key provider/workload identity being used (which resolve the real key later).
+        # This is needed so that requests don't fail header validation below when the
+        # caller intentionally disabled authentication (e.g. for local, auth-less
+        # OpenAI-compatible servers).
+        self._api_key_explicitly_empty = api_key == ""
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -546,11 +553,21 @@ class OpenAI(SyncAPIClient):
         }
 
     @override
-    def _validate_headers(self, headers: Headers, custom_headers: Headers) -> None:
+    def _validate_headers(
+        self, headers: Headers, custom_headers: Headers, security: SecurityOptions | None = None
+    ) -> None:
         if self._provider_runtime is not None:
             return
 
         if _has_header(headers, "Authorization") or _has_omitted_header(custom_headers, "Authorization"):
+            return
+
+        # An explicitly-passed `api_key=""` means the caller intentionally disabled
+        # authentication (e.g. for a local, auth-less OpenAI-compatible server), so
+        # don't fail requests just because no `Authorization` header could be built —
+        # unless the request specifically requires admin credentials, which an empty
+        # `api_key` cannot satisfy.
+        if self._api_key_explicitly_empty and not (security or {}).get("admin_api_key_auth", False):
             return
 
         raise TypeError(
@@ -806,6 +823,13 @@ class AsyncOpenAI(AsyncAPIClient):
         self.workload_identity = workload_identity if provider_runtime is None else None
 
         _api_key_explicitly_set = api_key is not None
+        # Tracks whether the caller explicitly passed a literal `api_key=""`, as opposed
+        # to it defaulting to an empty string because no credentials were configured, or
+        # a key provider/workload identity being used (which resolve the real key later).
+        # This is needed so that requests don't fail header validation below when the
+        # caller intentionally disabled authentication (e.g. for local, auth-less
+        # OpenAI-compatible servers).
+        self._api_key_explicitly_empty = api_key == ""
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -1157,11 +1181,21 @@ class AsyncOpenAI(AsyncAPIClient):
         }
 
     @override
-    def _validate_headers(self, headers: Headers, custom_headers: Headers) -> None:
+    def _validate_headers(
+        self, headers: Headers, custom_headers: Headers, security: SecurityOptions | None = None
+    ) -> None:
         if self._provider_runtime is not None:
             return
 
         if _has_header(headers, "Authorization") or _has_omitted_header(custom_headers, "Authorization"):
+            return
+
+        # An explicitly-passed `api_key=""` means the caller intentionally disabled
+        # authentication (e.g. for a local, auth-less OpenAI-compatible server), so
+        # don't fail requests just because no `Authorization` header could be built —
+        # unless the request specifically requires admin credentials, which an empty
+        # `api_key` cannot satisfy.
+        if self._api_key_explicitly_empty and not (security or {}).get("admin_api_key_auth", False):
             return
 
         raise TypeError(

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -565,9 +565,11 @@ class OpenAI(SyncAPIClient):
         # An explicitly-passed `api_key=""` means the caller intentionally disabled
         # authentication (e.g. for a local, auth-less OpenAI-compatible server), so
         # don't fail requests just because no `Authorization` header could be built —
-        # unless the request specifically requires admin credentials, which an empty
-        # `api_key` cannot satisfy.
-        if self._api_key_explicitly_empty and not (security or {}).get("admin_api_key_auth", False):
+        # as long as bearer auth (the auth method an empty `api_key` disables) is one
+        # of the accepted security methods for this request. Endpoints that *only*
+        # accept admin credentials (no `bearer_auth` alternative) still require them,
+        # since an empty `api_key` can never satisfy those.
+        if self._api_key_explicitly_empty and (security or {}).get("bearer_auth", False):
             return
 
         raise TypeError(
@@ -670,7 +672,12 @@ class OpenAI(SyncAPIClient):
             }
         else:
             auth_options = {
-                "api_key": api_key or self._api_key_provider or self.api_key,
+                # `api_key` defaults to `None`, meaning "not overridden, inherit from
+                # `self`" — but an explicitly-passed `api_key=""` (used to disable auth
+                # for local, auth-less servers) must still be honored rather than falling
+                # through to the inherited provider/key, so this checks `is not None`
+                # rather than truthiness.
+                "api_key": api_key if api_key is not None else (self._api_key_provider or self.api_key),
                 "admin_api_key": admin_api_key or self.admin_api_key,
                 "workload_identity": workload_identity or self.workload_identity,
                 "base_url": base_url or self.base_url,
@@ -1193,9 +1200,11 @@ class AsyncOpenAI(AsyncAPIClient):
         # An explicitly-passed `api_key=""` means the caller intentionally disabled
         # authentication (e.g. for a local, auth-less OpenAI-compatible server), so
         # don't fail requests just because no `Authorization` header could be built —
-        # unless the request specifically requires admin credentials, which an empty
-        # `api_key` cannot satisfy.
-        if self._api_key_explicitly_empty and not (security or {}).get("admin_api_key_auth", False):
+        # as long as bearer auth (the auth method an empty `api_key` disables) is one
+        # of the accepted security methods for this request. Endpoints that *only*
+        # accept admin credentials (no `bearer_auth` alternative) still require them,
+        # since an empty `api_key` can never satisfy those.
+        if self._api_key_explicitly_empty and (security or {}).get("bearer_auth", False):
             return
 
         raise TypeError(
@@ -1305,7 +1314,12 @@ class AsyncOpenAI(AsyncAPIClient):
             }
         else:
             auth_options = {
-                "api_key": api_key or self._api_key_provider or self.api_key,
+                # `api_key` defaults to `None`, meaning "not overridden, inherit from
+                # `self`" — but an explicitly-passed `api_key=""` (used to disable auth
+                # for local, auth-less servers) must still be honored rather than falling
+                # through to the inherited provider/key, so this checks `is not None`
+                # rather than truthiness.
+                "api_key": api_key if api_key is not None else (self._api_key_provider or self.api_key),
                 "admin_api_key": admin_api_key or self.admin_api_key,
                 "workload_identity": workload_identity or self.workload_identity,
                 "base_url": base_url or self.base_url,

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -363,7 +363,12 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
         return {}
 
     @override
-    def _validate_headers(self, headers: Headers, custom_headers: Headers) -> None:
+    def _validate_headers(
+        self,
+        headers: Headers,
+        custom_headers: Headers,
+        security: SecurityOptions | None = None,  # noqa: ARG002
+    ) -> None:
         if _has_auth_header(headers) or _has_auth_header(custom_headers):
             return
 
@@ -689,7 +694,12 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
         return {}
 
     @override
-    def _validate_headers(self, headers: Headers, custom_headers: Headers) -> None:
+    def _validate_headers(
+        self,
+        headers: Headers,
+        custom_headers: Headers,
+        security: SecurityOptions | None = None,  # noqa: ARG002
+    ) -> None:
         if _has_auth_header(headers) or _has_auth_header(custom_headers):
             return
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -540,6 +540,17 @@ class TestOpenAI:
             )
             assert client.api_key == ""
 
+        # OPENAI_API_KEY="" in the environment (without explicit api_key arg) should still raise,
+        # as an empty env var likely indicates misconfiguration rather than intentional use.
+        with update_env(
+            **{
+                "OPENAI_API_KEY": "",
+                "OPENAI_ADMIN_KEY": Omit(),
+            }
+        ):
+            with pytest.raises(OpenAIError, match="Missing credentials"):
+                OpenAI(base_url=base_url, admin_api_key=None, _strict_response_validation=True)
+
     @pytest.mark.respx(base_url=base_url)
     def test_api_key_provider_preserves_admin_auth(self, respx_mock: MockRouter) -> None:
         respx_mock.get("/organization/projects").mock(return_value=httpx.Response(200, json={"ok": True}))
@@ -1868,6 +1879,17 @@ class TestAsyncOpenAI:
                 _strict_response_validation=True,
             )
             assert client.api_key == ""
+
+        # OPENAI_API_KEY="" in the environment (without explicit api_key arg) should still raise,
+        # as an empty env var likely indicates misconfiguration rather than intentional use.
+        with update_env(
+            **{
+                "OPENAI_API_KEY": "",
+                "OPENAI_ADMIN_KEY": Omit(),
+            }
+        ):
+            with pytest.raises(OpenAIError, match="Missing credentials"):
+                AsyncOpenAI(base_url=base_url, admin_api_key=None, _strict_response_validation=True)
 
     @pytest.mark.respx(base_url=base_url)
     async def test_api_key_provider_preserves_admin_auth(self, respx_mock: MockRouter) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -558,6 +558,23 @@ class TestOpenAI:
                     )
                 )
 
+            # Raw request helpers (`client.get(...)`, `.post(...)`, etc.) don't pass an
+            # explicit `security` override, so they fall back to `FinalRequestOptions`'s
+            # default of requiring *either* bearer or admin auth. Since bearer auth is
+            # one of the accepted methods here, the empty `api_key` should still bypass
+            # validation instead of being treated as admin-only.
+            default_security_request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+            assert "Authorization" not in default_security_request.headers
+
+            # `copy()`/`with_options()` should also honor an explicitly-passed empty
+            # `api_key`, rather than silently falling back to the inherited key.
+            copied_client = client.copy(api_key="")
+            assert copied_client.api_key == ""
+            copied_request = copied_client._build_request(
+                FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True})
+            )
+            assert "Authorization" not in copied_request.headers
+
         # OPENAI_API_KEY="" in the environment (without explicit api_key arg) should still raise,
         # as an empty env var likely indicates misconfiguration rather than intentional use.
         with update_env(
@@ -568,6 +585,22 @@ class TestOpenAI:
         ):
             with pytest.raises(OpenAIError, match="Missing credentials"):
                 OpenAI(base_url=base_url, admin_api_key=None, _strict_response_validation=True)
+
+    def test_with_options_preserves_explicit_empty_api_key(self) -> None:
+        # `client.with_options(api_key="")` should disable auth on the copy, rather than
+        # inheriting the original client's non-empty `api_key` (a plain `or` fallback
+        # would treat the explicit `""` as "not provided" and keep the old key).
+        client = OpenAI(base_url=base_url, api_key=api_key, admin_api_key=None, _strict_response_validation=True)
+
+        copied = client.with_options(api_key="")
+        assert copied.api_key == ""
+
+        request = copied._build_request(FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True}))
+        assert "Authorization" not in request.headers
+
+        # With no override, `with_options()` should still inherit the original api_key.
+        inherited = client.with_options(timeout=5)
+        assert inherited.api_key == api_key
 
     @pytest.mark.respx(base_url=base_url)
     def test_api_key_provider_preserves_admin_auth(self, respx_mock: MockRouter) -> None:
@@ -1916,6 +1949,23 @@ class TestAsyncOpenAI:
                     )
                 )
 
+            # Raw request helpers (`client.get(...)`, `.post(...)`, etc.) don't pass an
+            # explicit `security` override, so they fall back to `FinalRequestOptions`'s
+            # default of requiring *either* bearer or admin auth. Since bearer auth is
+            # one of the accepted methods here, the empty `api_key` should still bypass
+            # validation instead of being treated as admin-only.
+            default_security_request = client._build_request(FinalRequestOptions(method="get", url="/foo"))
+            assert "Authorization" not in default_security_request.headers
+
+            # `copy()`/`with_options()` should also honor an explicitly-passed empty
+            # `api_key`, rather than silently falling back to the inherited key.
+            copied_client = client.copy(api_key="")
+            assert copied_client.api_key == ""
+            copied_request = copied_client._build_request(
+                FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True})
+            )
+            assert "Authorization" not in copied_request.headers
+
         # OPENAI_API_KEY="" in the environment (without explicit api_key arg) should still raise,
         # as an empty env var likely indicates misconfiguration rather than intentional use.
         with update_env(
@@ -1926,6 +1976,22 @@ class TestAsyncOpenAI:
         ):
             with pytest.raises(OpenAIError, match="Missing credentials"):
                 AsyncOpenAI(base_url=base_url, admin_api_key=None, _strict_response_validation=True)
+
+    def test_with_options_preserves_explicit_empty_api_key(self) -> None:
+        # `client.with_options(api_key="")` should disable auth on the copy, rather than
+        # inheriting the original client's non-empty `api_key` (a plain `or` fallback
+        # would treat the explicit `""` as "not provided" and keep the old key).
+        client = AsyncOpenAI(base_url=base_url, api_key=api_key, admin_api_key=None, _strict_response_validation=True)
+
+        copied = client.with_options(api_key="")
+        assert copied.api_key == ""
+
+        request = copied._build_request(FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True}))
+        assert "Authorization" not in request.headers
+
+        # With no override, `with_options()` should still inherit the original api_key.
+        inherited = client.with_options(timeout=5)
+        assert inherited.api_key == api_key
 
     @pytest.mark.respx(base_url=base_url)
     async def test_api_key_provider_preserves_admin_auth(self, respx_mock: MockRouter) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -540,6 +540,24 @@ class TestOpenAI:
             )
             assert client.api_key == ""
 
+            # Requests should also succeed, not just client construction: no `Authorization`
+            # header should be required or added when api_key was explicitly set to "".
+            request = client._build_request(
+                FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True})
+            )
+            assert "Authorization" not in request.headers
+
+            # An explicit empty api_key should not bypass validation for endpoints that
+            # require credentials the client doesn't have (e.g. admin-only endpoints).
+            with pytest.raises(TypeError, match="Could not resolve authentication method"):
+                client._build_request(
+                    FinalRequestOptions(
+                        method="get",
+                        url="/organization/projects",
+                        security={"admin_api_key_auth": True},
+                    )
+                )
+
         # OPENAI_API_KEY="" in the environment (without explicit api_key arg) should still raise,
         # as an empty env var likely indicates misconfiguration rather than intentional use.
         with update_env(
@@ -1879,6 +1897,24 @@ class TestAsyncOpenAI:
                 _strict_response_validation=True,
             )
             assert client.api_key == ""
+
+            # Requests should also succeed, not just client construction: no `Authorization`
+            # header should be required or added when api_key was explicitly set to "".
+            request = client._build_request(
+                FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True})
+            )
+            assert "Authorization" not in request.headers
+
+            # An explicit empty api_key should not bypass validation for endpoints that
+            # require credentials the client doesn't have (e.g. admin-only endpoints).
+            with pytest.raises(TypeError, match="Could not resolve authentication method"):
+                client._build_request(
+                    FinalRequestOptions(
+                        method="get",
+                        url="/organization/projects",
+                        security={"admin_api_key_auth": True},
+                    )
+                )
 
         # OPENAI_API_KEY="" in the environment (without explicit api_key arg) should still raise,
         # as an empty env var likely indicates misconfiguration rather than intentional use.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -524,6 +524,22 @@ class TestOpenAI:
             with pytest.raises(OpenAIError, match="Missing credentials"):
                 OpenAI(base_url=base_url, api_key=None, admin_api_key=None, _strict_response_validation=True)
 
+        # Explicitly passing api_key="" should not raise, even with _enforce_credentials=True.
+        # This is important for OpenAI-compatible local servers that don't require authentication.
+        with update_env(
+            **{
+                "OPENAI_API_KEY": Omit(),
+                "OPENAI_ADMIN_KEY": Omit(),
+            }
+        ):
+            client = OpenAI(
+                base_url=base_url,
+                api_key="",
+                admin_api_key=None,
+                _strict_response_validation=True,
+            )
+            assert client.api_key == ""
+
     @pytest.mark.respx(base_url=base_url)
     def test_api_key_provider_preserves_admin_auth(self, respx_mock: MockRouter) -> None:
         respx_mock.get("/organization/projects").mock(return_value=httpx.Response(200, json={"ok": True}))
@@ -1836,6 +1852,22 @@ class TestAsyncOpenAI:
         ):
             with pytest.raises(OpenAIError, match="Missing credentials"):
                 AsyncOpenAI(base_url=base_url, api_key=None, admin_api_key=None, _strict_response_validation=True)
+
+        # Explicitly passing api_key="" should not raise, even with _enforce_credentials=True.
+        # This is important for OpenAI-compatible local servers that don't require authentication.
+        with update_env(
+            **{
+                "OPENAI_API_KEY": Omit(),
+                "OPENAI_ADMIN_KEY": Omit(),
+            }
+        ):
+            client = AsyncOpenAI(
+                base_url=base_url,
+                api_key="",
+                admin_api_key=None,
+                _strict_response_validation=True,
+            )
+            assert client.api_key == ""
 
     @pytest.mark.respx(base_url=base_url)
     async def test_api_key_provider_preserves_admin_auth(self, respx_mock: MockRouter) -> None:

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -10,6 +10,7 @@ from httpx import URL
 
 import openai
 from openai import DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES
+from openai._models import FinalRequestOptions
 
 
 def reset_state() -> None:
@@ -98,6 +99,24 @@ def test_http_client_option() -> None:
     openai.http_client = new_client
 
     assert openai.completions._client._client is new_client
+
+
+def test_module_api_key_set_empty_after_load_bypasses_auth() -> None:
+    # The module client is constructed lazily on first access, capturing whatever
+    # `openai.api_key` was set to at that time. If the caller mutates `openai.api_key`
+    # afterwards, the already-constructed client must still pick up the new value —
+    # including switching to (or away from) the "explicitly disabled auth" state that
+    # an empty string represents, not just the plain `api_key` value.
+    openai.api_key = "real-key"
+
+    client = openai.completions._client
+    assert client.api_key == "real-key"
+
+    openai.api_key = ""
+
+    assert client.api_key == ""
+    request = client._build_request(FinalRequestOptions(method="get", url="/foo", security={"bearer_auth": True}))
+    assert "Authorization" not in request.headers
 
 
 import contextlib


### PR DESCRIPTION
## Summary

Fixes #3224

- In v2.34.0, the credential validation in `_client.py` changed from an identity check (`api_key is None`) to a truthiness check (`not self.api_key`), which causes `api_key=""` to be rejected as "Missing credentials"
- This broke OpenAI-compatible local servers (llama.cpp, llamafile, LM Studio, vLLM, etc.) that don't require authentication and intentionally pass `api_key=""`
- This fix tracks whether `api_key` was explicitly provided by the caller and skips the credential error when it was, even if the value is an empty string

## Changes

**`src/openai/_client.py`**: Added `_api_key_explicitly_set` local variable in both `OpenAI.__init__()` and `AsyncOpenAI.__init__()` that tracks whether the caller explicitly passed an `api_key` argument (vs it being resolved from the environment or defaulting to `None`). The credential validation check now also considers this flag, so `api_key=""` no longer triggers the error while `api_key=None` with no env var still does.

**`tests/test_client.py`**: Added test cases for both sync and async clients verifying that `api_key=""` does not raise `OpenAIError`, restoring the pre-v2.34.0 behavior.