### PR TITLE
fix(parsing): handle null response.output in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,14 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    # Some Responses-API backends emit a terminal payload with
+    # ``output: null`` instead of ``output: []`` (observed on the ChatGPT
+    # codex backend for newer models). The Response type annotation is
+    # ``List[ResponseOutputItem]`` so pydantic doesn't coerce None to [],
+    # which would raise ``TypeError: 'NoneType' object is not iterable``
+    # here. Treat None defensively as an empty list so streaming clients
+    # can recover from the deltas they already received.
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -8,6 +8,9 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai._types import omit
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -61,3 +64,34 @@ def test_parse_method_definition_in_sync(sync: bool, client: OpenAI, async_clien
         checking_client.responses.parse,
         exclude_params={"tools"},
     )
+
+
+def test_parse_response_handles_null_output() -> None:
+    """Regression test: some Responses-API backends emit a terminal
+    payload with ``output: null`` (observed on the ChatGPT codex backend
+    for newer models). ``parse_response`` should treat None defensively
+    as an empty list rather than raising
+    ``TypeError: 'NoneType' object is not iterable``.
+    """
+    response = Response.model_construct(
+        id="resp_test_null_output",
+        object="response",
+        created_at=0,
+        status="completed",
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        model="test-model",
+        output=None,  # the bug-trigger
+        parallel_tool_calls=True,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        metadata={},
+    )
+
+    parsed = parse_response(text_format=omit, input_tools=omit, response=response)
+
+    assert parsed.output == []
+    assert parsed.output_parsed is None


### PR DESCRIPTION
This pull request makes `parse_response` in `src/openai/lib/_parsing/_responses.py` robust to terminal `response.completed` events whose `response.output` is `null` instead of `[]`.

Without this change, the SDK raises `TypeError: 'NoneType' object is not iterable` during stream accumulation (`accumulate_event` → `parse_response`), so the streamed deltas the client already received via `response.output_text.delta` / `response.output_item.done` are lost and the caller's `for event in stream:` loop dies before `get_final_response()` is ever reached.

This has been observed on the ChatGPT codex backend (`chatgpt.com/backend-api/codex`) for newer codex models, where it breaks every `hermes-agent` conversation turn against that backend with `error_type=TypeError ... summary='NoneType' object is not iterable`. Tracking issues in the downstream consumer: [NousResearch/hermes-agent#33059](https://github.com/NousResearch/hermes-agent/issues/33059) (which explicitly identifies this SDK function as the broken layer) and [#32991](https://github.com/NousResearch/hermes-agent/issues/32991). Client-side workarounds in hermes around `get_final_response()` are unreachable because the crash happens earlier, inside the stream iterator.

Iterating over `(response.output or [])` defensively treats `None` as empty, matching the existing empty-list path. Added a regression test in `tests/lib/responses/test_responses.py`.