### PR TITLE
test: Use CI environment for examples API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
   examples:
     timeout-minutes: 10
     name: examples
+    environment: ci
     runs-on: ${{ github.repository == 'stainless-sdks/openai-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.repository == 'openai/openai-python' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
 

--- a/examples/async_demo.py
+++ b/examples/async_demo.py
@@ -9,13 +9,21 @@ client = AsyncOpenAI()
 
 
 async def main() -> None:
-    stream = await client.completions.create(
-        model="gpt-3.5-turbo-instruct",
-        prompt="Say this is a test",
+    stream = await client.chat.completions.create(
+        model="gpt-5.5",
+        messages=[
+            {
+                "role": "user",
+                "content": "Say this is a test",
+            },
+        ],
         stream=True,
     )
-    async for completion in stream:
-        print(completion.choices[0].text, end="")
+    async for chunk in stream:
+        if not chunk.choices:
+            continue
+
+        print(chunk.choices[0].delta.content, end="")
     print()
 
 

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -8,7 +8,7 @@ client = OpenAI()
 # Non-streaming:
 print("----- standard request -----")
 completion = client.chat.completions.create(
-    model="gpt-4",
+    model="gpt-5.5",
     messages=[
         {
             "role": "user",
@@ -21,7 +21,7 @@ print(completion.choices[0].message.content)
 # Streaming:
 print("----- streaming request -----")
 stream = client.chat.completions.create(
-    model="gpt-4",
+    model="gpt-5.5",
     messages=[
         {
             "role": "user",
@@ -40,7 +40,7 @@ print()
 # Response headers:
 print("----- custom response headers test -----")
 response = client.chat.completions.with_raw_response.create(
-    model="gpt-4",
+    model="gpt-5.5",
     messages=[
         {
             "role": "user",


### PR DESCRIPTION
## Summary
- add the `ci` environment to the `examples` job that consumes `secrets.OPENAI_API_KEY`
- keep the environment scoped to the only workflow job that needs `OPENAI_API_KEY`
- update the runnable sync/async examples to use the current README chat model path so the CI key can exercise them

## Validation
- `ruby -r psych -e 'Psych.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`
- `python -m py_compile examples/demo.py examples/async_demo.py`
- `git diff --check`

## Notes
- A fork-based PR could not access secrets (`Secret source: None`), so this PR uses an in-repo branch for the environment-backed secret check.
- After adding the `ci` environment, the examples job received `OPENAI_API_KEY` and then exposed the legacy `gpt-4` access failure; the examples now match the README model.