### PR TITLE
fix: sanitize newline characters in NO_PROXY env var before httpx reads it

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -849,7 +849,8 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        _sanitize_no_proxy_env_vars()
+        if kwargs.get("trust_env", True):
+            _sanitize_no_proxy_env_vars()
         super().__init__(**kwargs)
 
 
@@ -1437,7 +1438,8 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        _sanitize_no_proxy_env_vars()
+        if kwargs.get("trust_env", True):
+            _sanitize_no_proxy_env_vars()
         super().__init__(**kwargs)
 
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 import json
 import time
@@ -831,11 +832,24 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+def _sanitize_no_proxy_env_vars() -> None:
+    # Docker environments and .env files sometimes inject newline characters into
+    # NO_PROXY, which httpx's URL parser then rejects as invalid. Normalize any
+    # newlines to commas so the value is well-formed before httpx reads it.
+    for key in ("NO_PROXY", "no_proxy"):
+        value = os.environ.get(key)
+        if value and "\n" in value:
+            os.environ[key] = ",".join(
+                entry.strip() for entry in value.replace("\n", ",").split(",") if entry.strip()
+            )
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        _sanitize_no_proxy_env_vars()
         super().__init__(**kwargs)
 
 
@@ -1423,6 +1437,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        _sanitize_no_proxy_env_vars()
         super().__init__(**kwargs)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1302,6 +1302,13 @@ class TestOpenAI:
         assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
         assert os.environ["no_proxy"] == "internal.host,10.0.0.1"
 
+    def test_no_proxy_newline_skipped_when_trust_env_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # When trust_env=False, httpx never reads NO_PROXY so we must not
+        # mutate os.environ unnecessarily.
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+        DefaultHttpxClient(trust_env=False)
+        assert os.environ["NO_PROXY"] == "localhost\n192.168.1.1"
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions
@@ -2571,6 +2578,13 @@ class TestAsyncOpenAI:
         DefaultAsyncHttpxClient()
         assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
         assert os.environ["no_proxy"] == "internal.host,10.0.0.1"
+
+    async def test_no_proxy_newline_skipped_when_trust_env_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # When trust_env=False, httpx never reads NO_PROXY so we must not
+        # mutate os.environ unnecessarily.
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+        DefaultAsyncHttpxClient(trust_env=False)
+        assert os.environ["NO_PROXY"] == "localhost\n192.168.1.1"
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1292,6 +1292,16 @@ class TestOpenAI:
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
 
+    def test_no_proxy_newline_sanitization(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Docker and .env files can inject newlines into NO_PROXY, which httpx
+        # rejects as invalid non-printable characters in URLs.
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+        monkeypatch.setenv("no_proxy", "internal.host\n10.0.0.1")
+        # Must not raise httpx.InvalidURL
+        DefaultHttpxClient()
+        assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
+        assert os.environ["no_proxy"] == "internal.host,10.0.0.1"
+
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
         # Ensure that the client can be initialized without any exceptions
@@ -2551,6 +2561,16 @@ class TestAsyncOpenAI:
         mounts = tuple(client._mounts.items())
         assert len(mounts) == 1
         assert mounts[0][0].pattern == "https://"
+
+    async def test_no_proxy_newline_sanitization(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Docker and .env files can inject newlines into NO_PROXY, which httpx
+        # rejects as invalid non-printable characters in URLs.
+        monkeypatch.setenv("NO_PROXY", "localhost\n192.168.1.1")
+        monkeypatch.setenv("no_proxy", "internal.host\n10.0.0.1")
+        # Must not raise httpx.InvalidURL
+        DefaultAsyncHttpxClient()
+        assert os.environ["NO_PROXY"] == "localhost,192.168.1.1"
+        assert os.environ["no_proxy"] == "internal.host,10.0.0.1"
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:


### PR DESCRIPTION
Closes #3303

---

Docker environments and `.env` files sometimes contain `NO_PROXY` values with newline-separated entries (e.g. `NO_PROXY=localhost\n192.168.1.1`). The stdlib's `getproxies()` returns the raw value including the newline; httpx then splits only on commas, leaving the newline embedded in the hostname pattern. When httpx initializes its URL structures, it rejects the newline as an invalid non-printable ASCII character, raising `httpx.InvalidURL` before the client can be used at all.

The fix is in `_sanitize_no_proxy_env_vars()`, called from both `_DefaultHttpxClient.__init__` and `_DefaultAsyncHttpxClient.__init__` before delegating to httpx. It replaces any newlines in `NO_PROXY`/`no_proxy` with commas and strips empty entries, normalizing the value in-place so httpx always sees a well-formed string. The sanitization is idempotent — clean values pass through unchanged.

Unit tests added for both sync and async clients using `pytest`'s `monkeypatch` to inject a newline-containing `NO_PROXY` value and assert it is normalized and the client initializes without error.

*This contribution was made with AI-agent assistance (Claude Code).*