### PR TITLE
test(azure): cover image deployment routing

### DIFF
--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -33,17 +33,25 @@ class MockRequestCall(Protocol):
 
 
 @pytest.mark.parametrize("client", [sync_client, async_client])
-def test_implicit_deployment_path(client: Client) -> None:
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/chat/completions",
+        "/images/edits",
+        "/images/generations",
+    ],
+)
+def test_implicit_deployment_path(client: Client, path: str) -> None:
     req = client._build_request(
         FinalRequestOptions.construct(
             method="post",
-            url="/chat/completions",
+            url=path,
             json_data={"model": "my-deployment-model"},
         )
     )
     assert (
         req.url
-        == "https://example-resource.azure.openai.com/openai/deployments/my-deployment-model/chat/completions?api-version=2023-07-01"
+        == f"https://example-resource.azure.openai.com/openai/deployments/my-deployment-model{path}?api-version=2023-07-01"
     )
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add regression coverage for Azure deployment-path routing for Images API endpoints, including `images.edit` (`/images/edits`) and `images.generate` (`/images/generations`).

## Additional context & links

Refs #2608.

Tests:
- `uv run pytest tests/lib/test_azure.py -q`
- `uv run ruff format --check tests/lib/test_azure.py`
- `uv run ruff check tests/lib/test_azure.py`
