### PR TITLE
fix: handle null response.output in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
## Problem

`parse_response()` in `src/openai/lib/_parsing/_responses.py` iterates `response.output` without checking for `None`. The chatgpt.com Codex backend sometimes sends `response.output: null` in the consolidated `response.completed` event, even when valid `response.output_item.done` events were streamed earlier in the same response.

This causes `TypeError: 'NoneType' object is not iterable`, killing the entire stream before the consumer can read the deltas.

## Fix

Use `(response.output or [])` to handle null output gracefully:

```python
# Before
for output in response.output:

# After  
for output in (response.output or []):
```

## Testing

- Import test passes
- No existing tests for `parse_response` to verify against
- The fix is a defensive null check that doesn't change behavior when output is present

Fixes #3325