### PR TITLE
fix: merge indexed streaming deltas on first chunk

### DIFF
--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -977,16 +977,28 @@ def accumulate_event(
     return current_message_snapshot, new_content
 
 
+def _has_indexed_entries(value: object) -> bool:
+    return is_list(value) and any(is_dict(entry) and "index" in entry for entry in value)
+
+
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
-            acc[key] = delta_value
-            continue
+            if _has_indexed_entries(delta_value):
+                acc[key] = []
+            else:
+                acc[key] = delta_value
+                continue
 
         acc_value = acc[key]
         if acc_value is None:
-            acc[key] = delta_value
-            continue
+            if _has_indexed_entries(delta_value):
+                acc_value = []
+            else:
+                acc[key] = delta_value
+                continue
+        else:
+            acc_value = acc[key]
 
         # the `index` property is used in arrays of objects so it should
         # not be accumulated like other values e.g.
@@ -1007,7 +1019,9 @@ def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> 
         elif is_list(acc_value) and is_list(delta_value):
             # for lists of non-dictionary items we'll only ever get new entries
             # in the array, existing entries will never be changed
-            if all(isinstance(x, (str, int, float)) for x in acc_value):
+            if all(isinstance(x, (str, int, float)) for x in acc_value) and all(
+                isinstance(x, (str, int, float)) for x in delta_value
+            ):
                 acc_value.extend(delta_value)
                 continue
 

--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -3,16 +3,28 @@ from __future__ import annotations
 from ..._utils import is_dict, is_list
 
 
+def _has_indexed_entries(value: object) -> bool:
+    return is_list(value) and any(is_dict(entry) and "index" in entry for entry in value)
+
+
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
-            acc[key] = delta_value
-            continue
+            if _has_indexed_entries(delta_value):
+                acc[key] = []
+            else:
+                acc[key] = delta_value
+                continue
 
         acc_value = acc[key]
         if acc_value is None:
-            acc[key] = delta_value
-            continue
+            if _has_indexed_entries(delta_value):
+                acc_value = []
+            else:
+                acc[key] = delta_value
+                continue
+        else:
+            acc_value = acc[key]
 
         # the `index` property is used in arrays of objects so it should
         # not be accumulated like other values e.g.
@@ -33,7 +45,9 @@ def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> 
         elif is_list(acc_value) and is_list(delta_value):
             # for lists of non-dictionary items we'll only ever get new entries
             # in the array, existing entries will never be changed
-            if all(isinstance(x, (str, int, float)) for x in acc_value):
+            if all(isinstance(x, (str, int, float)) for x in acc_value) and all(
+                isinstance(x, (str, int, float)) for x in delta_value
+            ):
                 acc_value.extend(delta_value)
                 continue
 

--- a/tests/lib/test_streaming_deltas.py
+++ b/tests/lib/test_streaming_deltas.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from openai.lib.streaming._deltas import accumulate_delta
+from openai.lib.streaming._assistants import accumulate_delta as accumulate_assistant_delta
+
+
+@pytest.mark.parametrize("accumulator", [accumulate_delta, accumulate_assistant_delta])
+def test_accumulate_delta_merges_duplicate_index_entries_in_initial_list(
+    accumulator: Callable[[dict[object, object], dict[object, object]], dict[object, object]],
+) -> None:
+    acc: dict[object, object] = {}
+
+    accumulator(
+        acc,
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "id": "call_abc",
+                    "function": {"name": "list_files"},
+                    "type": "function",
+                },
+                {
+                    "index": 0,
+                    "function": {"arguments": '{"path"'},
+                },
+            ]
+        },
+    )
+    accumulator(
+        acc,
+        {
+            "tool_calls": [
+                {
+                    "index": 0,
+                    "function": {"arguments": ': "."}'},
+                }
+            ]
+        },
+    )
+
+    assert acc["tool_calls"] == [
+        {
+            "index": 0,
+            "id": "call_abc",
+            "function": {
+                "name": "list_files",
+                "arguments": '{"path": "."}',
+            },
+            "type": "function",
+        }
+    ]


### PR DESCRIPTION
Fixes #3201.

## Summary

`accumulate_delta()` already knows how to merge list entries by their logical `index`, but the first value for a key was assigned wholesale before that logic ran. If the first streamed `tool_calls` chunk contained multiple entries with the same `index`, the duplicate entries stayed as separate physical list elements and later argument fragments merged into only one of them.

This updates both streaming delta accumulators to route initial indexed lists through the existing indexed merge path instead of storing them wholesale. It also keeps primitive list accumulation on the primitive-list path by checking the incoming delta list as well.

## Validation

I first added the regression test and confirmed it failed on current `origin/main`:

```text
2 failed
```

Then after the fix:

```text
PYTHONPATH=src uv run --with pytest --with pytest-asyncio --with pytest-xdist pytest tests/lib/test_streaming_deltas.py -q
# 2 passed
```

Related targeted checks:

```text
env -u ALL_PROXY -u HTTPS_PROXY -u HTTP_PROXY -u all_proxy -u https_proxy -u http_proxy \
  PYTHONPATH=src uv run --with pytest --with pytest-asyncio --with pytest-xdist --with rich --with respx --with inline-snapshot \
  pytest tests/lib/test_streaming_deltas.py tests/lib/chat/test_completions_streaming.py tests/lib/test_assistants.py -q
# 25 passed

PYTHONPATH=src uv run --with ruff ruff format --check src/openai/lib/streaming/_deltas.py src/openai/lib/streaming/_assistants.py tests/lib/test_streaming_deltas.py
# 3 files already formatted

PYTHONPATH=src uv run --with ruff ruff check src/openai/lib/streaming/_deltas.py src/openai/lib/streaming/_assistants.py tests/lib/test_streaming_deltas.py
# All checks passed

git diff --check
# clean
```
