### PR TITLE
fix(client): treat empty OPENAI_BASE_URL env var as unset

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -211,7 +211,7 @@ class OpenAI(SyncAPIClient):
 
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url is None:
+        if not base_url:
             base_url = f"https://api.openai.com/v1"
 
         custom_headers_env = os.environ.get("OPENAI_CUSTOM_HEADERS")
@@ -717,7 +717,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         if base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
-        if base_url is None:
+        if not base_url:
             base_url = f"https://api.openai.com/v1"
 
         custom_headers_env = os.environ.get("OPENAI_CUSTOM_HEADERS")


### PR DESCRIPTION
Fixes #2927.

## Summary

When `OPENAI_BASE_URL` is set to an empty string in the environment, `os.environ.get("OPENAI_BASE_URL")` returns `""`. The subsequent `if base_url is None` check is skipped, so `base_url = ""` is passed to httpx — which raises `APIConnectionError: Connection error` before any network request is made.

## Root cause

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL")
if base_url is None:          # ← empty string is not None, falls through
    base_url = "https://api.openai.com/v1"
```

## Fix

Change `is None` → `not base_url` so both `None` and `""` fall back to the default:

```python
if not base_url:
    base_url = "https://api.openai.com/v1"
```

Applied to both `OpenAI.__init__` (line 214) and `AsyncOpenAI.__init__` (line 720).