### PR TITLE
fix(responses): guard parser/output_text when response.output is null

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -313,7 +313,7 @@ class Response(BaseModel):
         If no `output_text` content blocks exist, then an empty string is returned.
         """
         texts: List[str] = []
-        for output in self.output:
+        for output in (self.output or []):
             if output.type == "message":
                 for content in output.content:
                     if content.type == "output_text":


### PR DESCRIPTION
# Fix parse_response crash when `response.output` is `None`

## Summary

This patch hardens the OpenAI Python SDK Responses parsing path against `output=None` payloads.

Observed failure (openai==2.33.0):

- `openai/lib/_parsing/_responses.py` iterates `response.output` unconditionally.
- If a Responses backend returns `output: null`, parser raises:
  - `TypeError: 'NoneType' object is not iterable`

Patch behavior:

- Treat `response.output is None` as an empty list in parser loop.
- Apply same guard in `Response.output_text` property for consistency.

## Why

In rare edge cases, a Responses payload may contain `output: null`; the SDK should handle this defensively.

## Changes

1. `src/openai/lib/_parsing/_responses.py`

```diff
- for output in response.output:
+ for output in (response.output or []):
```

2. `src/openai/types/responses/response.py`

```diff
- for output in self.output:
+ for output in (self.output or []):
```

## Expected result

- `parse_response(...)` no longer crashes when `response.output is None`.
- Parsed response behavior is equivalent to an empty output list.
- `Response.output_text` returns `""` instead of crashing when `self.output is None`.

## Suggested tests

- Add regression test where `Response.model_construct(..., output=None)` is passed to `parse_response`.
- Assert parsed response returns `output=[]`.
- Assert `Response(..., output=None).output_text == ""`.
