### PR TITLE
fix: handle bare list annotations in construct_type

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -678,6 +678,9 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
+        if not args:
+            return value
+
         inner_type = args[0]  # List[inner_type]
         return [construct_type(value=entry, type_=inner_type) for entry in value]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -121,6 +121,10 @@ def test_list_mismatched_type() -> None:
     assert cast(Any, m.nested) is False
 
 
+def test_bare_list_type() -> None:
+    assert construct_type(value=[{"hello": "world"}], type_=list) == [{"hello": "world"}]
+
+
 def test_raw_dictionary() -> None:
     class NestedModel(BaseModel):
         nested: Dict[str, str]


### PR DESCRIPTION
Closed in favor of #3414, which uses the updated branch naming.