### PR TITLE
fix: add missing MCP server event types to RealtimeServerEvent union

### DIFF
--- a/src/openai/types/beta/realtime/realtime_server_event.py
+++ b/src/openai/types/beta/realtime/realtime_server_event.py
@@ -38,6 +38,14 @@ from .conversation_item_input_audio_transcription_failed_event import Conversati
 from .conversation_item_input_audio_transcription_completed_event import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
 )
+from ...realtime.mcp_list_tools_failed import McpListToolsFailed
+from ...realtime.mcp_list_tools_completed import McpListToolsCompleted
+from ...realtime.mcp_list_tools_in_progress import McpListToolsInProgress
+from ...realtime.response_mcp_call_failed import ResponseMcpCallFailed
+from ...realtime.response_mcp_call_completed import ResponseMcpCallCompleted
+from ...realtime.response_mcp_call_in_progress import ResponseMcpCallInProgress
+from ...realtime.response_mcp_call_arguments_done import ResponseMcpCallArgumentsDone
+from ...realtime.response_mcp_call_arguments_delta import ResponseMcpCallArgumentsDelta
 
 __all__ = [
     "RealtimeServerEvent",
@@ -128,6 +136,14 @@ RealtimeServerEvent: TypeAlias = Annotated[
         OutputAudioBufferStarted,
         OutputAudioBufferStopped,
         OutputAudioBufferCleared,
+        McpListToolsInProgress,
+        McpListToolsCompleted,
+        McpListToolsFailed,
+        ResponseMcpCallArgumentsDelta,
+        ResponseMcpCallArgumentsDone,
+        ResponseMcpCallInProgress,
+        ResponseMcpCallCompleted,
+        ResponseMcpCallFailed,
     ],
     PropertyInfo(discriminator="type"),
 ]


### PR DESCRIPTION
The RealtimeServerEvent TypeAlias was missing eight MCP-related event types emitted during MCP tool call flows: McpListToolsInProgress, McpListToolsCompleted, McpListToolsFailed, ResponseMcpCallArgumentsDelta, ResponseMcpCallArgumentsDone, ResponseMcpCallInProgress, ResponseMcpCallCompleted, ResponseMcpCallFailed. Without these in the union, client code switching on event type silently drops them, so MCP tool calls never complete. Added all eight to the alias in realtime_server_event.py.

Fixes #3128