### PR TITLE
fix(azure): send JWT api_key values as Bearer token

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -352,6 +352,8 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
             return {"Authorization": f"Bearer {self._azure_ad_token}"}
 
         if self.api_key and self.api_key != API_KEY_SENTINEL:
+            if self.api_key.startswith("eyJ"):
+                return {"Authorization": f"Bearer {self.api_key}"}
             return {"api-key": self.api_key}
 
         return {}
@@ -377,7 +379,10 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
             if not _has_header(headers, "Authorization"):
                 headers["Authorization"] = f"Bearer {azure_ad_token}"
         elif self.api_key and self.api_key != API_KEY_SENTINEL:
-            if not _has_header(headers, "api-key"):
+            if self.api_key.startswith("eyJ"):
+                if not _has_header(headers, "Authorization"):
+                    headers["Authorization"] = f"Bearer {self.api_key}"
+            elif not _has_header(headers, "api-key"):
                 headers["api-key"] = self.api_key
         elif _has_auth_header(headers) or _has_auth_header(self.default_headers):
             pass
@@ -674,6 +679,8 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
             return {"Authorization": f"Bearer {self._azure_ad_token}"}
 
         if self.api_key and self.api_key != API_KEY_SENTINEL:
+            if self.api_key.startswith("eyJ"):
+                return {"Authorization": f"Bearer {self.api_key}"}
             return {"api-key": self.api_key}
 
         return {}
@@ -699,7 +706,10 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
             if not _has_header(headers, "Authorization"):
                 headers["Authorization"] = f"Bearer {azure_ad_token}"
         elif self.api_key and self.api_key != API_KEY_SENTINEL:
-            if not _has_header(headers, "api-key"):
+            if self.api_key.startswith("eyJ"):
+                if not _has_header(headers, "Authorization"):
+                    headers["Authorization"] = f"Bearer {self.api_key}"
+            elif not _has_header(headers, "api-key"):
                 headers["api-key"] = self.api_key
         elif _has_auth_header(headers) or _has_auth_header(self.default_headers):
             pass

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -140,6 +140,43 @@ def test_enforce_credentials_false_sync_uses_request_authorization_header(respx_
     assert calls[0].request.headers.get("api-key") is None
 
 
+@pytest.mark.respx()
+def test_jwt_api_key_sent_as_bearer_sync(respx_mock: MockRouter) -> None:
+    respx_mock.post(
+        "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions?api-version=2024-02-01"
+    ).mock(return_value=httpx.Response(200, json={"model": "gpt-4"}))
+
+    client = AzureOpenAI(
+        api_version="2024-02-01",
+        api_key="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    client.chat.completions.create(messages=[], model="gpt-4")
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert calls[0].request.headers.get("Authorization") == "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature"
+    assert calls[0].request.headers.get("api-key") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.respx()
+async def test_jwt_api_key_sent_as_bearer_async(respx_mock: MockRouter) -> None:
+    respx_mock.post(
+        "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions?api-version=2024-02-01"
+    ).mock(return_value=httpx.Response(200, json={"model": "gpt-4"}))
+
+    client = AsyncAzureOpenAI(
+        api_version="2024-02-01",
+        api_key="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    await client.chat.completions.create(messages=[], model="gpt-4")
+
+    calls = cast("list[MockRequestCall]", respx_mock.calls)
+    assert calls[0].request.headers.get("Authorization") == "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature"
+    assert calls[0].request.headers.get("api-key") is None
+
+
 def test_enforce_credentials_true_sync() -> None:
     with update_env(AZURE_OPENAI_API_KEY=Omit(), AZURE_OPENAI_AD_TOKEN=Omit()):
         with pytest.raises(OpenAIError, match="Missing credentials"):


### PR DESCRIPTION
When an Azure AD access token (JWT) is passed via `api_key=` to `AzureOpenAI`, the client now sends it as `Authorization: Bearer <token>` instead of `api-key: <token>`. The JWT is detected by checking whether the value starts with `"eyJ"` (the base64-encoded `{"` that begins every JWT header). This restores the behavior from v2.33.0 where such tokens worked correctly through Azure APIM/proxy setups that validate Bearer tokens. The same fix is applied to both `AzureOpenAI` and `AsyncAzureOpenAI`, in both `_auth_headers` and `_prepare_options`.

Fixes #3282