### PR TITLE
ci: switch PyPI publish workflow to Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,6 +9,9 @@ jobs:
     name: publish
     runs-on: ubuntu-latest
     environment: publish
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -19,8 +22,10 @@ jobs:
           version: '0.44.0'
           enable-cache: true
 
-      - name: Publish to PyPI
+      - name: Build distributions
         run: |
-          bash ./bin/publish-pypi
-        env:
-          PYPI_TOKEN: ${{ secrets.OPENAI_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+          mkdir -p dist
+          rye build --clean
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #3273.

Replace the rye PYPI_TOKEN environment variable with the pypa/gh-action-pypi-publish action and id-token: write permissions, so the workflow uploads via PyPI Trusted Publishing rather than a long-lived token. Other steps in publish-pypi.yml are unchanged.

After merge, the PyPI project will need a Trusted Publisher binding pointing at openai/openai-python and the publish-pypi.yml workflow name; happy to leave the action shape alone if maintainers prefer to set that up first.