### PR TITLE
fix(azure): promote x-ms-served-model header into Response.model for Responses API

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import os
 import inspect
-from typing import Any, Union, Mapping, TypeVar, Callable, Awaitable, cast, overload
+from typing import Any, Type, Union, Mapping, TypeVar, Callable, Awaitable, cast, overload
 from typing_extensions import Self, override
 
 import httpx
 
 from ..auth import WorkloadIdentity
-from .._types import NOT_GIVEN, Omit, Query, Headers, Timeout, NotGiven
+from .._types import NOT_GIVEN, Omit, Query, Headers, Timeout, NotGiven, ResponseT
 from .._utils import is_given, is_mapping
 from .._client import OpenAI, AsyncOpenAI
 from .._compat import model_copy
@@ -412,6 +412,44 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
         url = realtime_url.copy_with(params={**query})
         return url, auth_headers
 
+    @override
+    def _process_response(
+        self,
+        *,
+        cast_to: Type[ResponseT],
+        options: FinalRequestOptions,
+        response: httpx.Response,
+        stream: bool,
+        stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retries_taken: int = 0,
+    ) -> ResponseT:
+        result = super()._process_response(
+            cast_to=cast_to,
+            options=options,
+            response=response,
+            stream=stream,
+            stream_cls=stream_cls,
+            retries_taken=retries_taken,
+        )
+        if options.url.startswith("/responses"):
+            served_model = response.headers.get("x-ms-served-model", "").strip()
+            if served_model:
+                from ..types.responses.response import Response as _ResponseType
+
+                if not stream and isinstance(result, _ResponseType):
+                    result.model = served_model
+                elif stream and isinstance(result, Stream):
+                    _orig_iter = result._iterator
+
+                    def _patched_iter(orig: Any = _orig_iter, model: str = served_model):  # type: ignore[return]
+                        for event in orig:
+                            if hasattr(event, "response") and isinstance(event.response, _ResponseType):
+                                event.response.model = model
+                            yield event
+
+                    result._iterator = _patched_iter()
+        return result
+
 
 class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], AsyncOpenAI):
     @overload
@@ -733,3 +771,41 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
 
         url = realtime_url.copy_with(params={**query})
         return url, auth_headers
+
+    @override
+    async def _process_response(
+        self,
+        *,
+        cast_to: Type[ResponseT],
+        options: FinalRequestOptions,
+        response: httpx.Response,
+        stream: bool,
+        stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retries_taken: int = 0,
+    ) -> ResponseT:
+        result = await super()._process_response(
+            cast_to=cast_to,
+            options=options,
+            response=response,
+            stream=stream,
+            stream_cls=stream_cls,
+            retries_taken=retries_taken,
+        )
+        if options.url.startswith("/responses"):
+            served_model = response.headers.get("x-ms-served-model", "").strip()
+            if served_model:
+                from ..types.responses.response import Response as _ResponseType
+
+                if not stream and isinstance(result, _ResponseType):
+                    result.model = served_model
+                elif stream and isinstance(result, AsyncStream):
+                    _orig_iter = result._iterator
+
+                    async def _patched_iter(orig: Any = _orig_iter, model: str = served_model):  # type: ignore[return]
+                        async for event in orig:
+                            if hasattr(event, "response") and isinstance(event.response, _ResponseType):
+                                event.response.model = model
+                            yield event
+
+                    result._iterator = _patched_iter()
+        return result

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -14,6 +14,7 @@ from openai._types import Omit
 from openai._utils import SensitiveHeadersFilter, is_dict
 from openai._models import FinalRequestOptions
 from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI
+from openai.types.responses.response import Response as _OAIResponse
 
 Client = Union[AzureOpenAI, AsyncAzureOpenAI]
 
@@ -953,3 +954,126 @@ def test_client_sets_base_url(client: Client) -> None:
         )
     )
     assert req.url == "https://example-resource.azure.openai.com/openai/models?api-version=2024-02-01"
