### PR TITLE
fix: handle null response output in parser

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -7,7 +7,11 @@ from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
+from openai._types import omit
 from openai._utils import assert_signatures_in_sync
+from openai._models import construct_type_unchecked
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +43,38 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_parse_response_handles_null_output() -> None:
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp_null_output",
+            "object": "response",
+            "created_at": 1754925861,
+            "status": "completed",
+            "error": None,
+            "incomplete_details": None,
+            "instructions": None,
+            "max_output_tokens": None,
+            "model": "gpt-4o-mini-2024-07-18",
+            "output": None,
+            "parallel_tool_calls": True,
+            "previous_response_id": None,
+            "reasoning": {"effort": None, "summary": None},
+            "store": True,
+            "temperature": 1.0,
+            "text": {"format": {"type": "text"}},
+            "tool_choice": "auto",
+            "tools": [],
+            "top_p": 1.0,
+            "truncation": "disabled",
+        },
+    )
+
+    parsed = parse_response(text_format=omit, input_tools=omit, response=response)
+
+    assert parsed.output == []
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3325.

`parse_response` now treats a null `response.output` as an empty output list before iterating, avoiding a `TypeError` when a completed response event has `output: null`. Added a regression test that constructs that response shape and verifies parsing returns `output=[]`.

AI-assisted: yes.

## Additional context & links

Verification run locally:

- `.venv/bin/python -m pytest -o addopts='' tests/lib/responses/test_responses.py -q` -> 6 passed
- `.venv/bin/ruff format --check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py` -> 2 files already formatted
- `.venv/bin/ruff check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py` -> all checks passed
- `.venv/bin/mypy src/openai/lib/_parsing/_responses.py` -> success, no issues found in 1 source file
- `git diff --check` -> passed

Not run: full `./scripts/test`; the repository docs note most tests require the mock server, and this change is covered by the focused responses parser test file.
