### PR TITLE
Guard response parsing against null output

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -7,7 +7,11 @@ from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
+from openai._types import omit
 from openai._utils import assert_signatures_in_sync
+from openai._models import construct_type_unchecked
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -61,3 +65,54 @@ def test_parse_method_definition_in_sync(sync: bool, client: OpenAI, async_clien
         checking_client.responses.parse,
         exclude_params={"tools"},
     )
+
+
+def test_parse_response_allows_null_output() -> None:
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp_689a0b2545288193953c892439b42e2800b2e36c65a1fd4b",
+            "object": "response",
+            "created_at": 1754925861,
+            "status": "completed",
+            "background": False,
+            "error": None,
+            "incomplete_details": None,
+            "instructions": None,
+            "max_output_tokens": None,
+            "max_tool_calls": None,
+            "model": "gpt-4o-mini-2024-07-18",
+            "output": None,
+            "parallel_tool_calls": True,
+            "previous_response_id": None,
+            "prompt_cache_key": None,
+            "reasoning": {"effort": None, "summary": None},
+            "safety_identifier": None,
+            "service_tier": "default",
+            "store": True,
+            "temperature": 1.0,
+            "text": {"format": {"type": "text"}, "verbosity": "medium"},
+            "tool_choice": "auto",
+            "tools": [],
+            "top_logprobs": 0,
+            "top_p": 1.0,
+            "truncation": "disabled",
+            "usage": {
+                "input_tokens": 14,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens": 50,
+                "output_tokens_details": {"reasoning_tokens": 0},
+                "total_tokens": 64,
+            },
+            "user": None,
+            "metadata": {},
+        },
+    )
+
+    parsed = parse_response(
+        text_format=omit,
+        input_tools=omit,
+        response=response,
+    )
+
+    assert parsed.output == []


### PR DESCRIPTION
## Summary

Guard `parse_response()` against `response.output == null` in `response.completed` payloads and add a regression test for the null-output case.

## Root Cause

`src/openai/lib/_parsing/_responses.py` assumes `response.output` is always iterable:

```py
for output in response.output:
```

When a backend sends `response.completed` with `output: null`, this raises `TypeError` during final response parsing even if earlier streamed output items were valid.

## Changes

- treat `response.output` as `response.output or []` in `parse_response()`
- add a focused unit test covering a `Response` object with `output=None`
- keep the fix confined to non-generated parser code plus one regression test

## Validation

- `python -m pytest tests/lib/responses/test_responses.py -p no:xdist -o addopts=""`
- `ruff check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py`

## Impact

This makes response parsing defensive against null `output` payloads while preserving existing behavior for normal responses with populated output lists.