### PR TITLE
docs: fix incorrect API call in Nested params README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,14 +475,14 @@ from openai import OpenAI
 
 client = OpenAI()
 
-response = client.chat.responses.create(
-    input=[
+response = client.chat.completions.create(
+    messages=[
         {
             "role": "user",
-            "content": "How much ?",
+            "content": "Can you generate an example json object describing a fruit?",
         }
     ],
-    model="gpt-5.2",
+    model="gpt-4o",
     response_format={"type": "json_object"},
 )
 ```


### PR DESCRIPTION
## Problem

The \"Nested params\" section in `README.md` references a non-existent API method `client.chat.responses.create` and mixes two incompatible API surfaces:

- `client.chat.responses` does not exist — `Chat` only exposes `completions` (see `src/openai/resources/chat/chat.py`)
- `input=[...]` is the Responses API parameter shape
- `response_format={"type": "json_object"}` is a Chat Completions parameter
- `gpt-5.2` is not a real model name

Running the snippet raises `AttributeError: 'Chat' object has no attribute 'responses'`.

## Fix

Switch to `client.chat.completions.create` with the correct `messages=` parameter name, a meaningful prompt, and a real model name (`gpt-4o`).

```diff
-response = client.chat.responses.create(
-    input=[
-        {
-            "role": "user",
-            "content": "How much ?",
-        }
-    ],
-    model="gpt-5.2",
-    response_format={"type": "json_object"},
-)
+response = client.chat.completions.create(
+    messages=[
+        {
+            "role": "user",
+            "content": "Can you generate an example json object describing a fruit?",
+        }
+    ],
+    model="gpt-4o",
+    response_format={"type": "json_object"},
+)
```

Fixes #3264