### PR TITLE
fix(parsing): guard against None response.output in parse_response and streaming accumulator

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -357,9 +357,15 @@ class ResponseStreamState(Generic[TextFormatT]):
             if output.type == "function_call":
                 output.arguments += event.delta
         elif event.type == "response.completed":
+            completed_response = event.response
+            if completed_response.output is None and snapshot.output:
+                completed_response = construct_type_unchecked(
+                    type_=type(event.response),
+                    value={**event.response.to_dict(), "output": [item.to_dict() for item in snapshot.output]},
+                )
             self._completed_response = parse_response(
                 text_format=self._text_format,
-                response=event.response,
+                response=completed_response,
                 input_tools=self._input_tools,
             )
 


### PR DESCRIPTION
## Summary

When a backend (e.g. the Codex endpoint) sends `response.output: null` in the terminal `response.completed` SSE event, the SDK crashes with `TypeError: 'NoneType' object is not iterable` because `parse_response()` iterates `response.output` unconditionally.

This PR applies two complementary fixes:

### 1. Null guard in `parse_response()` (`src/openai/lib/_parsing/_responses.py`)

```diff
-    for output in response.output:
+    for output in (response.output or []):
```

Prevents the `TypeError` for any caller — streaming or non-streaming — when `response.output` is `None`.

### 2. Snapshot fallback in the streaming accumulator (`src/openai/lib/streaming/responses/_responses.py`)

When the `response.completed` payload has `output=null`, but the accumulator's snapshot already has the reconstructed output items from the preceding `response.output_item.added/done` events, use those items instead of losing the data:

```diff
         elif event.type == "response.completed":
-            self._completed_response = parse_response(
-                text_format=self._text_format,
-                response=event.response,
-                input_tools=self._input_tools,
-            )
+            completed_response = event.response
+            if completed_response.output is None and snapshot.output:
+                completed_response = construct_type_unchecked(
+                    type_=type(event.response),
+                    value={**event.response.to_dict(), "output": [item.to_dict() for item in snapshot.output]},
+                )
+            self._completed_response = parse_response(
+                text_format=self._text_format,
+                response=completed_response,
+                input_tools=self._input_tools,
+            )
```

Fix 1 alone prevents the crash but returns `output=[]`, discarding all streamed items. Fix 2 preserves the actual content the user already received over the wire.

## Fixes

Closes #3314
Closes #3321
Closes #3325