### PR TITLE
fix: read workload token as utf-8

### DIFF
--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -54,7 +54,7 @@ def k8s_service_account_token_provider(
 
     def get_token() -> str:
         try:
-            with open(token_file_path, "r") as f:
+            with open(token_file_path, "r", encoding="utf-8") as f:
                 token = f.read().strip()
                 if not token:
                     raise SubjectTokenProviderError(f"The token file at {token_file_path} is empty.")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -154,7 +154,7 @@ def test_workload_identity_exchange_error() -> None:
 
 def test_k8s_service_account_token_provider(tmp_path: Path) -> None:
     token_file = tmp_path / "token"
-    token_file.write_text("my-k8s-token")
+    token_file.write_text("my-k8s-token", encoding="utf-8")
 
     provider = k8s_service_account_token_provider(token_file)
 


### PR DESCRIPTION
## Summary
- read the Kubernetes workload identity subject token file with explicit UTF-8 encoding
- update the matching test fixture write to use the same encoding

## Before / after
Before, `k8s_service_account_token_provider()` used the platform default text encoding when reading the mounted token file.
After, it reads the token as UTF-8 explicitly, matching the text-file behavior expected by the test.

## Verification
- `python -m py_compile src/openai/auth/_workload.py tests/test_auth.py`
- `git diff --check`
