### PR TITLE
fix: handle bare dict type annotations

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,10 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        if len(args) < 2:
+            return value
+
+        _, items_type = args  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,7 +180,11 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return data
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +350,11 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return data
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -655,6 +655,10 @@ def test_annotated_types() -> None:
     assert m.value == "foo"
 
 
+def test_construct_bare_dict_type() -> None:
+    assert construct_type(value={"key": "value"}, type_=dict) == {"key": "value"}
+
+
 def test_discriminated_unions_invalid_data() -> None:
     class A(BaseModel):
         type: Literal["a"]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -397,6 +397,18 @@ async def test_dictionary_items(use_async: bool) -> None:
     assert await transform({"foo": {"foo_baz": "bar"}}, Dict[str, DictItems], use_async) == {"foo": {"fooBaz": "bar"}}
 
 
+class BareDictParam(TypedDict):
+    metadata: dict
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dictionary_annotation(use_async: bool) -> None:
+    data = {"metadata": {"foo_bar": "bar"}}
+
+    assert await transform(data, BareDictParam, use_async) == data
+
+
 class TypedDictIterableUnionStr(TypedDict):
     foo: Annotated[Union[str, Iterable[Baz8]], PropertyInfo(alias="FOO")]
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -398,7 +398,8 @@ async def test_dictionary_items(use_async: bool) -> None:
 
 
 class BareDictParam(TypedDict):
-    metadata: dict
+    # the bare `dict` is the point of the regression: it must survive as-is
+    metadata: dict  # pyright: ignore[reportMissingTypeArgument]
 
 
 @parametrize


### PR DESCRIPTION
## Summary
- avoid indexing `get_args()` when request transform sees a bare `dict` annotation
- avoid unpacking empty `get_args()` in `construct_type(..., type_=dict)`
- add regressions for sync/async transform and model construction with unparameterized `dict`

Fixes #3338.
Fixes #3341.

## Tested
- Reproduced both failures locally before the patch with `PYTHONPATH=src`.
- `python -m pytest tests\test_transform.py::test_bare_dictionary_annotation tests\test_transform.py::test_dictionary_items tests\test_models.py::test_construct_bare_dict_type -q`
- `python -m pytest tests\test_transform.py tests\test_models.py -q`
- `python -m py_compile src\openai\_utils\_transform.py src\openai\_models.py tests\test_transform.py tests\test_models.py`
- `python -m ruff check src\openai\_utils\_transform.py src\openai\_models.py tests\test_transform.py tests\test_models.py`
- `python -m ruff format --check src\openai\_utils\_transform.py src\openai\_models.py tests\test_transform.py tests\test_models.py`
- `git diff --check`
