### PR TITLE
docs: fix vision example broken image URL (fixes #2776)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ With an image URL:
 
 ```python
 prompt = "What is in this image?"
-img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/640px-2023_06_08_Raccoon1.jpg"
 
 response = client.responses.create(
     model="gpt-5.5",


### PR DESCRIPTION
## Summary

Fixes #2776 — the vision example in README.md uses a 1599px Wikimedia image that causes a `400 BadRequestError`:

```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'Error while downloading https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg.'}}
```

This PR replaces the 1599px version with the 640px version of the same image, which resolves cleanly.

## Change

```diff
- img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+ img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/640px-2023_06_08_Raccoon1.jpg"
```

## Verification

- The 640px version of the same Wikimedia image loads successfully
- No visual quality loss for a README example
- All other examples unaffected