### PR TITLE
[codex] Use CI environment for examples API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
   examples:
     timeout-minutes: 10
     name: examples
+    environment: CI
     runs-on: ${{ github.repository == 'stainless-sdks/openai-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.repository == 'openai/openai-python' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
 


### PR DESCRIPTION
## Summary
- add the `CI` environment to the `examples` job that consumes `secrets.OPENAI_API_KEY`
- keep the change scoped to the only workflow job that references `OPENAI_API_KEY`

## Validation
- `ruby -r psych -e 'Psych.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`
- `git diff --cached --check`