### PR TITLE
Handle null response output in parser

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_parse_response.py
+++ b/tests/lib/responses/test_parse_response.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from openai._types import NOT_GIVEN
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
+
+
+def test_parse_response_handles_null_output() -> None:
+    response = Response.construct(
+        id="resp_123",
+        object="response",
+        created_at=0,
+        status="completed",
+        output=None,
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+
+    parsed = parse_response(
+        text_format=NOT_GIVEN,
+        input_tools=NOT_GIVEN,
+        response=response,
+    )
+
+    assert parsed.output == []


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Handle response.output = None in parse_response() by treating it the same as an empty output list. This prevents the parser from raising TypeError when a terminal Responses payload has a null output field.

The PR also adds a focused regression test that constructs a completed Response with output=None and verifies parsing returns an empty output list.

Closes #3312.

## Additional context & links

Local checks run:

- PYTHONPATH=src python -m pytest tests/lib/responses/test_parse_response.py -q -o addopts=""
- PYTHONPATH=src python -m ruff check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_parse_response.py
- python -m ruff format src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py tests/lib/responses/test_parse_response.py
