### PR TITLE
fix ActionSearchSource to accept type='api' and optional fields

### DIFF
--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -19,11 +19,14 @@ __all__ = [
 class ActionSearchSource(BaseModel):
     """A source used in the search."""
 
-    type: Literal["url"]
-    """The type of source. Always `url`."""
+    type: Literal["url", "api"]
+    """The type of source. `url` for a web page, `api` for a built-in OpenAI data source."""
 
-    url: str
-    """The URL of the source."""
+    url: Optional[str] = None
+    """The URL of the source. Present when type is `url`."""
+
+    name: Optional[str] = None
+    """The name of the built-in data source (e.g. `oai-weather`). Present when type is `api`."""
 
 
 class ActionSearch(BaseModel):


### PR DESCRIPTION
The API returns `type='api'` for built-in OpenAI data sources (e.g. `oai-weather`, `oai-sports`, `oai-finance`). The current type only declares `Literal["url"]`, causing a Pydantic validation error on any response that includes these sources.

- Add `"api"` to the `type` literal
- Make `url` optional (absent when `type` is `"api"`)
- Add optional `name` field for the data source identifier

Fixes #2736