### PR TITLE
fix(responses): skip parsing incomplete output text

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -71,7 +71,11 @@ def parse_response(
                         type_=ParsedResponseOutputText[TextFormatT],
                         value={
                             **item.to_dict(),
-                            "parsed": parse_text(item.text, text_format=text_format),
+                            "parsed": (
+                                None
+                                if output.status == "incomplete"
+                                else parse_text(item.text, text_format=text_format)
+                            ),
                         },
                     )
                 )

--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -4,10 +4,13 @@ from typing_extensions import TypeVar
 
 import pytest
 from respx import MockRouter
+from pydantic import BaseModel
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +42,45 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_parse_incomplete_message_skips_text_parsing() -> None:
+    class Location(BaseModel):
+        city: str
+
+    response = Response.model_validate(
+        {
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "model": "gpt-4o-mini",
+            "output": [
+                {
+                    "id": "msg_123",
+                    "type": "message",
+                    "status": "incomplete",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "annotations": [],
+                            "text": '{"city": "San Francisco",',
+                        }
+                    ],
+                }
+            ],
+            "parallel_tool_calls": True,
+            "tool_choice": "auto",
+            "tools": [],
+        }
+    )
+
+    parsed = parse_response(text_format=Location, input_tools=[], response=response)
+
+    assert parsed.output[0].type == "message"
+    assert parsed.output[0].status == "incomplete"
+    assert parsed.output[0].content[0].type == "output_text"
+    assert parsed.output[0].content[0].parsed is None
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -83,6 +83,26 @@ def test_parse_incomplete_message_skips_text_parsing() -> None:
     assert parsed.output[0].content[0].parsed is None
 
 
+def test_parse_response_handles_null_output() -> None:
+    class Location(BaseModel):
+        city: str
+
+    response = Response.model_construct(
+        id="resp_123",
+        object="response",
+        created_at=0,
+        model="gpt-4o-mini",
+        output=None,
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    parsed = parse_response(text_format=Location, input_tools=[], response=response)
+
+    assert parsed.output == []
+
+
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 def test_stream_method_definition_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
     checking_client: OpenAI | AsyncOpenAI = client if sync else async_client


### PR DESCRIPTION
Fixes #2486.\n\nWhen a Responses API output message is marked incomplete, its output text may contain partial structured JSON. This skips text-format parsing for incomplete messages while preserving the output item, avoiding a validation error on partial content.\n\nTests:\n- uv run --with respx --with inline-snapshot --with pytest-asyncio --with time-machine --with dirty-equals pytest tests/lib/responses/test_responses.py -q -o addopts=""\n- uv run --with ruff ruff check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py