### PR TITLE
feat: send request timeout header

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -451,12 +451,16 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         lower_custom_headers = [header.lower() for header in custom_headers]
         if "x-stainless-retry-count" not in lower_custom_headers:
             headers["x-stainless-retry-count"] = str(retries_taken)
+        timeout = self.timeout if isinstance(options.timeout, NotGiven) else options.timeout
         if "x-stainless-read-timeout" not in lower_custom_headers:
-            timeout = self.timeout if isinstance(options.timeout, NotGiven) else options.timeout
-            if isinstance(timeout, Timeout):
-                timeout = timeout.read
-            if timeout is not None:
-                headers["x-stainless-read-timeout"] = str(timeout)
+            read_timeout = timeout
+            if isinstance(read_timeout, Timeout):
+                read_timeout = read_timeout.read
+            if read_timeout is not None:
+                headers["x-stainless-read-timeout"] = str(read_timeout)
+        if "request-timeout-ms" not in lower_custom_headers:
+            if not isinstance(timeout, Timeout) and timeout is not None:
+                headers["request-timeout-ms"] = str(int(timeout * 1000))
 
         return headers
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1002,6 +1002,30 @@ class TestOpenAI:
 
         assert response.http_request.headers.get("x-stainless-retry-count") == "42"
 
+    @pytest.mark.respx(base_url=base_url)
+    @pytest.mark.parametrize(
+        ("timeout", "extra_headers", "expected"),
+        [
+            (12.5, {}, "12500"),
+            (httpx.Timeout(12.5), {}, None),
+            (12.5, {"request-timeout-ms": Omit()}, None),
+            (12.5, {"request-timeout-ms": "42"}, "42"),
+        ],
+    )
+    def test_request_timeout_ms_header(
+        self, client: OpenAI, respx_mock: MockRouter, timeout: float | httpx.Timeout, extra_headers: dict[str, Any], expected: str | None
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(return_value=httpx.Response(200))
+
+        response = client.chat.completions.with_raw_response.create(
+            messages=[{"content": "string", "role": "developer"}],
+            model="gpt-4o",
+            timeout=timeout,
+            extra_headers=extra_headers,
+        )
+
+        assert response.http_request.headers.get("request-timeout-ms") == expected
+
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx(base_url=base_url)


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds a `request-timeout-ms` header when a numeric request timeout is configured, allowing downstream services to receive the request wall-clock deadline in milliseconds. The header is not set for `httpx.Timeout` objects and can be omitted or overridden by callers via `extra_headers`.

## Additional context & links

Fixes #3277

Tests:
- `.venv/bin/ruff check src/openai/_base_client.py tests/test_client.py`
- `.venv/bin/python -m pytest -o addopts='' tests/test_client.py`
