### PR TITLE
fix: correct jitter comment to reflect 25% scaling

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -787,7 +787,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         # Apply exponential backoff, but not more than the max.
         sleep_seconds = min(INITIAL_RETRY_DELAY * pow(2.0, nb_retries), MAX_RETRY_DELAY)
 
-        # Apply some jitter, plus-or-minus half a second.
+        # Apply jitter, scaling the delay down by up to 25%.
         jitter = 1 - 0.25 * random()
         timeout = sleep_seconds * jitter
         return timeout if timeout >= 0 else 0


### PR DESCRIPTION
The retry backoff applies jitter via `jitter = 1 - 0.25 * random()`, which scales the computed delay **down by up to 25%** (`random()` is in `[0, 1)`, so `jitter` is in `(0.75, 1.0]`).

The existing comment says "plus-or-minus half a second," which describes neither the direction (only ever reduces the delay) nor the magnitude (proportional 25%, not a fixed ±0.5s). This corrects the comment to match the code.

Comment-only change; no behavior change.

(This supersedes #2566, which had a corrupted diff.)