### PR TITLE
fix(parsing): handle None response.output in parse_response to preven…

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
Fixes #3325

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`parse_response` in `src/openai/lib/_parsing/_responses.py` iterates directly over `response.output` without guarding against `None`. When the Responses API returns a response with `output=null` (e.g. a content-filtered or empty response), this crashes with:

```
TypeError: 'NoneType' object is not iterable
```

**Fix:** Replace:
```python
for output in response.output:
```

With:
```python
for output in (response.output or []):
```

This makes the behavior safe when `response.output` is `None`, treating it as an empty list and returning an empty `ParsedResponse`.

## Additional context & links

- Issue: #3325
- File: `src/openai/lib/_parsing/_responses.py` line 61
- Reproducible with any Responses API call where `output` is null