### PR TITLE
fix(streaming): handle duplicate-index list entries in accumulate_delta

### DIFF
--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -44,7 +44,7 @@ def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> 
         elif is_list(acc_value) and is_list(delta_value):
             # for lists of non-dictionary items we'll only ever get new entries
             # in the array, existing entries will never be changed
-            if all(isinstance(x, (str, int, float)) for x in acc_value):
+            if acc_value and all(isinstance(x, (str, int, float)) for x in acc_value):
                 acc_value.extend(delta_value)
                 continue
 

--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -6,13 +6,24 @@ from ..._utils import is_dict, is_list
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
-            acc[key] = delta_value
-            continue
+            if is_list(delta_value):
+                # Initialize an empty list so that list-merge logic below
+                # handles duplicate-index entries even on the very first chunk.
+                acc[key] = []
+            else:
+                acc[key] = delta_value
+                continue
 
         acc_value = acc[key]
         if acc_value is None:
-            acc[key] = delta_value
-            continue
+            if is_list(delta_value):
+                # Same as above: route list deltas through the merge path
+                # instead of copying the raw array wholesale.
+                acc[key] = []
+                acc_value = acc[key]
+            else:
+                acc[key] = delta_value
+                continue
 
         # the `index` property is used in arrays of objects so it should
         # not be accumulated like other values e.g.


### PR DESCRIPTION
There's a bug in accumulate_delta where if the very first streaming chunk contains a list value (like tool_calls), the function copies it wholesale into acc and returns early — completely skipping the index-based merge logic. That means if the first chunk happens to have two entries at the same index (which the OpenAI spec allows), they end up as two separate list items instead of being merged. Subsequent chunks then only ever touch index 0, leaving the duplicate entry orphaned and causing tool_calls[0].function.arguments to be missing a chunk and come out as invalid JSON.

The fix is straightforward: in the two early-return branches ("key not in acc" and "acc_value is None"), check whether delta_value is a list before doing the wholesale copy. If it is, initialize acc[key] to an empty list and let execution fall through to the existing per-index merge loop, the same path that all subsequent chunks already go through. Non-list values still take the original fast path.

- [x] I understand that this repository is auto-generated and my pull request may not be merged

The change is in src/openai/lib/streaming/_deltas.py only. The same early-return pattern exists in _assistants.py but that file has different context so I've left it for a separate follow-up if needed.

Fixes #3203. See also #3201 which covers a narrower version of the same bug.