### PR TITLE
fix: guard against item=None in response.output_item.added accumulator

### DIFF
--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -328,7 +328,9 @@ class ResponseStreamState(Generic[TextFormatT]):
             return self._create_initial_response(event)
 
         if event.type == "response.output_item.added":
-            if event.item.type == "function_call":
+            if event.item is None:
+                pass
+            elif event.item.type == "function_call":
                 snapshot.output.append(
                     construct_type_unchecked(
                         type_=cast(Any, ParsedResponseFunctionToolCall), value=event.item.to_dict()


### PR DESCRIPTION
## Summary

Closes #3125

The Responses stream accumulator assumed every `response.output_item.added` event includes a non-null `item` and immediately accessed `event.item.type`. OpenAI-compatible providers can emit this event with `item=None`, which crashes streaming with `AttributeError`.

## Changes

- **`src/openai/lib/streaming/responses/_responses.py`**: Add a defensive `None` check before inspecting `event.item.type`, so malformed/null output-item events are skipped instead of crashing the stream accumulator

## Verification

- Not run; small defensive guard in the accumulator path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>