### PR TITLE
Fix: None case handling in response.output parsing

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
This pull request makes a small but important change to the response parsing logic to improve robustness when handling API responses.

- Improved error handling in `parse_response` within `src/openai/lib/_parsing/_responses.py` by ensuring the code safely iterates over `response.output` even if it is `None`, preventing possible runtime errors.