### PR TITLE
fix: handle null response.output in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
Fixes #3325

## What

`parse_response()` in `src/openai/lib/_parsing/_responses.py` crashes with `TypeError: 'NoneType' object is not iterable` when `response.output` is `null`. This can happen when the server sends a `response.completed` event with `output: null` while valid `response.output_item.done` events were streamed earlier. The fix coerces `None` to `[]` before iteration.

## Verification

- Build: pass
- Tests: pass (5 passed)
- Lint: pass (ruff)
- Type check: pass (pyright, 0 errors)