### PR TITLE
fix: sanitize NO_PROXY newlines

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import sys
 import json
 import time
@@ -817,17 +816,53 @@ def _sanitize_no_proxy(value: str) -> str:
     return ",".join(part.strip() for part in value.replace("\r", ",").replace("\n", ",").split(",") if part.strip())
 
 
+def _get_sanitized_environment_proxies() -> dict[str, str | None]:
+    from urllib.request import getproxies
+
+    from httpx._utils import is_ipv4_hostname, is_ipv6_hostname  # pyright: ignore[reportPrivateImportUsage]
+
+    proxy_info = getproxies()
+    mounts: dict[str, str | None] = {}
+
+    for scheme in ("http", "https", "all"):
+        if proxy_info.get(scheme):
+            hostname = proxy_info[scheme]
+            mounts[f"{scheme}://"] = hostname if "://" in hostname else f"http://{hostname}"
+
+    no_proxy_hosts = [host.strip() for host in _sanitize_no_proxy(proxy_info.get("no", "")).split(",")]
+    for hostname in no_proxy_hosts:
+        if hostname == "*":
+            return {}
+        elif hostname:
+            if "://" in hostname:
+                mounts[hostname] = None
+            elif is_ipv4_hostname(hostname):
+                mounts[f"all://{hostname}"] = None
+            elif is_ipv6_hostname(hostname):
+                mounts[f"all://[{hostname}]"] = None
+            elif hostname.lower() == "localhost":
+                mounts[f"all://{hostname}"] = None
+            else:
+                mounts[f"all://*{hostname}"] = None
+
+    return mounts
+
+
 class _DefaultHttpxClient(httpx.Client):
+    @override
+    def _get_proxy_map(self, proxy: Any | None, allow_env_proxies: bool) -> dict[str, httpx.Proxy | None]:
+        if proxy is None and allow_env_proxies:
+            return {
+                key: None if url is None else httpx.Proxy(url=url)
+                for key, url in _get_sanitized_environment_proxies().items()
+            }
+
+        return super()._get_proxy_map(proxy, allow_env_proxies)
+
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-
-        if kwargs.get("trust_env", True):
-            for key in ("NO_PROXY", "no_proxy"):
-                value = os.environ.get(key)
-                if value is not None:
-                    os.environ[key] = _sanitize_no_proxy(value)
 
         super().__init__(**kwargs)
 
@@ -1399,16 +1434,20 @@ class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
 
 
 class _DefaultAsyncHttpxClient(httpx.AsyncClient):
+    @override
+    def _get_proxy_map(self, proxy: Any | None, allow_env_proxies: bool) -> dict[str, httpx.Proxy | None]:
+        if proxy is None and allow_env_proxies:
+            return {
+                key: None if url is None else httpx.Proxy(url=url)
+                for key, url in _get_sanitized_environment_proxies().items()
+            }
+
+        return super()._get_proxy_map(proxy, allow_env_proxies)
+
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-
-        if kwargs.get("trust_env", True):
-            for key in ("NO_PROXY", "no_proxy"):
-                value = os.environ.get(key)
-                if value is not None:
-                    os.environ[key] = _sanitize_no_proxy(value)
 
         super().__init__(**kwargs)
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import json
 import time
@@ -809,11 +810,25 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+def _sanitize_no_proxy(value: str) -> str:
+    if "\n" not in value and "\r" not in value:
+        return value
+
+    return ",".join(part.strip() for part in value.replace("\r", ",").replace("\n", ",").split(",") if part.strip())
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+
+        if kwargs.get("trust_env", True):
+            for key in ("NO_PROXY", "no_proxy"):
+                value = os.environ.get(key)
+                if value is not None:
+                    os.environ[key] = _sanitize_no_proxy(value)
+
         super().__init__(**kwargs)
 
 
@@ -1388,6 +1403,13 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+
+        if kwargs.get("trust_env", True):
+            for key in ("NO_PROXY", "no_proxy"):
+                value = os.environ.get(key)
+                if value is not None:
+                    os.environ[key] = _sanitize_no_proxy(value)
+
         super().__init__(**kwargs)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1043,6 +1043,14 @@ class TestOpenAI:
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
 
+    def test_no_proxy_environment_variable_with_newlines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+
+        client = DefaultHttpxClient()
+
+        patterns = {mount.pattern for mount in client._mounts}
+        assert patterns == {"all://localhost", "all://192.168.1.1"}
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions
@@ -2085,6 +2093,14 @@ class TestAsyncOpenAI:
         mounts = tuple(client._mounts.items())
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
+
+    async def test_no_proxy_environment_variable_with_newlines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+
+        client = DefaultAsyncHttpxClient()
+
+        patterns = {mount.pattern for mount in client._mounts}
+        assert patterns == {"all://localhost", "all://192.168.1.1"}
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1050,6 +1050,7 @@ class TestOpenAI:
 
         patterns = {mount.pattern for mount in client._mounts}
         assert patterns == {"all://localhost", "all://192.168.1.1"}
+        assert os.environ["NO_PROXY"] == "localhost\n192.168.1.1"
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
@@ -2101,6 +2102,7 @@ class TestAsyncOpenAI:
 
         patterns = {mount.pattern for mount in client._mounts}
         assert patterns == {"all://localhost", "all://192.168.1.1"}
+        assert os.environ["NO_PROXY"] == "localhost\n192.168.1.1"
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Sanitize newline and carriage-return separators in NO_PROXY/no_proxy before constructing the SDK's default httpx clients, so Docker/.env-style multiline NO_PROXY values do not raise httpx.InvalidURL.

Fixes #3303

## Additional context & links

Tests run:

- uv run pytest -o addopts='' tests/test_client.py -k 'no_proxy_environment_variable_with_newlines or proxy_environment_variables'
- uv run ruff check src/openai/_base_client.py tests/test_client.py
- uv run pytest -o addopts='' tests/test_client.py