### PR TITLE
fix: handle bare dict annotation in _transform_recursive

### DIFF
--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,7 +180,10 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return cast(object, data)
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +349,10 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return cast(object, data)
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -397,6 +397,22 @@ async def test_dictionary_items(use_async: bool) -> None:
     assert await transform({"foo": {"foo_baz": "bar"}}, Dict[str, DictItems], use_async) == {"foo": {"fooBaz": "bar"}}
 
 
+
+class BareDictTypedDict(TypedDict, total=False):
+    metadata: dict  # bare dict — no type parameters
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_in_typeddict(use_async: bool) -> None:
+    """transform should not crash on bare dict annotations in TypedDict."""
+    result = await transform({"metadata": {"key": "value"}}, BareDictTypedDict, use_async)
+    assert result == {"metadata": {"key": "value"}}
+
+    result = await transform({"metadata": {}}, BareDictTypedDict, use_async)
+    assert result == {"metadata": {}}
+
+
 class TypedDictIterableUnionStr(TypedDict):
     foo: Annotated[Union[str, Iterable[Baz8]], PropertyInfo(alias="FOO")]
 


### PR DESCRIPTION
## What breaks

When a `TypedDict` field is annotated with a bare, unparameterised `dict` (e.g. `metadata: dict` instead of `metadata: dict[str, str]`), calling `transform()` raises `IndexError`.

```python
from typing import TypedDict
from openai._utils._transform import transform

class TestParams(TypedDict, total=False):
    metadata: dict  # bare dict — no type parameters

result = transform({"metadata": {"key": "value"}}, TestParams)
# IndexError: tuple index out of range
```

Fixes #3338

## Root cause

Both `_transform_recursive` and `_async_transform_recursive` unconditionally do `get_args(stripped_type)[1]` when `origin == dict`. For bare `dict`, `get_args(dict)` returns an empty tuple, so the index access crashes.

## Fix

Add a length check before indexing. When `get_args()` returns fewer than 2 elements (bare `dict`), return the data as-is since there are no type parameters to recurse into.

```python
args = get_args(stripped_type)
if len(args) < 2:
    return cast(object, data)
items_type = args[1]
```

## Tests

Added `test_bare_dict_in_typeddict()` covering:
- Bare `dict` with nested values
- Empty `dict`

Both sync and async paths pass. All existing `test_transform.py` tests continue to pass.