### PR TITLE
fix: allow api web search sources

### DIFF
--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -19,11 +19,14 @@ __all__ = [
 class ActionSearchSource(BaseModel):
     """A source used in the search."""
 
-    type: Literal["url"]
-    """The type of source. Always `url`."""
+    type: Literal["url", "api"]
+    """The type of source. One of `url` or `api`."""
 
-    url: str
-    """The URL of the source."""
+    name: Optional[str] = None
+    """The source name, used for non-URL providers such as internal APIs."""
+
+    url: Optional[str] = None
+    """The URL of the source when the source type is `url`."""
 
 
 class ActionSearch(BaseModel):

--- a/src/openai/types/responses/response_function_web_search_param.py
+++ b/src/openai/types/responses/response_function_web_search_param.py
@@ -20,11 +20,14 @@ __all__ = [
 class ActionSearchSource(TypedDict, total=False):
     """A source used in the search."""
 
-    type: Required[Literal["url"]]
-    """The type of source. Always `url`."""
+    type: Required[Literal["url", "api"]]
+    """The type of source. One of `url` or `api`."""
 
-    url: Required[str]
-    """The URL of the source."""
+    name: str
+    """The source name, used for non-URL providers such as internal APIs."""
+
+    url: str
+    """The URL of the source when the source type is `url`."""
 
 
 class ActionSearch(TypedDict, total=False):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from openai._utils import PropertyInfo
 from openai._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
 from openai._models import DISCRIMINATOR_CACHE, BaseModel, construct_type
+from openai.types.responses.response_function_web_search import ActionSearchSource as ResponseActionSearchSource
 
 
 class BasicModel(BaseModel):
@@ -961,3 +962,11 @@ def test_extra_properties() -> None:
     assert model.a.prop == 1
     assert isinstance(model.a, Item)
     assert model.other == "foo"
+
+
+def test_response_function_web_search_source_allows_api_sources() -> None:
+    source = parse_obj(ResponseActionSearchSource, {"type": "api", "name": "oai-weather"})
+
+    assert source.type == "api"
+    assert source.name == "oai-weather"
+    assert source.url is None


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #2636

- allow `ActionSearchSource.type` to be either `"url"` or `"api"`
- allow API-backed sources to carry a `name` while keeping `url` optional for non-URL sources
- add a regression test that parses an `api` source successfully

## Additional context & links

- issue: #2636
- docs reference: https://platform.openai.com/docs/api-reference/responses/object#responses/object-output-web-search-tool-call-action-search-action-sources-type