### PR TITLE
fix: use running loop in audio helpers

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -71,7 +71,7 @@ class LocalAudioPlayer:
         else:
             audio_content = await self._tts_response_to_buffer(input)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         idx = 0
 
@@ -105,7 +105,7 @@ class LocalAudioPlayer:
         self,
         buffer_stream: AsyncGenerator[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None], None],
     ) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         buffer_queue: queue.Queue[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None]] = queue.Queue(maxsize=50)
 

--- a/src/openai/helpers/microphone.py
+++ b/src/openai/helpers/microphone.py
@@ -54,7 +54,7 @@ class Microphone(Generic[DType]):
     async def record(self, return_ndarray: None = ...) -> FileTypes: ...
 
     async def record(self, return_ndarray: Union[bool, None] = False) -> Union[npt.NDArray[DType], FileTypes]:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         self.buffer_chunks: list[npt.NDArray[DType]] = []
         start_time = time.perf_counter()


### PR DESCRIPTION
Problem: the async microphone and local audio playback helpers call asyncio.get_event_loop() from inside async methods. get_event_loop() is deprecated in this usage and can behave differently depending on event loop policy.

Before / after: before, the helpers asked the policy for an event loop even though they were already running in one. After, they use asyncio.get_running_loop(), preserving the callback thread handoff behavior while binding to the active loop explicitly.

Verification: python -m py_compile src\openai\helpers\microphone.py src\openai\helpers\local_audio_player.py