### PR TITLE
fix: handle null response.output in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
## What breaks

`parse_response()` in `src/openai/lib/_parsing/_responses.py` crashes with `TypeError` when `response.output` is `None`.

The chatgpt.com Codex backend (`https://chatgpt.com/backend-api/codex`) sometimes sends `response.output: null` in the consolidated `response.completed` event — even when valid `response.output_item.done` events were streamed earlier. The SDK then raises `TypeError: 'NoneType' object is not iterable` inside `parse_response()`.

Fixes #3325

## Root cause

Line 61 does `for output in response.output:` without checking for `None`. When the Codex backend sends `response.output: null`, iterating over `None` crashes.

## Fix

Add a fallback to empty list when `response.output` is `None`:

```python
for output in response.output or []:
```

This is safe because:
- If `response.output` is a valid list, it iterates normally
- If `response.output` is `None`, it iterates over nothing (no output items to parse)
- The earlier streamed events already populated the output items, so the final consolidated event having null output is a no-op