### PR TITLE
fix: sanitize NO_PROXY env vars containing newline characters

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import json
 import time
@@ -831,11 +832,19 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+def _sanitize_proxy_env_vars() -> None:
+    for key in ("NO_PROXY", "no_proxy"):
+        val = os.environ.get(key)
+        if val and "\n" in val:
+            os.environ[key] = ",".join(part.strip() for part in val.replace("\n", ",").split(",") if part.strip())
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        _sanitize_proxy_env_vars()
         super().__init__(**kwargs)
 
 
@@ -1423,6 +1432,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        _sanitize_proxy_env_vars()
         super().__init__(**kwargs)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1292,6 +1292,18 @@ class TestOpenAI:
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
 
+    def test_no_proxy_with_newlines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost\n127.0.0.1\n")
+        monkeypatch.delenv("no_proxy", raising=False)
+        client = DefaultHttpxClient()
+        assert client is not None
+
+    def test_no_proxy_lowercase_with_newlines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("no_proxy", "localhost\n127.0.0.1\n")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        client = DefaultHttpxClient()
+        assert client is not None
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions
@@ -2551,6 +2563,18 @@ class TestAsyncOpenAI:
         mounts = tuple(client._mounts.items())
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
+
+    async def test_no_proxy_with_newlines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost\n127.0.0.1\n")
+        monkeypatch.delenv("no_proxy", raising=False)
+        client = DefaultAsyncHttpxClient()
+        assert client is not None
+
+    async def test_no_proxy_lowercase_with_newlines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("no_proxy", "localhost\n127.0.0.1\n")
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        client = DefaultAsyncHttpxClient()
+        assert client is not None
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:


### PR DESCRIPTION
When `NO_PROXY` or `no_proxy` contains newline characters (common in Docker and `.env` files), httpx fails with `InvalidURL` because it doesn't split on newlines when parsing the env var.

This adds a `_sanitize_proxy_env_vars()` helper that normalizes newlines to commas before the httpx client is instantiated in `_DefaultHttpxClient` and `_DefaultAsyncHttpxClient`. Tests cover both uppercase and lowercase variants.

Fixes #3303