### PR TITLE
fix: handle bare dict annotation in construct_type()

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,12 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args = get_args(type_)
+        if len(args) < 2:
+            # bare `dict` with no type parameters (e.g. `dict` instead of
+            # `dict[str, Any]`) — nothing to recurse into, return as-is.
+            return value
+        _, items_type = args
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -133,6 +133,22 @@ def test_raw_dictionary() -> None:
     assert cast(Any, m.nested) is False
 
 
+
+def test_bare_dict_annotation() -> None:
+    """construct_type should not crash on bare dict annotations without type parameters."""
+    # This was crashing with ValueError: not enough values to unpack
+    # because get_args(dict) returns () for unparameterised dict.
+    result = construct_type(value={"key": "value"}, type_=dict)
+    assert result == {"key": "value"}
+
+    result = construct_type(value={"a": 1, "b": 2}, type_=dict)
+    assert result == {"a": 1, "b": 2}
+
+    # empty dict
+    result = construct_type(value={}, type_=dict)
+    assert result == {}
+
+
 def test_nested_dictionary_model() -> None:
     class NestedModel(BaseModel):
         nested: Dict[str, BasicModel]


### PR DESCRIPTION
## What breaks

`construct_type()` in `src/openai/_models.py` crashes with `ValueError` when `type_` is a bare, unparameterised `dict` (no `[K, V]` type arguments).

```python
from openai._models import construct_type
result = construct_type(value={key: value}, type_=dict)
# ValueError: not enough values to unpack (expected 2, got 0)
```

Fixes #3341

## Root cause

Line 660 does `_, items_type = get_args(type_)` after checking `origin == dict`. For bare `dict`, `get_args(dict)` returns an empty tuple `()`, and unpacking with two targets raises `ValueError`.

## Fix

Add a length check before unpacking. When `get_args()` returns fewer than 2 elements (bare `dict`), return the value as-is since there are no type parameters to recurse into.

```python
args = get_args(type_)
if len(args) < 2:
    return value  # bare dict, no type parameters
_, items_type = args
```

## Tests

Added `test_bare_dict_annotation()` covering:
- Bare `dict` with string values
- Bare `dict` with int values
- Empty `dict`

All existing `test_models.py` tests continue to pass.