+
+
+# ---------------------------------------------------------------------------
+# Tests for x-ms-served-model header promotion into Response.model (#3271)
+# ---------------------------------------------------------------------------
+
+_MINIMAL_RESPONSE_JSON = {
+    "id": "resp_test001",
+    "created_at": 1700000000.0,
+    "model": "gpt-4o",
+    "object": "response",
+    "output": [],
+    "parallel_tool_calls": False,
+    "tool_choice": "auto",
+    "tools": [],
+}
+
+_RESPONSES_URL = "https://example-resource.azure.openai.com/openai/responses?api-version=2024-02-01"
+
+
+def _make_response(status: int = 200, headers: dict | None = None) -> httpx.Response:
+    req = httpx.Request("POST", _RESPONSES_URL)
+    resp = httpx.Response(status, json=_MINIMAL_RESPONSE_JSON, headers=headers or {})
+    resp.request = req
+    return resp
+
+
+def _make_response_for_url(url: str, headers: dict | None = None) -> httpx.Response:
+    req = httpx.Request("POST", url)
+    resp = httpx.Response(200, json=_MINIMAL_RESPONSE_JSON, headers=headers or {})
+    resp.request = req
+    return resp
+
+
+def test_azure_responses_x_ms_served_model_promoted() -> None:
+    """x-ms-served-model header is promoted into Response.model for non-streaming calls."""
+    client = AzureOpenAI(
+        api_version="2024-02-01",
+        api_key="test-key",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    result = client._process_response(
+        cast_to=_OAIResponse,
+        options=FinalRequestOptions.construct(method="post", url="/responses"),
+        response=_make_response(headers={"x-ms-served-model": "gpt-4o-2024-11-20"}),
+        stream=False,
+        stream_cls=None,
+    )
+    assert isinstance(result, _OAIResponse)
+    assert result.model == "gpt-4o-2024-11-20"
+
+
+def test_azure_responses_x_ms_served_model_absent() -> None:
+    """Without x-ms-served-model, Response.model is unchanged."""
+    client = AzureOpenAI(
+        api_version="2024-02-01",
+        api_key="test-key",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    result = client._process_response(
+        cast_to=_OAIResponse,
+        options=FinalRequestOptions.construct(method="post", url="/responses"),
+        response=_make_response(),
+        stream=False,
+        stream_cls=None,
+    )
+    assert isinstance(result, _OAIResponse)
+    assert result.model == "gpt-4o"
+
+
+def test_azure_non_responses_endpoint_not_affected() -> None:
+    """x-ms-served-model on a non-/responses URL should not be promoted."""
+    client = AzureOpenAI(
+        api_version="2024-02-01",
+        api_key="test-key",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    chat_url = "https://example-resource.azure.openai.com/openai/deployments/gpt-4/chat/completions"
+    result = client._process_response(
+        cast_to=_OAIResponse,
+        options=FinalRequestOptions.construct(method="post", url="/deployments/gpt-4/chat/completions"),
+        response=_make_response_for_url(chat_url, headers={"x-ms-served-model": "should-be-ignored"}),
+        stream=False,
+        stream_cls=None,
+    )
+    assert isinstance(result, _OAIResponse)
+    assert result.model == "gpt-4o"
+
+
+async def test_async_azure_responses_x_ms_served_model_promoted() -> None:
+    """Async client: x-ms-served-model is promoted into Response.model."""
+    client = AsyncAzureOpenAI(
+        api_version="2024-02-01",
+        api_key="test-key",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    result = await client._process_response(
+        cast_to=_OAIResponse,
+        options=FinalRequestOptions.construct(method="post", url="/responses"),
+        response=_make_response(headers={"x-ms-served-model": "gpt-4o-2024-11-20"}),
+        stream=False,
+        stream_cls=None,
+    )
+    assert isinstance(result, _OAIResponse)
+    assert result.model == "gpt-4o-2024-11-20"
+
+
+async def test_async_azure_responses_x_ms_served_model_absent() -> None:
+    """Async client: without header, Response.model is unchanged."""
+    client = AsyncAzureOpenAI(
+        api_version="2024-02-01",
+        api_key="test-key",
+        azure_endpoint="https://example-resource.azure.openai.com",
+    )
+    result = await client._process_response(
+        cast_to=_OAIResponse,
+        options=FinalRequestOptions.construct(method="post", url="/responses"),
+        response=_make_response(),
+        stream=False,
+        stream_cls=None,
+    )
+    assert isinstance(result, _OAIResponse)
+    assert result.model == "gpt-4o"


### PR DESCRIPTION
## Summary

- Adds `_process_response` overrides to both `AzureOpenAI` and `AsyncAzureOpenAI` that promote the `x-ms-served-model` response header into `Response.model` for Responses API calls.
- Mirrors the existing behaviour for Chat Completions (where Azure already rewrites `model` from the header) so callers can see the actually-deployed model name rather than the logical alias.
- Zero impact on non-`/responses` paths and on responses that lack the header.

## Issue

Fixes #3271 — when using `AzureOpenAI.responses.create(...)` the returned `Response.model` reflects the *requested* model alias (e.g. `"gpt-4o"`) rather than the precise deployment actually served (e.g. `"gpt-4o-2024-11-20"`). Azure surfaces the real model name in the `x-ms-served-model` HTTP response header; this PR reads that header and writes it back into `Response.model`.

## Changes

**`src/openai/lib/azure.py`**

- Added `Type` to the `typing` imports.
- Imported `ResponseT` from `.._types`.
- Added `AzureOpenAI._process_response` (sync): calls `super()`, then if the URL starts with `/responses` and `x-ms-served-model` is non-empty, patches `result.model` (non-streaming) or wraps `stream._iterator` to patch `event.response.model` for every event that carries a `response: Response` field (streaming).
- Added `AsyncAzureOpenAI._process_response` (async): identical logic using `await super()` and an async generator.

**`tests/lib/test_azure.py`**

- Added import for `openai.types.responses.response.Response`.
- Added five focused unit tests covering: header promoted (sync), header absent (sync), non-`/responses` endpoint not affected, header promoted (async), header absent (async).

## Local verification

```
=== LOCAL_TEST_PASSED ===
$ python -m pytest tests/lib/test_azure.py -v
...
collected 64 items

tests/lib/test_azure.py::test_implicit_deployment_path[client0] PASSED
tests/lib/test_azure.py::test_implicit_deployment_path[client1] PASSED
tests/lib/test_azure.py::test_client_copying[sync_client-copy] PASSED
tests/lib/test_azure.py::test_client_copying[sync_client-with_options] PASSED
tests/lib/test_azure.py::test_client_copying[async_client-copy] PASSED
tests/lib/test_azure.py::test_client_copying[async_client-with_options] PASSED
...
tests/lib/test_azure.py::test_azure_responses_x_ms_served_model_promoted PASSED
tests/lib/test_azure.py::test_azure_responses_x_ms_served_model_absent PASSED
tests/lib/test_azure.py::test_azure_non_responses_endpoint_not_affected PASSED
tests/lib/test_azure.py::test_async_azure_responses_x_ms_served_model_promoted PASSED
tests/lib/test_azure.py::test_async_azure_responses_x_ms_served_model_absent PASSED
...
64 passed in 3.44s
=== LOCAL_TEST_PASSED ===
```

## Risk

**Low.** The override only activates when:
1. The URL path starts with `/responses` (exact SDK-generated path for the Responses resource), AND
2. The `x-ms-served-model` header is present and non-empty.

All other paths and clients are untouched. `Response` uses a mutable Pydantic `BaseModel` (`extra="allow"`), so field assignment is safe. The streaming wrapper is a thin generator replacement on `_iterator`; it does not touch transport or parsing.
