### PR TITLE
fix: handle bare dict annotations in construct_type

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,10 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        if len(args) < 2:
+            return value
+
+        _, items_type = args  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -133,6 +133,18 @@ def test_raw_dictionary() -> None:
     assert cast(Any, m.nested) is False
 
 
+def test_bare_dictionary() -> None:
+    class NestedModel(BaseModel):
+        nested: dict
+
+    m = NestedModel.construct(nested={"hello": {"world": True}})
+    assert m.nested == {"hello": {"world": True}}
+
+    # mismatched types
+    m = NestedModel.construct(nested=False)
+    assert cast(Any, m.nested) is False
+
+
 def test_nested_dictionary_model() -> None:
     class NestedModel(BaseModel):
         nested: Dict[str, BasicModel]


### PR DESCRIPTION
## Summary
- Return bare `dict` values unchanged during model construction when no value type argument is available.
- Add a regression test for `BaseModel.construct()` with a field annotated as plain `dict`.

## Changes
| File | Change |
|------|--------|
| `src/openai/_models.py` | Guard dict value type unpacking when `get_args(dict)` is empty. |
| `tests/test_models.py` | Cover model construction for bare `dict` fields. |

## Test Plan
- [x] `PYTHONPATH="$PWD/src" /home/ut006460@uos/project/openai-python/.venv/bin/python -m pytest tests/test_models.py -k bare_dictionary -n 0`
- [x] `PYTHONPATH="$PWD/src" /home/ut006460@uos/project/openai-python/.venv/bin/python -m pytest tests/test_models.py -n 0`
- [x] `/home/ut006460@uos/project/openai-python/.venv/bin/ruff format tests/test_models.py src/openai/_models.py`
- [x] `/home/ut006460@uos/project/openai-python/.venv/bin/ruff check tests/test_models.py src/openai/_models.py`

Fixes #3341