### PR TITLE
fix(_models): guard against empty get_args() on bare dict annotation

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,11 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args = get_args(type_)
+        if not args:
+            # bare `dict` with no type arguments — return value as-is
+            return value
+        _, items_type = args  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -655,6 +655,12 @@ def test_annotated_types() -> None:
     assert m.value == "foo"
 
 
+def test_construct_type_bare_dict_annotation() -> None:
+    # bare `dict` (no type args) must not raise ValueError on unpack
+    result = construct_type(value={"key": "value"}, type_=dict)
+    assert result == {"key": "value"}
+
+
 def test_discriminated_unions_invalid_data() -> None:
     class A(BaseModel):
         type: Literal["a"]


### PR DESCRIPTION
## What's broken

`construct_type()` in `src/openai/_models.py` crashes with `ValueError: not enough values to unpack (expected 2, got 0)` when the field type is a bare, unparameterised `dict` with no type arguments. The code does `_, items_type = get_args(type_)` unconditionally after detecting `origin == dict`, but `get_args(dict)` returns an empty tuple `()` for the bare class.

## Why it happens

The guard only checks `origin == dict`; it never verifies that `get_args` actually returned two arguments before unpacking.

## Fix

Added a two-line guard: if `get_args(type_)` returns an empty tuple (bare `dict`), return the mapping value as-is instead of attempting the unpack. The parameterised `Dict[K, V]` path is unchanged.

## Test

Added `test_construct_type_bare_dict_annotation` to `tests/test_models.py`. It calls `construct_type(value={"key": "value"}, type_=dict)` and asserts the result equals the input dict without raising.

Fixes #3341