### PR TITLE
fix: handle bare dict annotations in transform

### DIFF
--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,7 +180,11 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return data
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +350,11 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return data
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -154,6 +154,18 @@ class Bar7(TypedDict):
     foo: str
 
 
+class Foo7BareDict(TypedDict):
+    metadata: dict
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_typeddict_field(use_async: bool) -> None:
+    data = {"metadata": {"key": "value"}}
+
+    assert await transform(data, Foo7BareDict, use_async) == data
+
+
 @parametrize
 @pytest.mark.asyncio
 async def test_ignores_invalid_input(use_async: bool) -> None:


### PR DESCRIPTION
## Summary
- Return bare `dict` values unchanged in request transform logic when no value type argument is available.
- Add a sync/async regression test for `TypedDict` fields annotated as plain `dict`.

## Changes
| File | Change |
|------|--------|
| `src/openai/_utils/_transform.py` | Guard dict value type lookup when `get_args(dict)` is empty. |
| `tests/test_transform.py` | Cover bare `dict` fields in both sync and async transform paths. |

## Test Plan
- [x] `PYTHONPATH="$PWD/src" /home/ut006460@uos/project/openai-python/.venv/bin/python -m pytest tests/test_transform.py -k bare_dict_typeddict_field -n 0`
- [x] `PYTHONPATH="$PWD/src" /home/ut006460@uos/project/openai-python/.venv/bin/python -m pytest tests/test_transform.py -n 0`
- [x] `/home/ut006460@uos/project/openai-python/.venv/bin/ruff format tests/test_transform.py src/openai/_utils/_transform.py`
- [x] `/home/ut006460@uos/project/openai-python/.venv/bin/ruff check tests/test_transform.py src/openai/_utils/_transform.py`

Fixes #3338