### PR TITLE
chore(azure): use API_KEY_SENTINEL constant in _configure_realtime

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -394,7 +394,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
             "api-version": self._api_version,
             "deployment": self._azure_deployment or model,
         }
-        if self.api_key and self.api_key != "<missing API key>":
+        if self.api_key and self.api_key != API_KEY_SENTINEL:
             auth_headers = {"api-key": self.api_key}
         else:
             token = self._get_azure_ad_token()
@@ -716,7 +716,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
             "api-version": self._api_version,
             "deployment": self._azure_deployment or model,
         }
-        if self.api_key and self.api_key != "<missing API key>":
+        if self.api_key and self.api_key != API_KEY_SENTINEL:
             auth_headers = {"api-key": self.api_key}
         else:
             token = await self._get_azure_ad_token()


### PR DESCRIPTION
Both _configure_realtime methods in src/openai/lib/azure.py compare self.api_key to the literal "<missing API key>" to decide whether to send an api-key header or fall back to an Azure AD token. The rest of this module guards the same branch with the named API_KEY_SENTINEL constant.

The values are identical at runtime, so this is a pure cleanup with no behavior change. It just removes two duplicates of the sentinel string that would silently drift if API_KEY_SENTINEL ever changed.

This is a hand-written file, so the change should survive Stainless regeneration. The existing tests in tests/lib/test_azure.py pass unchanged.