### PR TITLE
fix: tolerate null response output when parsing responses

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -7,7 +7,10 @@ from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
+from openai._types import NOT_GIVEN
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +42,23 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_parse_response_allows_null_output() -> None:
+    response = Response.construct(
+        id="resp_123",
+        object="response",
+        created_at=0,
+        model="gpt-4o-mini",
+        output=None,
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    parsed = parse_response(text_format=NOT_GIVEN, input_tools=NOT_GIVEN, response=response)
+
+    assert parsed.output == []
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary

Handle Responses objects whose `output` is `None` when parsing Responses API results.

A live downstream regression in Hermes/Codex surfaced this path: the backend can stream usable output events, then the terminal Responses object may deserialize with `response.output is None`. `parse_response()` currently iterates `response.output` directly and raises `TypeError: 'NoneType' object is not iterable` before callers can recover from streamed events.

This keeps parsing defensive by treating null output like an empty output list.

Related downstream report: https://github.com/NousResearch/hermes-agent/issues/32883

## Tests

```text
python -m pytest tests\lib\responses\test_responses.py -q -o addopts=
6 passed in 1.28s
```

Also ran:

```text
python -m ruff check src\openai\lib\_parsing\_responses.py tests\lib\responses\test_responses.py
python -m ruff format --check src\openai\lib\_parsing\_responses.py tests\lib\responses\test_responses.py
```