### PR TITLE
fix(types): make `query` optional in `ActionSearch`

### DIFF
--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -29,7 +29,7 @@ class ActionSearchSource(BaseModel):
 class ActionSearch(BaseModel):
     """Action type "search" - Performs a web search query."""
 
-    query: str
+    query: Optional[str] = None
     """[DEPRECATED] The search query."""
 
     type: Literal["search"]

--- a/src/openai/types/responses/response_function_web_search_param.py
+++ b/src/openai/types/responses/response_function_web_search_param.py
@@ -30,7 +30,7 @@ class ActionSearchSource(TypedDict, total=False):
 class ActionSearch(TypedDict, total=False):
     """Action type "search" - Performs a web search query."""
 
-    query: Required[str]
+    query: str
     """[DEPRECATED] The search query."""
 
     type: Required[Literal["search"]]


### PR DESCRIPTION
The `query` field on the web search `search` action (`ActionSearch`) is typed as a required `str`, but it is marked `[DEPRECATED]` and the API no longer returns it — `web_search_call` items now carry only the plural `queries`. Parsing real responses therefore raises `ValidationError` (`ActionSearch.query` Field required).

## Changes being requested

Make `ActionSearch.query` optional (`Optional[str] = None`) to match actual API responses where the field is absent.

## Additional context & links

This is the same class of fix as #3181 (which made the sibling `ResponseFunctionWebSearch.action` optional) and is related to #3179. It is backward compatible: `query` is already deprecated, so callers must tolerate its absence.

- [x] I understand that this repository is auto-generated and my pull request may not be merged