### PR TITLE
fix: read validator text files as utf-8

### DIFF
--- a/src/openai/lib/_validators.py
+++ b/src/openai/lib/_validators.py
@@ -482,7 +482,7 @@ def read_any_format(
             elif fname.lower().endswith(".txt"):
                 immediate_msg = "\n- Based on your file extension, you provided a text file"
                 necessary_msg = "Your format `TXT` will be converted to `JSONL`"
-                with open(fname, "r") as f:
+                with open(fname, "r", encoding="utf-8") as f:
                     content = f.read()
                     df = pd.DataFrame(
                         [["", line] for line in content.split("\n")],


### PR DESCRIPTION
## Summary
- read `.txt` files in the fine-tuning data validator with explicit UTF-8 encoding

## Before / after
Before, the `.txt` conversion path used the platform default text encoding when reading user-provided text files.
After, it reads text files as UTF-8 explicitly, matching the validator's JSONL/CSV-style text data expectations and avoiding locale-dependent behavior.

## Verification
- `python -m py_compile src/openai/lib/_validators.py`
- `git diff --check`
