### PR TITLE
docs: fix nested params example

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,15 +379,10 @@ from openai import OpenAI
 
 client = OpenAI()
 
-response = client.chat.responses.create(
-    input=[
-        {
-            "role": "user",
-            "content": "How much ?",
-        }
-    ],
+response = client.responses.create(
     model="gpt-5.2",
-    response_format={"type": "json_object"},
+    input="Generate an example JSON object describing a fruit.",
+    text={"format": {"type": "json_object"}},
 )
 ```
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3264.

Updates the README "Nested params" example to use the Responses API consistently:

- calls `client.responses.create(...)` instead of the non-existent `client.chat.responses.create(...)`
- uses `text={"format": {"type": "json_object"}}` for JSON output configuration

## Additional context & links

Validation run locally:

- `python` compile check for the extracted README nested params example
- `ruff check /tmp/readme_nested_params.py`
- `ruff format --check /tmp/readme_nested_params.py`

Note: `ruff format --check --preview README.md` reports the existing README would be reformatted outside this targeted change, so I validated the extracted Python snippet directly.
