### PR TITLE
fix: preserve query params in realtime websocket URLs

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -399,9 +399,18 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
             )
 
     def _enforce_trailing_slash(self, url: URL) -> URL:
-        if url.raw_path.endswith(b"/"):
+        raw_path = url.raw_path
+        if url.query:
+            raw_path = raw_path[: -(len(url.query) + 1)]
+
+        if raw_path.endswith(b"/"):
             return url
-        return url.copy_with(raw_path=url.raw_path + b"/")
+
+        raw_path += b"/"
+        if url.query:
+            raw_path += b"?" + url.query
+
+        return url.copy_with(raw_path=raw_path)
 
     def _make_status_error_from_response(
         self,

--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -399,8 +399,8 @@ class AsyncRealtimeConnectionManager:
         else:
             base_url = self.__client._base_url.copy_with(scheme="wss")
 
-        merge_raw_path = base_url.raw_path.rstrip(b"/") + b"/realtime"
-        return base_url.copy_with(raw_path=merge_raw_path)
+        path = base_url.path.rstrip("/") + "/realtime"
+        return base_url.copy_with(path=path)
 
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc: BaseException | None, exc_tb: TracebackType | None
@@ -582,8 +582,8 @@ class RealtimeConnectionManager:
         else:
             base_url = self.__client._base_url.copy_with(scheme="wss")
 
-        merge_raw_path = base_url.raw_path.rstrip(b"/") + b"/realtime"
-        return base_url.copy_with(raw_path=merge_raw_path)
+        path = base_url.path.rstrip("/") + "/realtime"
+        return base_url.copy_with(path=path)
 
     def __exit__(
         self, exc_type: type[BaseException] | None, exc: BaseException | None, exc_tb: TracebackType | None

--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -410,8 +410,8 @@ class AsyncRealtimeConnectionManager:
         else:
             base_url = self.__client._base_url.copy_with(scheme="wss")
 
-        merge_raw_path = base_url.raw_path.rstrip(b"/") + b"/realtime"
-        return base_url.copy_with(raw_path=merge_raw_path)
+        path = base_url.path.rstrip("/") + "/realtime"
+        return base_url.copy_with(path=path)
 
     async def __aexit__(
         self, exc_type: type[BaseException] | None, exc: BaseException | None, exc_tb: TracebackType | None
@@ -599,8 +599,8 @@ class RealtimeConnectionManager:
         else:
             base_url = self.__client._base_url.copy_with(scheme="wss")
 
-        merge_raw_path = base_url.raw_path.rstrip(b"/") + b"/realtime"
-        return base_url.copy_with(raw_path=merge_raw_path)
+        path = base_url.path.rstrip("/") + "/realtime"
+        return base_url.copy_with(path=path)
 
     def __exit__(
         self, exc_type: type[BaseException] | None, exc: BaseException | None, exc_tb: TracebackType | None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -696,6 +696,27 @@ class TestOpenAI:
             client = OpenAI(api_key=api_key, _strict_response_validation=True)
             assert client.base_url == "http://localhost:5000/from/env/"
 
+    def test_realtime_url_preserves_http_query_param(self) -> None:
+        client = OpenAI(
+            base_url="https://proxy.com/forward?target=http://backend.internal/v1",
+            api_key=api_key,
+            _strict_response_validation=True,
+        )
+        assert client.base_url == "https://proxy.com/forward/?target=http://backend.internal/v1"
+
+        url = (
+            client.realtime.connect(model="gpt-realtime")
+            ._prepare_url()
+            .copy_with(
+                params={**client.base_url.params, "model": "gpt-realtime"},
+            )
+        )
+
+        assert str(url) == (
+            "wss://proxy.com/forward/realtime?target=http%3A%2F%2Fbackend.internal%2Fv1&model=gpt-realtime"
+        )
+        client.close()
+
     @pytest.mark.parametrize(
         "client",
         [


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3294.

Preserve query strings when normalizing `base_url` with a trailing slash and when deriving Realtime WebSocket URLs, so query parameter values containing `http://` are not moved into the path or rewritten as part of the `wss://` URL construction.

## Additional context & links

Validation:
- `ruff check src/openai/_base_client.py src/openai/resources/realtime/realtime.py src/openai/resources/beta/realtime/realtime.py tests/test_client.py`
- `ruff format --check src/openai/_base_client.py src/openai/resources/realtime/realtime.py src/openai/resources/beta/realtime/realtime.py tests/test_client.py`
- `pytest -o addopts='' tests/test_client.py`
