### PR TITLE
docs: import httpx in timeout example

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,7 @@ By default requests time out after 10 minutes. You can configure this with a `ti
 which accepts a float or an [`httpx.Timeout`](https://www.python-httpx.org/advanced/timeouts/#fine-tuning-the-configuration) object:
 
 ```python
+import httpx
 from openai import OpenAI
 
 # Configure the default for all requests:


### PR DESCRIPTION
## Summary
- imports `httpx` in the README timeout example before using `httpx.Timeout`

## Test plan
- `PYTHONPATH=src OPENAI_API_KEY=sk-test python3 <timeout snippet>`
- `git diff --check`
