### PR TITLE
fix: add explicit encoding="utf-8" to .txt read in _validators.py

### DIFF
--- a/src/openai/lib/_validators.py
+++ b/src/openai/lib/_validators.py
@@ -482,7 +482,7 @@ def read_any_format(
             elif fname.lower().endswith(".txt"):
                 immediate_msg = "\n- Based on your file extension, you provided a text file"
                 necessary_msg = "Your format `TXT` will be converted to `JSONL`"
-                with open(fname, "r") as f:
+                with open(fname, "r", encoding="utf-8") as f:
                     content = f.read()
                     df = pd.DataFrame(
                         [["", line] for line in content.split("\n")],


### PR DESCRIPTION
### What

`src/openai/lib/_validators.py` reads a user-supplied `.txt` fine-tuning file in text mode without an explicit encoding:

```python
with open(fname, "r") as f:
    content = f.read()
```

In text mode, `open()` uses the platform default encoding (`locale.getpreferredencoding()`). On Windows that is typically **cp1252**, not UTF-8.

### Why it matters

`.txt` datasets frequently contain non-ASCII characters (smart quotes, accented text, CJK, emoji). On a default-cp1252 platform, reading a valid UTF-8 file raises `UnicodeDecodeError` or silently corrupts characters.

### Before / After

```python
# Before - platform-dependent
with open(fname, "r") as f:
# After - consistent across platforms
with open(fname, "r", encoding="utf-8") as f:
```

### How I verified

Reproduced the failure on a simulated cp1252 default: the explicit utf-8 read preserves content, while a cp1252 read of the same valid UTF-8 file raises `UnicodeDecodeError`. With `encoding="utf-8"` the read succeeds regardless of platform. No behavior change on systems that already default to UTF-8.

### Scope

Single-line change in `src/openai/lib/`, a hand-maintained (non-generated) path per CONTRIBUTING. Happy to adjust if you would prefer a different approach.