### PR TITLE
fix(types): add missing fields to ImageGenerationCall response types

### DIFF
--- a/src/openai/types/responses/response_input_item.py
+++ b/src/openai/types/responses/response_input_item.py
@@ -184,6 +184,21 @@ class ImageGenerationCall(BaseModel):
     type: Literal["image_generation_call"]
     """The type of the image generation call. Always `image_generation_call`."""
 
+    background: Optional[Literal["transparent", "opaque", "auto"]] = None
+    """The background setting used for the generated image."""
+
+    output_format: Optional[Literal["png", "webp", "jpeg"]] = None
+    """The output format of the generated image."""
+
+    quality: Optional[Literal["low", "medium", "high", "auto"]] = None
+    """The quality setting used for the generated image."""
+
+    revised_prompt: Optional[str] = None
+    """The revised prompt that was used to generate the image, if applicable."""
+
+    size: Optional[Literal["1024x1024", "1024x1536", "1536x1024", "auto"]] = None
+    """The size of the generated image."""
+
 
 class LocalShellCallAction(BaseModel):
     """Execute a shell command on the server."""

--- a/src/openai/types/responses/response_input_item_param.py
+++ b/src/openai/types/responses/response_input_item_param.py
@@ -185,6 +185,21 @@ class ImageGenerationCall(TypedDict, total=False):
     type: Required[Literal["image_generation_call"]]
     """The type of the image generation call. Always `image_generation_call`."""
 
+    background: Optional[Literal["transparent", "opaque", "auto"]]
+    """The background setting used for the generated image."""
+
+    output_format: Optional[Literal["png", "webp", "jpeg"]]
+    """The output format of the generated image."""
+
+    quality: Optional[Literal["low", "medium", "high", "auto"]]
+    """The quality setting used for the generated image."""
+
+    revised_prompt: Optional[str]
+    """The revised prompt that was used to generate the image, if applicable."""
+
+    size: Optional[Literal["1024x1024", "1024x1536", "1536x1024", "auto"]]
+    """The size of the generated image."""
+
 
 class LocalShellCallAction(TypedDict, total=False):
     """Execute a shell command on the server."""

--- a/src/openai/types/responses/response_item.py
+++ b/src/openai/types/responses/response_item.py
@@ -54,6 +54,21 @@ class ImageGenerationCall(BaseModel):
     type: Literal["image_generation_call"]
     """The type of the image generation call. Always `image_generation_call`."""
 
+    background: Optional[Literal["transparent", "opaque", "auto"]] = None
+    """The background setting used for the generated image."""
+
+    output_format: Optional[Literal["png", "webp", "jpeg"]] = None
+    """The output format of the generated image."""
+
+    quality: Optional[Literal["low", "medium", "high", "auto"]] = None
+    """The quality setting used for the generated image."""
+
+    revised_prompt: Optional[str] = None
+    """The revised prompt that was used to generate the image, if applicable."""
+
+    size: Optional[Literal["1024x1024", "1024x1536", "1536x1024", "auto"]] = None
+    """The size of the generated image."""
+
 
 class LocalShellCallAction(BaseModel):
     """Execute a shell command on the server."""

--- a/src/openai/types/responses/response_output_item.py
+++ b/src/openai/types/responses/response_output_item.py
@@ -53,6 +53,21 @@ class ImageGenerationCall(BaseModel):
     type: Literal["image_generation_call"]
     """The type of the image generation call. Always `image_generation_call`."""
 
+    background: Optional[Literal["transparent", "opaque", "auto"]] = None
+    """The background setting used for the generated image."""
+
+    output_format: Optional[Literal["png", "webp", "jpeg"]] = None
+    """The output format of the generated image."""
+
+    quality: Optional[Literal["low", "medium", "high", "auto"]] = None
+    """The quality setting used for the generated image."""
+
+    revised_prompt: Optional[str] = None
+    """The revised prompt that was used to generate the image, if applicable."""
+
+    size: Optional[Literal["1024x1024", "1024x1536", "1536x1024", "auto"]] = None
+    """The size of the generated image."""
+
 
 class LocalShellCallAction(BaseModel):
     """Execute a shell command on the server."""


### PR DESCRIPTION
## Summary

The `ImageGenerationCall` model in the Responses API type stubs is missing several fields that the API actually returns. When the API response contains `background`, `output_format`, `quality`, `revised_prompt`, or `size`, accessing those attributes raises `AttributeError` because Pydantic's `BaseModel` (and the corresponding `TypedDict` param type) doesn't know about them.

Fixes #2649, closes #2580.

**Fields added to `ImageGenerationCall` in all four affected files:**

| Field | Type |
|---|---|
| `background` | `Optional[Literal["transparent", "opaque", "auto"]]` |
| `output_format` | `Optional[Literal["png", "webp", "jpeg"]]` |
| `quality` | `Optional[Literal["low", "medium", "high", "auto"]]` |
| `revised_prompt` | `Optional[str]` |
| `size` | `Optional[Literal["1024x1024", "1024x1536", "1536x1024", "auto"]]` |

The Literal values are consistent with `ImageGenCompletedEvent` (already present in `src/openai/types/image_gen_completed_event.py`) and with the live API spec.

**Files changed:**
- `src/openai/types/responses/response_output_item.py`
- `src/openai/types/responses/response_input_item.py`
- `src/openai/types/responses/response_item.py`
- `src/openai/types/responses/response_input_item_param.py`

## Checklist

- [x] All fields are `Optional` with `= None` default (non-breaking)
- [x] Literal values match those in `ImageGenCompletedEvent`
- [x] `TypedDict` param variant also updated (`response_input_item_param.py`)
- [x] `ruff check` — no issues
- [x] `ruff format --check` — already formatted
- [x] `pytest tests/test_models.py tests/test_utils` — 179 passed

```
$ python -m pytest tests/test_models.py tests/test_utils -x -q
179 passed in 1.51s

=== LOCAL_TEST_PASSED ===
```
