### PR TITLE
fix: sanitize NO_PROXY newlines before httpx client init

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import json
 import time
@@ -831,11 +832,27 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+def _sanitize_proxy_env() -> None:
+    """Sanitize proxy-related environment variables that may contain newline characters.
+
+    Some environments (Docker .env files, shell scripts) introduce newline characters
+    into NO_PROXY / no_proxy values. httpx only splits these by comma, so newlines
+    end up embedded in hostnames and trigger ``httpx.InvalidURL``.
+    """
+    for key in ("NO_PROXY", "no_proxy"):
+        value = os.environ.get(key)
+        if value and "\n" in value:
+            os.environ[key] = ",".join(
+                part.strip() for part in value.replace("\n", ",").split(",") if part.strip()
+            )
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        _sanitize_proxy_env()
         super().__init__(**kwargs)
 
 
@@ -1423,6 +1440,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        _sanitize_proxy_env()
         super().__init__(**kwargs)
 
 
@@ -1440,7 +1458,7 @@ else:
             kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
             kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
             kwargs.setdefault("follow_redirects", True)
-
+            _sanitize_proxy_env()
             super().__init__(**kwargs)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1292,6 +1292,48 @@ class TestOpenAI:
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
 
+    def test_no_proxy_newline_sanitized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        client = DefaultHttpxClient()
+        assert client is not None
+        assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
+
+    def test_no_proxy_lowercase_newline_sanitized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("no_proxy", "localhost\n192.168.1.1\n10.0.0.0/8")
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+
+        client = DefaultHttpxClient()
+        assert client is not None
+        assert os.environ["no_proxy"] == "localhost,192.168.1.1,10.0.0.0/8"
+
+    def test_no_proxy_without_newlines_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost,192.168.1.1")
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        client = DefaultHttpxClient()
+        assert client is not None
+        assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions
@@ -2551,6 +2593,48 @@ class TestAsyncOpenAI:
         mounts = tuple(client._mounts.items())
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
+
+    async def test_no_proxy_newline_sanitized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        client = DefaultAsyncHttpxClient()
+        assert client is not None
+        assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
+
+    async def test_no_proxy_lowercase_newline_sanitized(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("no_proxy", "localhost\n192.168.1.1\n10.0.0.0/8")
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("NO_PROXY", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+
+        client = DefaultAsyncHttpxClient()
+        assert client is not None
+        assert os.environ["no_proxy"] == "localhost,192.168.1.1,10.0.0.0/8"
+
+    async def test_no_proxy_without_newlines_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_PROXY", "localhost,192.168.1.1")
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("ALL_PROXY", raising=False)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("https_proxy", raising=False)
+        monkeypatch.delenv("all_proxy", raising=False)
+        monkeypatch.delenv("no_proxy", raising=False)
+
+        client = DefaultAsyncHttpxClient()
+        assert client is not None
+        assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:


### PR DESCRIPTION
## Summary

- Fixes `httpx.InvalidURL` when `NO_PROXY` or `no_proxy` environment variables contain newline characters (common in Docker `.env` files, shell scripts, and CI environments)
- Adds a `_sanitize_proxy_env()` helper in `_base_client.py` that replaces newlines with commas in `NO_PROXY`/`no_proxy` before httpx reads the environment
- Wired into all three default client constructors (`_DefaultHttpxClient`, `_DefaultAsyncHttpxClient`, `_DefaultAioHttpClient`)

## Context

httpx's `get_environment_proxies()` only splits `NO_PROXY` by comma, not by newline. When a newline is present, it becomes part of the hostname and triggers URL validation failure. Since httpx is not currently accepting external PRs, this fix sanitizes at the openai-python layer.

Closes #3303

## Test plan

- [x] Added 3 sync tests (`TestOpenAI`): newline in `NO_PROXY`, newline in `no_proxy`, no-newline passthrough
- [x] Added 3 async tests (`TestAsyncOpenAI`): same coverage
- [x] Verified existing `test_proxy_environment_variables` tests still pass (both sync and async)
- [x] All 8 proxy-related tests pass