### PR TITLE
fix: sanitize newline characters in NO_PROXY environment variable

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -831,6 +831,32 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+def _sanitize_proxy_env() -> None:
+    """Sanitize proxy-related environment variables.
+
+    httpx get_environment_proxies() splits NO_PROXY only by comma,
+    but the value often contains newlines (from Docker, .env files, or shell
+    scripts). Newlines inside a hostname cause httpx.InvalidURL at client
+    creation time. This helper normalises the values so that newlines are
+    treated as delimiters equivalent to commas.
+    """
+    import os
+
+    for key in ("NO_PROXY", "no_proxy"):
+        val = os.environ.get(key)
+        if val and "\n" in val:
+            os.environ[key] = ",".join(
+                part.strip() for part in val.replace("\n", ",").split(",") if part.strip()
+            )
+
+
+# Best-effort: run once at import time so every httpx client benefits.
+try:
+    _sanitize_proxy_env()
+except Exception:
+    pass
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)


### PR DESCRIPTION
## Problem

When the `NO_PROXY` environment variable contains newline characters (common in Docker containers, .env files, or shell scripts), creating an `OpenAI` client raises `httpx.InvalidURL`.

**Root cause:** httpx's `get_environment_proxies()` splits `NO_PROXY` only by comma (`)`, not by newline (`\n`). When a newline is present, it becomes part of the hostname and triggers URL validation failure.

## Fix

Add `_sanitize_proxy_env()` that runs once at import time to normalize proxy-related environment variables. Newlines in `NO_PROXY`/`no_proxy` are treated as comma-equivalent delimiters.

This is a best-effort sanitization wrapped in try/except to avoid any side effects if the environment is unusual.

## Testing

Verified the fix resolves the reported issue:

```python
import os
os.environ['NO_PROXY'] = 'localhost\n192.168.1.1'
from openai import OpenAI  # No longer raises InvalidURL
```

Fixes #3303