### PR TITLE
docs(readme): fix Nested params example to call existing chat.completions.create

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,11 +475,11 @@ from openai import OpenAI
 
 client = OpenAI()
 
-response = client.chat.responses.create(
-    input=[
+response = client.chat.completions.create(
+    messages=[
         {
             "role": "user",
-            "content": "How much ?",
+            "content": "Can you generate an example json object describing a fruit?",
         }
     ],
     model="gpt-5.2",


### PR DESCRIPTION
Fixes #3264.

The "Nested params" example in `README.md` called `client.chat.responses.create(...)`, which doesn't exist — `Chat` only exposes `completions`, so the snippet raised `AttributeError: 'Chat' object has no attribute 'responses'`. The example also mixed Responses-API parameter shape (`input=[...]`) with the Chat Completions parameter `response_format`, so it wouldn't work as a Responses example either.

This change rewrites the snippet as a real Chat Completions call, preserving `response_format` (which is valid there) so the "nested params are dictionaries, typed using `TypedDict`" point still lands.

```diff
-response = client.chat.responses.create(
-    input=[
-        {
-            "role": "user",
-            "content": "How much ?",
-        }
-    ],
-    model="gpt-5.2",
-    response_format={"type": "json_object"},
-)
+response = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Can you generate an example json object describing a fruit?",
+        }
+    ],
+    model="gpt-5.2",
+    response_format={"type": "json_object"},
+)
```