### PR TITLE
fix: merge duplicate logical indexes in accumulate_delta list entries

### DIFF
--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -3,10 +3,60 @@ from __future__ import annotations
 from ..._utils import is_dict, is_list
 
 
+def _accumulate_list(
+    acc_list: list[object],
+    delta_list: list[object],
+    acc: dict[object, object],
+    delta: dict[object, object],
+) -> list[object]:
+    """Merge *delta_list* into *acc_list* using the logical ``index`` field.
+
+    Each entry in a tool-call (or similar) list carries an ``"index"`` key that
+    identifies which *logical* object it belongs to.  Physical list position must
+    **not** be used as the key because a single streaming chunk may contain
+    multiple entries that share the same logical index (e.g. the first chunk may
+    emit both the tool-call header *and* the first argument fragment for
+    ``index=0`` in the same delta).  Using the logical index prevents those
+    entries from being stored as separate physical slots and later causing
+    argument accumulation to target the wrong slot.
+    """
+    for delta_entry in delta_list:
+        if not is_dict(delta_entry):
+            raise TypeError(f"Unexpected list delta entry is not a dictionary: {delta_entry}")
+
+        try:
+            index = delta_entry["index"]  # type: ignore[index]
+        except KeyError as exc:
+            raise RuntimeError(f"Expected list delta entry to have an `index` key; {delta_entry}") from exc
+
+        if not isinstance(index, int):
+            raise TypeError(f"Unexpected, list delta entry `index` value is not an integer; {index}")
+
+        # Search for an existing entry with this logical index.
+        found = False
+        for i, existing in enumerate(acc_list):
+            if is_dict(existing) and existing.get("index") == index:  # type: ignore[union-attr]
+                acc_list[i] = accumulate_delta(existing, delta_entry)  # type: ignore[arg-type]
+                found = True
+                break
+
+        if not found:
+            acc_list.append(delta_entry)
+
+    return acc_list
+
+
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
-            acc[key] = delta_value
+            # When a list is encountered for the first time, run it through the
+            # same index-based merge so that duplicate logical indexes within a
+            # single first chunk are collapsed immediately rather than being
+            # stored as distinct physical slots.
+            if is_list(delta_value) and delta_value and all(is_dict(x) and "index" in x for x in delta_value):  # type: ignore[union-attr]
+                acc[key] = _accumulate_list([], delta_value, acc, delta)  # type: ignore[arg-type]
+            else:
+                acc[key] = delta_value
             continue
 
         acc_value = acc[key]
@@ -37,27 +87,7 @@ def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> 
                 acc_value.extend(delta_value)
                 continue
 
-            for delta_entry in delta_value:
-                if not is_dict(delta_entry):
-                    raise TypeError(f"Unexpected list delta entry is not a dictionary: {delta_entry}")
-
-                try:
-                    index = delta_entry["index"]
-                except KeyError as exc:
-                    raise RuntimeError(f"Expected list delta entry to have an `index` key; {delta_entry}") from exc
-
-                if not isinstance(index, int):
-                    raise TypeError(f"Unexpected, list delta entry `index` value is not an integer; {index}")
-
-                try:
-                    acc_entry = acc_value[index]
-                except IndexError:
-                    acc_value.insert(index, delta_entry)
-                else:
-                    if not is_dict(acc_entry):
-                        raise TypeError("not handled yet")
-
-                    acc_value[index] = accumulate_delta(acc_entry, delta_entry)
+            acc_value = _accumulate_list(acc_value, delta_value, acc, delta)  # type: ignore[arg-type]
 
         acc[key] = acc_value
 


### PR DESCRIPTION
## Summary

Fixes #3201 — streaming tool-call accumulation produces invalid JSON when the first chunk contains multiple entries with the same logical "index" value.

## Root Cause

In `accumulate_delta`, when a list-valued key is seen **for the first time** it takes the fast path:

```python
if key not in acc:
    acc[key] = delta_value   # stores the raw list directly
```

If that first chunk has two entries both with `"index": 0` (e.g. one with the tool-call header and one with the first argument fragment), both are stored as separate physical slots. Subsequent chunks merge into physical slot 0 while the duplicate slot retains stale partial data — producing duplicate tool-call entries and broken argument JSON.

## Fix

Extract the list-merge logic into a private helper `_accumulate_list()` that matches entries by **logical index** (scanning for an existing entry whose `"index"` field matches) rather than physical position.

Call this helper on first-encounter as well as on subsequent merges:

```python
if key not in acc:
    if is_list(delta_value) and delta_value and all(is_dict(x) and "index" in x for x in delta_value):
        acc[key] = _accumulate_list([], delta_value, acc, delta)
    else:
        acc[key] = delta_value
    continue
```

## Verification

After the fix, two index-0 entries in the first chunk are collapsed into one logical tool-call entry and subsequent argument fragments are correctly accumulated:

```python
assert len(acc["tool_calls"]) == 1
assert acc["tool_calls"][0]["function"]["arguments"] == ' {"path": "."}' 
```

No changes to public API or other behaviours.