### PR TITLE
build: fix release workflow permissions

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Restore `contents: write` for the `Create releases` workflow's `release` job.
- Keep the split build/publish shape from trusted publishing intact: build remains read-only, and the PyPI upload job keeps scoped OIDC permissions.

## Why

The `release: 2.41.1` run failed before build or PyPI upload, in `stainless-api/trigger-release-please`, leaving a partial release state: the repo version/changelog were bumped, but no `v2.41.1` GitHub tag/release or PyPI package exists.

The last successful release run had write-capable contents permissions, while the failing run had only `contents: read`. The release job is responsible for creating GitHub release state, so this restores the minimum permission that job should have without broadening the build or publish jobs.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/create-releases.yml"); puts "yaml ok"'`

`actionlint` was not available locally.