### PR TITLE
fix(helpers): use asyncio.get_running_loop() inside async methods

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -71,7 +71,7 @@ class LocalAudioPlayer:
         else:
             audio_content = await self._tts_response_to_buffer(input)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         idx = 0
 
@@ -105,7 +105,7 @@ class LocalAudioPlayer:
         self,
         buffer_stream: AsyncGenerator[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None], None],
     ) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         buffer_queue: queue.Queue[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None]] = queue.Queue(maxsize=50)
 

--- a/src/openai/helpers/microphone.py
+++ b/src/openai/helpers/microphone.py
@@ -54,7 +54,7 @@ class Microphone(Generic[DType]):
     async def record(self, return_ndarray: None = ...) -> FileTypes: ...
 
     async def record(self, return_ndarray: Union[bool, None] = False) -> Union[npt.NDArray[DType], FileTypes]:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         self.buffer_chunks: list[npt.NDArray[DType]] = []
         start_time = time.perf_counter()


### PR DESCRIPTION
### What

Three `async` methods in `src/openai/helpers/` call `asyncio.get_event_loop()` from inside a running coroutine:

- `LocalAudioPlayer.play` (`local_audio_player.py`)
- `LocalAudioPlayer.play_stream` (`local_audio_player.py`)
- `Microphone.record` (`microphone.py`)

### Why it matters

Since Python 3.10, calling `asyncio.get_event_loop()` when there is no current event loop is deprecated, and calling it from within a coroutine to obtain the running loop emits a `DeprecationWarning`. The documented replacement for code that runs inside a coroutine is `asyncio.get_running_loop()`.

### Fix

```python
# Before
loop = asyncio.get_event_loop()
# After
loop = asyncio.get_running_loop()
```

In all three cases the loop is obtained inside an `async def` and only used for `run_in_executor` / `call_soon_threadsafe`, so there is always a running loop and behavior is unchanged. This just removes the deprecation and makes the intent explicit.

### Scope

Three one-line changes in `src/openai/helpers/` (a hand-maintained, non-generated path). Files still parse and import. Happy to adjust if you would prefer a different approach.