### PR TITLE
fix(_models): guard get_args() unpack for bare dict in construct_type()

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,11 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args = get_args(type_)
+        if len(args) < 2:
+            # bare `dict` with no type parameters — return as-is
+            return value
+        _, items_type = args  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1015,3 +1015,10 @@ def test_iterable_construction_str_falls_back_to_list() -> None:
     # falls back to list of chars rather than calling str(["h", "e", "l", "l", "o"])
     assert m.data["items"] == ["h", "e", "l", "l", "o"]
     assert m.model_dump()["data"]["items"] == ["h", "e", "l", "l", "o"]
+
+
+def test_construct_type_bare_dict_no_unpack_error() -> None:
+    # bare `dict` (no type parameters) must not raise ValueError when unpacking get_args()
+    value = {"key": "value"}
+    result = construct_type(type_=dict, value=value)
+    assert result == value


### PR DESCRIPTION
## What's broken

Calling `construct_type(type_=dict, value={...})` crashes with `ValueError: not enough values to unpack (expected 2, got 0)`. The branch at line 660 unconditionally does `_, items_type = get_args(type_)`, but `get_args(dict)` returns an empty tuple when `dict` is bare (no `K, V` parameters).

```
ValueError: not enough values to unpack (expected 2, got 0)
  File "_models.py", line 660, in construct_type
    _, items_type = get_args(type_)  # Dict[_, items_type]
```

## Why it happens

`get_args` on an unparameterized `dict` returns `()`, so the two-variable destructure always fails for bare dict annotations.

## Fix

Store `args = get_args(type_)` and only destructure when `len(args) >= 2`; if fewer args exist (bare dict), return `value` unchanged since there is no item-level type to enforce.

## Test

Added `test_construct_type_bare_dict_no_unpack_error` which calls `construct_type(type_=dict, value={...})` and asserts the result equals the input dict without raising.

Fixes #3338