### PR TITLE
fix(parsing): prevent Pydantic schema validator leak in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -67,22 +67,29 @@ def parse_response(
                     continue
 
                 content_list.append(
-                    construct_type_unchecked(
-                        type_=ParsedResponseOutputText[TextFormatT],
-                        value={
-                            **item.to_dict(),
-                            "parsed": parse_text(item.text, text_format=text_format),
-                        },
+                    cast(
+                        "ParsedResponseOutputText[TextFormatT]",
+                        construct_type_unchecked(
+                            # Unparameterised: lets Pydantic cache the schema; free TypeVar causes unbounded rebuilds.
+                            type_=ParsedResponseOutputText,
+                            value={
+                                **item.to_dict(),
+                                "parsed": parse_text(item.text, text_format=text_format),
+                            },
+                        ),
                     )
                 )
 
             output_list.append(
-                construct_type_unchecked(
-                    type_=ParsedResponseOutputMessage[TextFormatT],
-                    value={
-                        **output.to_dict(),
-                        "content": content_list,
-                    },
+                cast(
+                    "ParsedResponseOutputMessage[TextFormatT]",
+                    construct_type_unchecked(
+                        type_=ParsedResponseOutputMessage,
+                        value={
+                            **output.to_dict(),
+                            "content": content_list,
+                        },
+                    ),
                 )
             )
         elif output.type == "function_call":
@@ -129,12 +136,15 @@ def parse_response(
         else:
             output_list.append(output)
 
-    return construct_type_unchecked(
-        type_=ParsedResponse[TextFormatT],
-        value={
-            **response.to_dict(),
-            "output": output_list,
-        },
+    return cast(
+        "ParsedResponse[TextFormatT]",
+        construct_type_unchecked(
+            type_=ParsedResponse,
+            value={
+                **response.to_dict(),
+                "output": output_list,
+            },
+        ),
     )
 
 

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
+import gc
+
 from typing_extensions import TypeVar
 
 import pytest
+import pydantic
 from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai._models import construct_type_unchecked
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -60,4 +66,92 @@ def test_parse_method_definition_in_sync(sync: bool, client: OpenAI, async_clien
         checking_client.responses.create,
         checking_client.responses.parse,
         exclude_params={"tools"},
+    )
+
+
+_MINIMAL_RESPONSE_DICT = {
+    "id": "resp_test",
+    "object": "response",
+    "created_at": 1700000000,
+    "status": "completed",
+    "model": "gpt-4o-mini",
+    "output": [
+        {
+            "id": "msg_test",
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": '{"name": "Birthday Party", "date": "2026-06-01"}',
+                    "annotations": [],
+                    "logprobs": [],
+                }
+            ],
+        }
+    ],
+    "parallel_tool_calls": True,
+    "reasoning": {"effort": None, "summary": None},
+    "text": {"format": {"type": "text"}, "verbosity": "medium"},
+    "tool_choice": "auto",
+    "tools": [],
+    "truncation": "disabled",
+    "usage": {
+        "input_tokens": 10,
+        "input_tokens_details": {"cached_tokens": 0},
+        "output_tokens": 10,
+        "output_tokens_details": {"reasoning_tokens": 0},
+        "total_tokens": 20,
+    },
+}
+
+
+class _CalendarEvent(pydantic.BaseModel):
+    name: str
+    date: str
+
+
+def test_parse_response_structured_output_correctness() -> None:
+    """parse_response returns correctly-typed and correctly-valued output."""
+    response = construct_type_unchecked(type_=Response, value=_MINIMAL_RESPONSE_DICT)
+
+    parsed = parse_response(text_format=_CalendarEvent, input_tools=None, response=response)
+
+    assert len(parsed.output) == 1
+    msg = parsed.output[0]
+    assert msg.type == "message"
+    content = msg.content[0]
+    assert content.type == "output_text"
+    assert isinstance(content.parsed, _CalendarEvent)
+    assert content.parsed.name == "Birthday Party"
+    assert content.parsed.date == "2026-06-01"
+
+
+def test_parse_response_no_pydantic_schema_leak() -> None:
+    """parse_response must not allocate new SchemaValidator objects on every call.
+
+    Using ParsedResponse[free_TypeVar] prevents Pydantic from caching the schema,
+    causing a new SchemaValidator/SchemaSerializer per call (issue #3084).
+    """
+    response = construct_type_unchecked(type_=Response, value=_MINIMAL_RESPONSE_DICT)
+
+    # One warm-up call triggers the initial (and only legitimate) schema build.
+    parse_response(text_format=_CalendarEvent, input_tools=None, response=response)
+
+    def _count_validators() -> int:
+        return sum(1 for obj in gc.get_objects() if type(obj).__name__ == "SchemaValidator")
+
+    gc.collect()
+    before = _count_validators()
+
+    for _ in range(50):
+        parse_response(text_format=_CalendarEvent, input_tools=None, response=response)
+
+    gc.collect()
+    after = _count_validators()
+
+    assert after == before, (
+        f"parse_response leaked {after - before} SchemaValidator object(s) over 50 calls. "
+        "The Pydantic schema for ParsedResponse and friends must be built once and cached."
     )


### PR DESCRIPTION
## Summary

- Replace `ParsedResponseOutputText[TextFormatT]`, `ParsedResponseOutputMessage[TextFormatT]`, and `ParsedResponse[TextFormatT]` with their unparameterised forms in `openai/lib/_parsing/_responses.py`.
- Add `cast(...)` wrappers to preserve the static type signatures for callers.
- Add two regression tests: one for correctness, one that asserts `SchemaValidator` objects do not grow after the initial warm-up call.

## Issue

Closes #3084

`parse_response` constructs `ParsedResponse[TextFormatT]` (and the two inner types) using a **free `TypeVar`** as the type argument. Pydantic v2's `model_rebuild` cannot resolve a free TypeVar, so it returns `False` and never populates `MockCoreSchema._built_memo`. This causes a fresh `SchemaValidator` and `SchemaSerializer` (heavy Rust objects) to be allocated on **every single** `responses.parse()` call. In a long-running server the process RSS grows linearly with request count.

Root cause:
```python
# Before — free TypeVar causes pydantic model_rebuild to return False every time
construct_type_unchecked(type_=ParsedResponse[TextFormatT], value={...})
```

Fix — use the unparameterised class so Pydantic builds and caches the schema once:
```python
# After
cast("ParsedResponse[TextFormatT]", construct_type_unchecked(type_=ParsedResponse, value={...}))
```

All three parameterised Generic fields are either guarded by `if TYPE_CHECKING:` (runtime-inert) or set explicitly from the dict passed to `construct_type_unchecked`, so the unparameterised form is runtime-equivalent.

## Local verification

```
=== LOCAL_TEST_PASSED ===
$ cd /tmp/openai-python && python3 -m pytest tests/lib/responses/ tests/test_models.py tests/test_utils/ -v --override-ini="addopts=" -q

============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /tmp/openai-python
configfile: pyproject.toml
plugins: respx-0.23.1, inline-snapshot-0.33.0, xdist-3.8.0, asyncio-1.3.0, anyio-4.46.0
asyncio: mode=Mode.AUTO

collected 186 items

tests/lib/responses/test_responses.py .......                            [  3%]
tests/test_models.py ................................................    [ 29%]
tests/test_utils/test_datetime_parse.py ...................................
...............................                                          [ 63%]
tests/test_utils/test_json.py .........                                  [ 68%]
tests/test_utils/test_logging.py .....                                   [ 70%]
tests/test_utils/test_path.py ..............................................
.....                                                                    [ 96%]
tests/test_utils/test_proxy.py ..                                        [ 97%]
tests/test_utils/test_typing.py .....                                    [100%]

186 passed in 0.86s
```

Schema-leak verification (warm-up + 50 calls, delta must be 0):
```python
gc.collect(); before = count_schema_validators()
for _ in range(50): parse_response(text_format=CalendarEvent, ...)
gc.collect(); after = count_schema_validators()
# delta = 0  ✓
```

## Risk

- **Correctness**: no runtime change — the type arguments only affect type-checker annotations. The `parsed` field value is already embedded in the dict passed to `construct_type_unchecked`.
- **Type safety**: explicit `cast` preserves all existing type signatures; no downstream callers need updating.
- **Pydantic v1 / v2**: both use `construct_type_unchecked` the same way; the caching fix only matters for Pydantic v2's `model_rebuild` path, and the unparameterised form is valid for both.
