### PR TITLE
fix(_transform): guard IndexError for bare dict annotation

### DIFF
--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,8 +180,11 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        args = get_args(stripped_type)
+        if len(args) >= 2:
+            items_type = args[1]
+            return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        return data
 
     if (
         # List[T]
@@ -346,8 +349,11 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        args = get_args(stripped_type)
+        if len(args) >= 2:
+            items_type = args[1]
+            return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        return data
 
     if (
         # List[T]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -458,3 +458,16 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+class TypedDictBareDict(TypedDict):
+    metadata: dict  # bare dict, no type parameters
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_no_indexerror(use_async: bool) -> None:
+    # bare `dict` annotation (no type params) must not raise IndexError
+    assert await transform({"metadata": {"key": "value"}}, TypedDictBareDict, use_async) == {
+        "metadata": {"key": "value"}
+    }


### PR DESCRIPTION
## What's broken

Calling `transform()` on a TypedDict whose field is annotated with a bare, unparameterised `dict` (e.g. `metadata: dict`) raises an `IndexError`. The bug affects both the sync and async transform paths.

```python
class TestParams(TypedDict, total=False):
    metadata: dict  # no type parameters

transform({"metadata": {"key": "value"}}, TestParams)
# IndexError: tuple index out of range
```

## Why it happens

`_transform_recursive` and `_async_transform_recursive` both unconditionally access `get_args(stripped_type)[1]` when `origin == dict`. For a bare `dict`, `get_args(dict)` returns an empty tuple, so index `1` does not exist.

## Fix

Store `args = get_args(stripped_type)` and only recurse with `args[1]` when `len(args) >= 2`. When no type arguments are present the data is returned unchanged, which is the correct behaviour for an unparameterised dict.

## Test

Added `test_bare_dict_no_indexerror` in `tests/test_transform.py`: passes `{"metadata": {"key": "value"}}` through a TypedDict with a bare `dict` field and asserts the result is returned unchanged without error. Runs in both sync and async variants.

Fixes #3338