### PR TITLE
fix: guard parse_response against null output

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
This is a minimal defensive guard for `parse_response()` when a terminal Responses object arrives with `response.output=None`.

Change:
- `for output in response.output:`
- `for output in (response.output or []):`

Why:
- some downstream consumers are seeing final accumulated Responses objects with null or missing output after valid stream events
- the current parser raises `TypeError: 'NoneType' object is not iterable`
- treating null output like an empty list preserves current behavior for normal responses while avoiding the crash path
