### PR TITLE
fix(examples): guard non-streaming choices access to match streaming pattern

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -16,7 +16,8 @@ completion = client.chat.completions.create(
         },
     ],
 )
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)
 
 # Streaming:
 print("----- streaming request -----")
@@ -50,4 +51,5 @@ response = client.chat.completions.with_raw_response.create(
 )
 completion = response.parse()
 print(response.request_id)
-print(completion.choices[0].message.content)
+if completion.choices:
+    print(completion.choices[0].message.content)

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -16,7 +16,7 @@ completion = client.chat.completions.create(
         },
     ],
 )
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)
 
 # Streaming:
@@ -51,5 +51,5 @@ response = client.chat.completions.with_raw_response.create(
 )
 completion = response.parse()
 print(response.request_id)
-if completion.choices:
+if completion.choices and completion.choices[0].message is not None:
     print(completion.choices[0].message.content)


### PR DESCRIPTION
## Problem

The streaming section of `examples/demo.py` already guards `choices` access:

```python
for chunk in stream:
    if not chunk.choices:
        continue
    print(chunk.choices[0].delta.content, end="")
```

But the two non-streaming completions access `choices[0]` directly without the same check. Content-policy filters return `choices=[]`, which raises `IndexError`.

## Change

Add `if completion.choices:` guards to the two non-streaming print statements to make the pattern consistent with the streaming example already in the file.

Minimal diff — 4 lines added, no behaviour change when the API returns choices normally.

---
*Found by [pact](https://github.com/qizwiz/pact) static analysis — `llm_response_unguarded` mode.*