### PR TITLE
fix(examples): correct Azure endpoint hostname

### DIFF
--- a/examples/azure.py
+++ b/examples/azure.py
@@ -26,7 +26,7 @@ print(completion.to_json())
 deployment_client = AzureOpenAI(
     api_version=api_version,
     # https://learn.microsoft.com/en-us/azure/cognitive-services/openai/how-to/create-resource?pivots=web-portal#create-a-resource
-    azure_endpoint="https://example-resource.azure.openai.com/",
+    azure_endpoint="https://example-resource.openai.azure.com/",
     # Navigate to the Azure OpenAI Studio to deploy a model.
     azure_deployment="deployment-name",  # e.g. gpt-35-instant
 )


### PR DESCRIPTION
Correct the deployment-client endpoint in `examples/azure.py` from `example-resource.azure.openai.com` to `example-resource.openai.azure.com`, matching the first example and [Microsoft's documented endpoint format](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints#azure-openai-endpoints).