### PR TITLE
Fix response annotation event typing

### DIFF
--- a/src/openai/types/responses/response_output_text_annotation_added_event.py
+++ b/src/openai/types/responses/response_output_text_annotation_added_event.py
@@ -3,6 +3,7 @@
 from typing_extensions import Literal
 
 from ..._models import BaseModel
+from .response_output_text import Annotation
 
 __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 
@@ -10,7 +11,7 @@ __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 class ResponseOutputTextAnnotationAddedEvent(BaseModel):
     """Emitted when an annotation is added to output text content."""
 
-    annotation: object
+    annotation: Annotation
     """The annotation object being added. (See annotation schema for details.)"""
 
     annotation_index: int

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,8 @@ from pydantic import Field
 from openai._utils import PropertyInfo
 from openai._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
 from openai._models import DISCRIMINATOR_CACHE, BaseModel, EagerIterable, construct_type
+from openai.types.responses.response_output_text import AnnotationURLCitation
+from openai.types.responses.response_output_text_annotation_added_event import ResponseOutputTextAnnotationAddedEvent
 
 
 class BasicModel(BaseModel):
@@ -167,6 +169,30 @@ def test_strict_validation_unknown_fields() -> None:
     assert cast(Any, model).user == "Robert"
 
     assert model_dump(model) == {"foo": "hello!", "user": "Robert"}
+
+
+def test_response_output_text_annotation_added_event_annotation_type() -> None:
+    event = parse_obj(
+        ResponseOutputTextAnnotationAddedEvent,
+        {
+            "annotation": {
+                "end_index": 42,
+                "start_index": 10,
+                "title": "OpenAI",
+                "type": "url_citation",
+                "url": "https://www.openai.com/",
+            },
+            "annotation_index": 0,
+            "content_index": 0,
+            "item_id": "msg_123",
+            "output_index": 0,
+            "sequence_number": 1,
+            "type": "response.output_text.annotation.added",
+        },
+    )
+
+    assert isinstance(event.annotation, AnnotationURLCitation)
+    assert event.annotation.url == "https://www.openai.com/"
 
 
 def test_aliases() -> None:


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Type `ResponseOutputTextAnnotationAddedEvent.annotation` as the existing `Annotation` union instead of `object`.
- Add a regression test that parses a `url_citation` annotation event into `AnnotationURLCitation`.

## Additional context & links

Addresses #3419.

Validation:

- `uv run pytest tests/test_models.py -q -k response_output_text_annotation_added_event_annotation_type`
- `uv run pytest tests/test_models.py -q`
- `uv run ruff check src/openai/types/responses/response_output_text_annotation_added_event.py tests/test_models.py`
- `uv run scripts/run-pyright src/openai/types/responses/response_output_text_annotation_added_event.py tests/test_models.py`
