### PR TITLE
fix(tests): use "compaction" as ContextManagement type value

### DIFF
--- a/tests/api_resources/test_responses.py
+++ b/tests/api_resources/test_responses.py
@@ -32,7 +32,7 @@ class TestResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -120,7 +120,7 @@ class TestResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -445,7 +445,7 @@ class TestAsyncResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],
@@ -533,7 +533,7 @@ class TestAsyncResponses:
             background=True,
             context_management=[
                 {
-                    "type": "type",
+                    "type": "compaction",
                     "compact_threshold": 1000,
                 }
             ],


### PR DESCRIPTION
## Summary

Fixes #2868.

The `ContextManagement` TypedDict's `type` field is documented to accept only `"compaction"`:

> The context management entry type. Currently only `'compaction'` is supported.

The auto-generated test stubs in `tests/api_resources/test_responses.py` used the placeholder string `"type"` in four `context_management` fixtures, which is not a valid value. This means the tests were constructing payloads that the API would reject, not exercising the actual accepted value.

## Change

`tests/api_resources/test_responses.py` — replace `"type": "type"` → `"type": "compaction"` at lines 35, 123, 448, and 536 (all four `context_management` dict literals in the sync and async test variants).

## Verification

```python
# Before: would hit a 400 from the API — "type" is not a valid context management type
context_management=[{"type": "type", "compact_threshold": 1000}]

# After: matches the only accepted value per the type definition
context_management=[{"type": "compaction", "compact_threshold": 1000}]
```