### PR TITLE
Fix responses stream null output item handling

### DIFF
--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -328,18 +328,20 @@ class ResponseStreamState(Generic[TextFormatT]):
             return self._create_initial_response(event)
 
         if event.type == "response.output_item.added":
-            if event.item.type == "function_call":
+            item = event.item
+            if item is None:
+                return snapshot
+
+            if item.type == "function_call":
                 snapshot.output.append(
-                    construct_type_unchecked(
-                        type_=cast(Any, ParsedResponseFunctionToolCall), value=event.item.to_dict()
-                    )
+                    construct_type_unchecked(type_=cast(Any, ParsedResponseFunctionToolCall), value=item.to_dict())
                 )
-            elif event.item.type == "message":
+            elif item.type == "message":
                 snapshot.output.append(
-                    construct_type_unchecked(type_=cast(Any, ParsedResponseOutputMessage), value=event.item.to_dict())
+                    construct_type_unchecked(type_=cast(Any, ParsedResponseOutputMessage), value=item.to_dict())
                 )
             else:
-                snapshot.output.append(event.item)
+                snapshot.output.append(item)
         elif event.type == "response.content_part.added":
             output = snapshot.output[event.output_index]
             if output.type == "message":

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -8,6 +8,8 @@ from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
 from openai._utils import assert_signatures_in_sync
+from openai.types.responses import Response, ResponseCreatedEvent, ResponseOutputItemAddedEvent
+from openai.lib.streaming.responses._responses import ResponseStreamState
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -61,3 +63,35 @@ def test_parse_method_definition_in_sync(sync: bool, client: OpenAI, async_clien
         checking_client.responses.parse,
         exclude_params={"tools"},
     )
+
+
+def test_response_stream_ignores_null_output_item_added() -> None:
+    response = Response.model_construct(
+        id="resp_123",
+        created_at=0.0,
+        model="gpt-4o",
+        object="response",
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+    )
+    state = ResponseStreamState(input_tools=[], text_format=str)
+
+    state.handle_event(
+        ResponseCreatedEvent.model_construct(
+            type="response.created",
+            sequence_number=0,
+            response=response,
+        )
+    )
+    events = state.handle_event(
+        ResponseOutputItemAddedEvent.model_construct(
+            type="response.output_item.added",
+            sequence_number=1,
+            output_index=0,
+            item=None,
+        )
+    )
+
+    assert [event.type for event in events] == ["response.output_item.added"]


### PR DESCRIPTION
Fixes #3125.

## Summary

`ResponseStreamState.accumulate_event()` assumes every `response.output_item.added` event has an `item`. Some OpenAI-compatible Responses streams can send `item: null`; when that happens the SDK currently raises before user code can recover:

```text
AttributeError: 'NoneType' object has no attribute 'type'
```

This treats a null added item as a no-op for the accumulated snapshot, matching the fact that there is no concrete output item to append.

## Validation

I reproduced the failure on current `origin/main` by feeding `ResponseStreamState.handle_event()` a normal `response.created` event followed by `response.output_item.added` with `item=None`; current main raises the `AttributeError` above.

On this branch:

- `uv run --with pytest --with pytest-asyncio --with respx --with inline-snapshot pytest -o addopts='' tests/lib/responses/test_responses.py::test_response_stream_ignores_null_output_item_added -q` -> `1 passed in 0.12s`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with pytest-asyncio --with respx --with inline-snapshot pytest -o addopts='' tests/lib/responses/test_responses.py -q` -> `6 passed in 0.87s`
- `uv run --with ruff ruff check src/openai/lib/streaming/responses/_responses.py tests/lib/responses/test_responses.py` -> `All checks passed!`
- `uv run python -m py_compile src/openai/lib/streaming/responses/_responses.py tests/lib/responses/test_responses.py` -> passed
- `git diff --check` -> clean
