### PR TITLE
fix: align realtime audio event types

### DIFF
--- a/src/openai/types/realtime/response_audio_delta_event.py
+++ b/src/openai/types/realtime/response_audio_delta_event.py
@@ -28,5 +28,5 @@ class ResponseAudioDeltaEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.output_audio.delta"]
-    """The event type, must be `response.output_audio.delta`."""
+    type: Literal["response.audio.delta"]
+    """The event type, must be `response.audio.delta`."""

--- a/src/openai/types/realtime/response_audio_done_event.py
+++ b/src/openai/types/realtime/response_audio_done_event.py
@@ -29,5 +29,5 @@ class ResponseAudioDoneEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.output_audio.done"]
-    """The event type, must be `response.output_audio.done`."""
+    type: Literal["response.audio.done"]
+    """The event type, must be `response.audio.done`."""

--- a/src/openai/types/realtime/response_audio_transcript_delta_event.py
+++ b/src/openai/types/realtime/response_audio_transcript_delta_event.py
@@ -28,5 +28,5 @@ class ResponseAudioTranscriptDeltaEvent(BaseModel):
     response_id: str
     """The ID of the response."""
 
-    type: Literal["response.output_audio_transcript.delta"]
-    """The event type, must be `response.output_audio_transcript.delta`."""
+    type: Literal["response.audio_transcript.delta"]
+    """The event type, must be `response.audio_transcript.delta`."""

--- a/src/openai/types/realtime/response_audio_transcript_done_event.py
+++ b/src/openai/types/realtime/response_audio_transcript_done_event.py
@@ -32,5 +32,5 @@ class ResponseAudioTranscriptDoneEvent(BaseModel):
     transcript: str
     """The final transcript of the audio."""
 
-    type: Literal["response.output_audio_transcript.done"]
-    """The event type, must be `response.output_audio_transcript.done`."""
+    type: Literal["response.audio_transcript.done"]
+    """The event type, must be `response.audio_transcript.done`."""

--- a/tests/test_realtime_types.py
+++ b/tests/test_realtime_types.py
@@ -1,0 +1,32 @@
+import pytest
+
+from openai._compat import parse_obj
+from openai.types.realtime.response_audio_done_event import ResponseAudioDoneEvent
+from openai.types.realtime.response_audio_delta_event import ResponseAudioDeltaEvent
+from openai.types.realtime.response_audio_transcript_done_event import ResponseAudioTranscriptDoneEvent
+from openai.types.realtime.response_audio_transcript_delta_event import ResponseAudioTranscriptDeltaEvent
+
+
+@pytest.mark.parametrize(
+    ("model", "event_type", "extra"),
+    [
+        (ResponseAudioDeltaEvent, "response.audio.delta", {"delta": "abc"}),
+        (ResponseAudioDoneEvent, "response.audio.done", {}),
+        (ResponseAudioTranscriptDeltaEvent, "response.audio_transcript.delta", {"delta": "hello"}),
+        (ResponseAudioTranscriptDoneEvent, "response.audio_transcript.done", {"transcript": "hello"}),
+    ],
+)
+def test_realtime_audio_event_type_literals_match_api_events(model: type, event_type: str, extra: dict) -> None:
+    event = parse_obj(
+        model,
+        {
+            "event_id": "event_1",
+            "response_id": "resp_1",
+            "item_id": "item_1",
+            "output_index": 0,
+            "content_index": 0,
+            "type": event_type,
+            **extra,
+        },
+    )
+    assert event.type == event_type


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #2698.

Updates the non-beta realtime audio response event type literals to match the event names emitted by the API and already used by the beta realtime types:

- `response.audio.delta`
- `response.audio.done`
- `response.audio_transcript.delta`
- `response.audio_transcript.done`

Adds a small regression test that validates the four realtime audio event models accept those API event names.

## Additional context & links

Tests run:

- `python3 -m ruff check src/openai/types/realtime/response_audio_delta_event.py src/openai/types/realtime/response_audio_done_event.py src/openai/types/realtime/response_audio_transcript_delta_event.py src/openai/types/realtime/response_audio_transcript_done_event.py tests/test_realtime_types.py`
- `python3 -m pytest -o addopts='' tests/test_realtime_types.py`
