### PR TITLE
Fix parsing responses with null output

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -7,7 +7,11 @@ from respx import MockRouter
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
+from openai._types import omit
 from openai._utils import assert_signatures_in_sync
+from openai._models import construct_type_unchecked
+from openai.types.responses import Response
+from openai.lib._parsing._responses import parse_response
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -39,6 +43,48 @@ def test_output_text(client: OpenAI, respx_mock: MockRouter) -> None:
     assert response.output_text == snapshot(
         "I can't provide real-time updates, but you can easily check the current weather in San Francisco using a weather website or app. Typically, San Francisco has cool, foggy summers and mild winters, so it's good to be prepared for variable weather!"
     )
+
+
+def test_parse_response_handles_null_output() -> None:
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "background": False,
+            "error": None,
+            "incomplete_details": None,
+            "instructions": None,
+            "max_output_tokens": None,
+            "max_tool_calls": None,
+            "model": "gpt-test",
+            "output": None,
+            "parallel_tool_calls": True,
+            "previous_response_id": None,
+            "prompt_cache_key": None,
+            "reasoning": {"effort": None, "summary": None},
+            "safety_identifier": None,
+            "service_tier": "default",
+            "store": True,
+            "temperature": 1.0,
+            "text": {"format": {"type": "text"}, "verbosity": "medium"},
+            "tool_choice": "auto",
+            "tools": [],
+            "top_logprobs": 0,
+            "top_p": 1.0,
+            "truncation": "disabled",
+            "usage": None,
+            "user": None,
+            "metadata": {},
+        },
+    )
+
+    parsed = parse_response(text_format=omit, input_tools=omit, response=response)
+
+    assert parsed.output == []
+    assert parsed.to_dict()["output"] == []
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
Fixes #3325.

## Summary
- Treat a wire-level `response.output: null` as an empty output list when parsing Responses API objects.
- Preserve the existing parsing path for normal non-empty output lists.
- Add a regression test that constructs the backend edge case directly and asserts the parsed response has `output == []` instead of raising `TypeError`.

## Root Cause
`parse_response()` iterated `response.output` directly. If a completed response event contained `output: null`, the stream accumulator called into `parse_response()` and raised `TypeError: 'NoneType' object is not iterable`.\n\n## Duplicate Check\nI checked for existing open/closed PRs with these searches before opening this:\n- `gh search prs --repo openai/openai-python --state open '3325 parse_response response.output null completed event'`\n- `gh search prs --repo openai/openai-python --state open '"response.output" null parse_response'`\n- `gh search prs --repo openai/openai-python --state open '"NoneType" "not iterable" responses'`\n- `gh search prs --repo openai/openai-python --state closed '"response.output" null parse_response'`\n\nNo duplicate PRs showed up.\n\n## Validation\n- Reproduced before the fix with a constructed `Response` whose `output` is `None`: `TypeError 'NoneType' object is not iterable`.\n- `uv run --with pytest --with pytest-asyncio --with respx --with inline-snapshot pytest -o addopts='\ tests/lib/responses/test_responses.py::test_parse_response_handles_null_output -q` -> `1 passed in 0.10s`\n- `uv run --with ruff ruff check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py` -> `All checks passed!`\n- `uv run python -m py_compile src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py` -> passed\n- `git diff --check` -> clean