### PR TITLE
fix: guard against IndexError/ValueError when bare dict has no type args

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,11 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        _dict_args = get_args(type_)
+        if len(_dict_args) < 2:
+            return value
+
+        _, items_type = _dict_args  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,7 +180,10 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _dict_args = get_args(stripped_type)
+        if not _dict_args:
+            return data
+        items_type = _dict_args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +349,10 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _dict_args = get_args(stripped_type)
+        if not _dict_args:
+            return data
+        items_type = _dict_args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (


### PR DESCRIPTION
## Summary

Two crashes when a TypedDict field or model field uses a bare `dict` (no type params).

### 1. IndexError in `_transform_recursive` (`_utils/_transform.py`) — fixes #3338

`get_args(bare_dict)` returns `()`, so `[1]` index access crashes.
Applied to both sync and async paths.

### 2. ValueError in `construct_type` (`_models.py`) — fixes #3341

`_, items_type = get_args(bare_dict)` raises `ValueError: not enough values to unpack`.

Both are simple early-return guards with zero behaviour change for `dict[K, V]`.

## Fixes

Closes #3338
Closes #3341