### PR TITLE
fix: merge duplicate-index entries in streaming tool_call deltas

### DIFF
--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -977,14 +977,48 @@ def accumulate_event(
     return current_message_snapshot, new_content
 
 
+def _merge_indexed_list(items: list[object]) -> list[object]:
+    """Merge list entries that share the same ``index`` value.
+
+    Streaming chunks may contain multiple entries with the same logical
+    ``index`` (e.g. a tool-call name and its first argument fragment in one
+    SSE event).  When such a list is stored for the first time it must be
+    collapsed by logical index so that later chunks merge correctly.
+    """
+    if not items or not is_dict(items[0]) or "index" not in items[0]:  # type: ignore[arg-type]
+        return items
+
+    merged: dict[int, object] = {}
+    order: list[int] = []
+    for item in items:
+        if not is_dict(item):
+            continue
+        idx = item.get("index")  # type: ignore[union-attr]
+        if not isinstance(idx, int):
+            continue
+        if idx in merged:
+            existing = merged[idx]
+            if is_dict(existing):
+                merged[idx] = accumulate_delta(existing, item)  # type: ignore[arg-type]
+        else:
+            order.append(idx)
+            merged[idx] = item
+
+    return [merged[i] for i in order]
+
+
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
+            if is_list(delta_value):
+                delta_value = _merge_indexed_list(delta_value)
             acc[key] = delta_value
             continue
 
         acc_value = acc[key]
         if acc_value is None:
+            if is_list(delta_value):
+                delta_value = _merge_indexed_list(delta_value)
             acc[key] = delta_value
             continue
 

--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -3,14 +3,48 @@ from __future__ import annotations
 from ..._utils import is_dict, is_list
 
 
+def _merge_indexed_list(items: list[object]) -> list[object]:
+    """Merge list entries that share the same ``index`` value.
+
+    Streaming chunks may contain multiple entries with the same logical
+    ``index`` (e.g. a tool-call name and its first argument fragment in one
+    SSE event).  When such a list is stored for the first time it must be
+    collapsed by logical index so that later chunks merge correctly.
+    """
+    if not items or not is_dict(items[0]) or "index" not in items[0]:  # type: ignore[arg-type]
+        return items
+
+    merged: dict[int, object] = {}
+    order: list[int] = []
+    for item in items:
+        if not is_dict(item):
+            continue
+        idx = item.get("index")  # type: ignore[union-attr]
+        if not isinstance(idx, int):
+            continue
+        if idx in merged:
+            existing = merged[idx]
+            if is_dict(existing):
+                merged[idx] = accumulate_delta(existing, item)  # type: ignore[arg-type]
+        else:
+            order.append(idx)
+            merged[idx] = item
+
+    return [merged[i] for i in order]
+
+
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
+            if is_list(delta_value):
+                delta_value = _merge_indexed_list(delta_value)
             acc[key] = delta_value
             continue
 
         acc_value = acc[key]
         if acc_value is None:
+            if is_list(delta_value):
+                delta_value = _merge_indexed_list(delta_value)
             acc[key] = delta_value
             continue
 


### PR DESCRIPTION
## Summary

Fixes #3201

When the first streamed chunk contains multiple `tool_calls` entries with the same logical `index` (e.g. a tool-call name and its first argument fragment in one SSE event), the two early-return branches in `accumulate_delta` store the list as-is without merging by index. Later chunks merge into physical position 0 only, leaving the duplicate entry orphaned and producing invalid final JSON.

### Root cause

Both early-return branches at the top of the per-key loop in `_deltas.py` (and the identical copy in `_assistants.py`) assign the delta list wholesale and skip the index-based merge logic that handles duplicate indexes in steady state:

```python
if key not in acc:          # L8-10: first occurrence
    acc[key] = delta_value
    continue

acc_value = acc[key]
if acc_value is None:       # L13-15: None placeholder
    acc[key] = delta_value
    continue
```

### Fix

Add `_merge_indexed_list()` that collapses list entries sharing the same `index` value before the list is stored for the first time. Applied in both `_deltas.py` and `_assistants.py`.

- Non-indexed lists (strings, ints) pass through unchanged
- Lists without an `index` field in the first entry pass through unchanged
- Lists with duplicate `index` values are merged using the existing `accumulate_delta` recursion

## Test plan

- [x] Verified with exact reproduction from issue (duplicate `index: 0` in first chunk, `acc_value is None`)
- [x] Verified with `key not in acc` variant
- [x] Verified multiple distinct tool calls (different indexes) still work correctly
- [x] Verified non-indexed string lists still accumulate normally
- [x] Existing streaming test suite passes (35/35)