### PR TITLE
fix: allow api_key="" to bypass credential validation for local servers

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -182,6 +182,8 @@ class OpenAI(SyncAPIClient):
                 self._api_key_provider = None
             self._workload_identity_auth = None
 
+        self._api_key_explicitly_provided = _api_key_explicitly_provided
+
         if admin_api_key is None:
             admin_api_key = os.environ.get("OPENAI_ADMIN_KEY")
         self.admin_api_key = admin_api_key
@@ -492,6 +494,9 @@ class OpenAI(SyncAPIClient):
         if _has_header(headers, "Authorization") or _has_omitted_header(custom_headers, "Authorization"):
             return
 
+        if self._api_key_explicitly_provided:
+            return
+
         raise TypeError(
             '"Could not resolve authentication method. Expected either api_key or admin_api_key to be set. Or for one of the `Authorization` or `Authorization` headers to be explicitly omitted"'
         )
@@ -690,6 +695,8 @@ class AsyncOpenAI(AsyncAPIClient):
                 self.api_key = api_key or ""
                 self._api_key_provider = None
             self._workload_identity_auth = None
+
+        self._api_key_explicitly_provided = _api_key_explicitly_provided
 
         if admin_api_key is None:
             admin_api_key = os.environ.get("OPENAI_ADMIN_KEY")
@@ -999,6 +1006,9 @@ class AsyncOpenAI(AsyncAPIClient):
     @override
     def _validate_headers(self, headers: Headers, custom_headers: Headers) -> None:
         if _has_header(headers, "Authorization") or _has_omitted_header(custom_headers, "Authorization"):
+            return
+
+        if self._api_key_explicitly_provided:
             return
 
         raise TypeError(

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -163,6 +163,7 @@ class OpenAI(SyncAPIClient):
 
         self.workload_identity = workload_identity
 
+        _api_key_explicitly_provided = False
         if workload_identity is not None:
             self.api_key = WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER
             self._api_key_provider = None
@@ -170,6 +171,7 @@ class OpenAI(SyncAPIClient):
                 workload_identity=workload_identity,
             )
         else:
+            _api_key_explicitly_provided = api_key is not None
             if api_key is None:
                 api_key = os.environ.get("OPENAI_API_KEY")
             if callable(api_key):
@@ -187,6 +189,7 @@ class OpenAI(SyncAPIClient):
         if (
             _enforce_credentials
             and not self.api_key
+            and not _api_key_explicitly_provided
             and self._api_key_provider is None
             and workload_identity is None
             and self.admin_api_key is None
@@ -669,6 +672,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         self.workload_identity = workload_identity
 
+        _api_key_explicitly_provided = False
         if workload_identity is not None:
             self.api_key = WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER
             self._api_key_provider = None
@@ -676,6 +680,7 @@ class AsyncOpenAI(AsyncAPIClient):
                 workload_identity=workload_identity,
             )
         else:
+            _api_key_explicitly_provided = api_key is not None
             if api_key is None:
                 api_key = os.environ.get("OPENAI_API_KEY")
             if callable(api_key):
@@ -693,6 +698,7 @@ class AsyncOpenAI(AsyncAPIClient):
         if (
             _enforce_credentials
             and not self.api_key
+            and not _api_key_explicitly_provided
             and self._api_key_provider is None
             and workload_identity is None
             and self.admin_api_key is None


### PR DESCRIPTION
Fixes #3224

## Summary

- `v2.34.0` changed the credential check from `api_key is None` to `not self.api_key` (truthiness), which rejects `api_key=""` as missing credentials
- This broke local OpenAI-compatible servers (llama.cpp, llamafile, LM Studio, vLLM, etc.) that pass `api_key=""` because no auth is needed
- Fix tracks `_api_key_explicitly_provided` before the env var fallback in both `OpenAI.__init__()` and `AsyncOpenAI.__init__()`

## How it works

Capture whether the caller explicitly passed `api_key` before the env var fallback:

```python
_api_key_explicitly_provided = False  # safe default for workload_identity path
# ...
else:
    _api_key_explicitly_provided = api_key is not None  # capture before env fallback
    if api_key is None:
        api_key = os.environ.get("OPENAI_API_KEY")
```

Then skip the error when the caller explicitly passed `api_key=""`:

```python
if (
    _enforce_credentials
    and not self.api_key
    and not _api_key_explicitly_provided  # allow explicit empty string
    and self._api_key_provider is None
    and workload_identity is None
    and self.admin_api_key is None
):
```

## Behavior

| Scenario | Before fix | After fix |
|---|---|---|
| `api_key=""` explicitly passed | raises `OpenAIError` | allowed |
| `api_key=None`, no env var | raises `OpenAIError` | raises `OpenAIError` |
| `api_key=None`, env var set | works | works |
| `workload_identity` set | works | works |

## Test plan

- [x] `OpenAI(api_key="", base_url="http://localhost:8080/v1")` no longer raises
- [x] `AsyncOpenAI(api_key="", base_url="http://localhost:8080/v1")` no longer raises
- [ ] `OpenAI()` with no env var still raises `OpenAIError`