### PR TITLE
fix(realtime): transform pre-connect manager.send dict events

### DIFF
--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -604,7 +604,7 @@ class AsyncRealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 
@@ -1072,7 +1072,7 @@ class RealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 

--- a/tests/test_realtime_manager_send.py
+++ b/tests/test_realtime_manager_send.py
@@ -1,0 +1,15 @@
+import json
+
+from openai import OpenAI
+from openai._types import omit
+
+
+def test_preconnect_manager_send_strips_omit() -> None:
+    client = OpenAI(api_key="sk-test", base_url="http://127.0.0.1:4010")
+    manager = client.realtime.connect(model="gpt-4o-realtime-preview")
+    manager.send({"type": "response.cancel", "event_id": omit})
+    queued = manager._RealtimeConnectionManager__send_queue.drain()  # type: ignore[attr-defined]
+    assert len(queued) == 1
+    payload = json.loads(queued[0])
+    assert payload == {"type": "response.cancel"}
+    assert "event_id" not in payload


### PR DESCRIPTION
Fixes #3402

Pre-connect manager.send() now runs maybe_transform() before json.dumps().

Test: tests/test_realtime_manager_send.py — passed locally