### PR TITLE
fix(client): sanitize NO_PROXY whitespace before httpx init (fixes #3303)

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -11,6 +11,7 @@ import asyncio
 import inspect
 import logging
 import platform
+import threading
 import warnings
 import contextlib
 import email.utils
@@ -834,6 +835,12 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+# Serializes the temporary NO_PROXY mutation in `_sanitized_proxy_env` so
+# overlapping client constructions from multiple threads cannot snapshot
+# each other's cleaned value and leave the env permanently sanitized.
+_proxy_env_lock = threading.Lock()
+
+
 @contextlib.contextmanager
 def _sanitized_proxy_env() -> Iterator[None]:
     """Temporarily replace any whitespace inside `NO_PROXY` / `no_proxy` with commas.
@@ -842,24 +849,31 @@ def _sanitized_proxy_env() -> Iterator[None]:
     tabs that sneak in via Docker, .env files, or shell scripts become part
     of the hostname and trigger `httpx.InvalidURL` during client construction.
     Normalize them just for the duration of the wrapped httpx initialization
-    so the parsed proxy bypass list is well-formed. See openai/openai-python#3303.
+    so the parsed proxy bypass list is well-formed, then restore the
+    original value. See openai/openai-python#3303.
+
+    The mutation is serialized by `_proxy_env_lock` because `os.environ` is
+    process-wide; without the lock, concurrent client constructions could
+    snapshot each other's already-cleaned value as their "original" and
+    leave NO_PROXY permanently sanitized for the rest of the process.
     """
-    saved: Dict[str, Optional[str]] = {}
-    for name in ("NO_PROXY", "no_proxy"):
-        original = os.environ.get(name)
-        saved[name] = original
-        if original is not None and re.search(r"\s", original):
-            cleaned = re.sub(r"\s+", ",", original.strip())
-            cleaned = re.sub(r",+", ",", cleaned).strip(",")
-            os.environ[name] = cleaned
-    try:
-        yield
-    finally:
-        for name, original in saved.items():
-            if original is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = original
+    with _proxy_env_lock:
+        saved: Dict[str, Optional[str]] = {}
+        for name in ("NO_PROXY", "no_proxy"):
+            original = os.environ.get(name)
+            saved[name] = original
+            if original is not None and re.search(r"\s", original):
+                cleaned = re.sub(r"\s+", ",", original.strip())
+                cleaned = re.sub(r",+", ",", cleaned).strip(",")
+                os.environ[name] = cleaned
+        try:
+            yield
+        finally:
+            for name, original in saved.items():
+                if original is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = original
 
 
 class _DefaultHttpxClient(httpx.Client):

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import re
 import sys
 import json
 import time
@@ -10,6 +12,7 @@ import inspect
 import logging
 import platform
 import warnings
+import contextlib
 import email.utils
 from types import TracebackType
 from random import random
@@ -831,12 +834,41 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+@contextlib.contextmanager
+def _sanitized_proxy_env() -> Iterator[None]:
+    """Temporarily replace any whitespace inside `NO_PROXY` / `no_proxy` with commas.
+
+    httpx parses these env vars by splitting on commas only, so newlines or
+    tabs that sneak in via Docker, .env files, or shell scripts become part
+    of the hostname and trigger `httpx.InvalidURL` during client construction.
+    Normalize them just for the duration of the wrapped httpx initialization
+    so the parsed proxy bypass list is well-formed. See openai/openai-python#3303.
+    """
+    saved: Dict[str, Optional[str]] = {}
+    for name in ("NO_PROXY", "no_proxy"):
+        original = os.environ.get(name)
+        saved[name] = original
+        if original is not None and re.search(r"\s", original):
+            cleaned = re.sub(r"\s+", ",", original.strip())
+            cleaned = re.sub(r",+", ",", cleaned).strip(",")
+            os.environ[name] = cleaned
+    try:
+        yield
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = original
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        super().__init__(**kwargs)
+        with _sanitized_proxy_env():
+            super().__init__(**kwargs)
 
 
 if TYPE_CHECKING:
@@ -1423,7 +1455,8 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        super().__init__(**kwargs)
+        with _sanitized_proxy_env():
+            super().__init__(**kwargs)
 
 
 try:
@@ -1441,7 +1474,8 @@ else:
             kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
             kwargs.setdefault("follow_redirects", True)
 
-            super().__init__(**kwargs)
+            with _sanitized_proxy_env():
+                super().__init__(**kwargs)
 
 
 if TYPE_CHECKING:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1309,6 +1309,39 @@ class TestOpenAI:
         # The original env var is restored so user code observes what it set.
         assert os.environ["NO_PROXY"] == "localhost\nexample.com\t192.168.1.1"
 
+    def test_no_proxy_concurrent_construction_preserves_original(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Without the lock around _sanitized_proxy_env, two threads that
+        # construct clients at the same time could snapshot each other's
+        # already-cleaned value as the "original" and leave NO_PROXY
+        # permanently sanitized for the rest of the process. Spin up
+        # several constructions in parallel and assert the env is the
+        # same string the caller set when everything has finished.
+        import threading
+
+        original = "localhost\nexample.com\t192.168.1.1\n10.0.0.0/8"
+        monkeypatch.setenv("NO_PROXY", original)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        errors: list[BaseException] = []
+
+        def construct() -> None:
+            try:
+                for _ in range(20):
+                    DefaultHttpxClient()
+            except BaseException as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=construct) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"client construction raised: {errors!r}"
+        assert os.environ["NO_PROXY"] == original
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1292,6 +1292,23 @@ class TestOpenAI:
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
 
+    def test_no_proxy_with_whitespace_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Regression test for openai/openai-python#3303: NO_PROXY values that
+        # contain newlines or other whitespace (common in Docker, .env files,
+        # and shell scripts) used to break client construction with
+        # httpx.InvalidURL because httpx splits NO_PROXY only by comma.
+        # The sanitizer in _DefaultHttpxClient.__init__ normalizes whitespace
+        # to commas just for the duration of the httpx init, then restores
+        # the original env var.
+        monkeypatch.setenv("NO_PROXY", "localhost\nexample.com\t192.168.1.1")
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        # Construction must not raise.
+        DefaultHttpxClient()
+
+        # The original env var is restored so user code observes what it set.
+        assert os.environ["NO_PROXY"] == "localhost\nexample.com\t192.168.1.1"
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions
@@ -2551,6 +2568,15 @@ class TestAsyncOpenAI:
         mounts = tuple(client._mounts.items())
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
+
+    async def test_no_proxy_with_whitespace_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Async counterpart of the sync regression test for #3303.
+        monkeypatch.setenv("NO_PROXY", "localhost\nexample.com\t192.168.1.1")
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        DefaultAsyncHttpxClient()
+
+        assert os.environ["NO_PROXY"] == "localhost\nexample.com\t192.168.1.1"
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:


### PR DESCRIPTION
Fixes #3303.

## Bug

`OpenAI()` and `AsyncOpenAI()` raise `httpx.InvalidURL` at construction time when the `NO_PROXY` environment variable contains whitespace (newlines, tabs, or runs of spaces). This is common when `NO_PROXY` is set from a Docker compose file with multi-line YAML, a `.env` file where the value wraps, or a shell script using line continuations.

```python
import os
os.environ['NO_PROXY'] = 'localhost\nexample.com'

from openai import OpenAI
client = OpenAI(api_key='sk-test')
# httpx.InvalidURL: Invalid non-printable ASCII character in URL, '\n' at position 16.
```

Root cause is in `httpx._utils.get_environment_proxies`: it splits `NO_PROXY` on commas only, so whitespace inside an entry survives into the hostname and httpx rejects it during proxy-mounts setup, before any request is made. The reporter notes the fix would be trivial in httpx but the encode/httpx project is not currently accepting external PRs, so the practical workaround is for the SDK to normalize the value just for the duration of the internal httpx client's `__init__`.

## Fix

Introduce a `_sanitized_proxy_env()` context manager in `_base_client.py` that, while active, replaces any whitespace inside `NO_PROXY` / `no_proxy` with commas (then collapses adjacent commas). Wrap `super().__init__(**kwargs)` in each of the three internal httpx wrappers (`_DefaultHttpxClient`, `_DefaultAsyncHttpxClient`, `_DefaultAioHttpClient`). The original env var value is restored on exit so user code observes the env var it set.

```python
with _sanitized_proxy_env():
    super().__init__(**kwargs)
```

If `NO_PROXY` contains no whitespace, the context manager is a no-op.

## Verification

Added two regression tests in `tests/test_client.py`:

- `TestOpenAI.test_no_proxy_with_whitespace_does_not_raise`
- `TestAsyncOpenAI.test_no_proxy_with_whitespace_does_not_raise`

Each sets `NO_PROXY="localhost\nexample.com\t192.168.1.1"`, constructs the default client, asserts no exception, and asserts the original env var is restored.

Local A/B:

```
without fix: FAILED ... httpx.InvalidURL: Invalid non-printable ASCII character in URL, '\n' at position 16
with fix:    PASSED 6 passed (new + the existing test_proxy_environment_variables and test_default_client_creation, sync + async)
```

## Scope

40-line change to `_base_client.py` (one helper + three two-line `with:` wraps + three import additions) plus 26 lines of test coverage. No behavior change for users who do not set `NO_PROXY` or who set it with valid comma-separated values.