### PR TITLE
build: Avoid publish approval for release-please checks

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -9,7 +9,6 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-python'
     runs-on: ubuntu-latest
-    environment: publish
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     permissions:


### PR DESCRIPTION
## Summary

- Remove `environment: publish` from the `release` job in the `Create releases` workflow.
- Keep the protected `publish` environment on the final upload-only PyPI publishing job.

## Why

After PR #3366 removed the scheduled trigger, pushes to `main` still entered the protected `publish` environment before release-please could check whether there was an actual release. That means ordinary main-branch changes could request publish approval even when release-please only needed to create or update a release PR.

With this change, the release-please check runs on `main` pushes without publish approval. The protected PyPI path remains gated by the downstream `build` and `publish` jobs, which only run when `releases_created == 'true'`.

## Validation

- Rebasing onto latest `origin/main` reduced the PR diff to a one-line workflow change.
- Parsed `.github/workflows/create-releases.yml` as YAML successfully.
- No runtime tests run; this is a GitHub Actions workflow configuration change.