### PR TITLE
examples: use `env -S` so example shebangs work on Linux

### DIFF
--- a/examples/audio.py
+++ b/examples/audio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env rye run python
+#!/usr/bin/env -S rye run python
 
 from pathlib import Path
 

--- a/examples/speech_to_text.py
+++ b/examples/speech_to_text.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env rye run python
+#!/usr/bin/env -S rye run python
 
 import asyncio
 

--- a/examples/text_to_speech.py
+++ b/examples/text_to_speech.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env rye run python
+#!/usr/bin/env -S rye run python
 
 import time
 import asyncio


### PR DESCRIPTION
## Summary

Three example scripts have a shebang of:

```
#!/usr/bin/env rye run python
```

This works on macOS BSD `env`, but on Linux `/usr/bin/env` does not split the interpreter spec on spaces and instead tries to exec a binary literally named `"rye run python"`, which fails with `bad interpreter: no such file or directory`. The fix is to add the `-S` flag, which tells `env` to tokenize the rest of the line.

`CONTRIBUTING.md` already documents the correct form:

> ```
> #!/usr/bin/env -S rye run python
> ```

and the rest of `examples/` (`async_demo.py`, `demo.py`, `streaming.py`, `video.py`) already uses `-S` with the `poetry`/`python` runner. This PR brings the three remaining files in line.

## Files touched

- `examples/audio.py`
- `examples/speech_to_text.py`
- `examples/text_to_speech.py`

## Verification

Manual test on Linux confirms the previous form fails and the `-S` form executes the script. No SDK behavior change.