### PR TITLE
fix: use running loop in audio helpers

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -71,7 +71,7 @@ class LocalAudioPlayer:
         else:
             audio_content = await self._tts_response_to_buffer(input)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         idx = 0
 
@@ -105,7 +105,7 @@ class LocalAudioPlayer:
         self,
         buffer_stream: AsyncGenerator[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None], None],
     ) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         buffer_queue: queue.Queue[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None]] = queue.Queue(maxsize=50)
 

--- a/src/openai/helpers/microphone.py
+++ b/src/openai/helpers/microphone.py
@@ -54,7 +54,7 @@ class Microphone(Generic[DType]):
     async def record(self, return_ndarray: None = ...) -> FileTypes: ...
 
     async def record(self, return_ndarray: Union[bool, None] = False) -> Union[npt.NDArray[DType], FileTypes]:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         self.buffer_chunks: list[npt.NDArray[DType]] = []
         start_time = time.perf_counter()


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in audio helper async methods
- Keep the callback/executor loop reference tied to the active running loop

## Problem
The audio helper methods are already async methods, but they currently call `asyncio.get_event_loop()` before using the loop for thread-safe callback notifications and executor work. `get_event_loop()` has legacy behavior in modern Python when no loop is set by policy; inside async code, `get_running_loop()` is the clearer and more precise API.

## Before / After
Before, the helpers asked asyncio for the policy/current loop with `get_event_loop()`.

After, they capture the loop that is actively running the coroutine with `get_running_loop()`.

## Verification
- `python -m compileall -q src\openai\helpers\local_audio_player.py src\openai\helpers\microphone.py`
- `git diff --check`