### PR TITLE
[codex] Skip parsing incomplete response text

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -71,7 +71,9 @@ def parse_response(
                         type_=ParsedResponseOutputText[TextFormatT],
                         value={
                             **item.to_dict(),
-                            "parsed": parse_text(item.text, text_format=text_format),
+                            "parsed": parse_text(item.text, text_format=text_format)
+                            if output.status == "completed"
+                            else None,
                         },
                     )
                 )

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -4,6 +4,7 @@ from typing_extensions import TypeVar
 
 import pytest
 from respx import MockRouter
+from pydantic import BaseModel
 from inline_snapshot import snapshot
 
 from openai import OpenAI, AsyncOpenAI
@@ -70,6 +71,52 @@ def test_parse_response_preserves_program_items(item: dict[str, object]) -> None
     parsed = parse_response(text_format=omit, input_tools=omit, response=response)
 
     assert parsed.output[0].to_dict() == item
+
+
+def test_parse_incomplete_output_text() -> None:
+    class CalendarEvent(BaseModel):
+        name: str
+
+    content_item: dict[str, object] = {
+        "type": "output_text",
+        "text": '{"name":',
+        "annotations": [],
+        "logprobs": [],
+    }
+    output_item: dict[str, object] = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "status": "incomplete",
+        "content": [content_item],
+    }
+    response_payload: dict[str, object] = {
+        "id": "resp_123",
+        "object": "response",
+        "created_at": 0,
+        "model": "gpt-4o-mini",
+        "output": [output_item],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+    }
+    response = construct_type_unchecked(
+        type_=Response,
+        value=response_payload,
+    )
+
+    parsed = parse_response(text_format=CalendarEvent, input_tools=None, response=response)
+
+    assert parsed.output_parsed is None
+
+    output = parsed.output[0]
+    assert output.type == "message"
+    assert output.status == "incomplete"
+
+    content = output.content[0]
+    assert content.type == "output_text"
+    assert content.text == '{"name":'
+    assert content.parsed is None
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])


### PR DESCRIPTION
## Summary
- avoid structured-output parsing for response message text unless the message is completed
- preserve incomplete output text while leaving `parsed` as `None`
- add a regression test for incomplete JSON output in `parse_response`

Fixes #2486.

## Root cause
`parse_response` attempted to parse every `message.output_text` item with the requested structured output type. For incomplete responses, that text can contain partial JSON, so Pydantic raises a validation error instead of returning the incomplete response payload.

## Validation
- `PYTHONPATH=src uv run --frozen --python 3.9 --with pytest --with pytest-asyncio --with respx --with inline-snapshot pytest tests/lib/responses/test_responses.py::test_parse_incomplete_output_text -q -o addopts=""` (`1 passed`)
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy PYTHONPATH=src uv run --frozen --python 3.9 --with pytest --with pytest-asyncio --with respx --with inline-snapshot pytest tests/lib/responses/test_responses.py -q -o addopts=""` (`8 passed`)
- `uv run --frozen --python 3.9 --with ruff ruff format --check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py`
- `uv run --frozen --python 3.9 --with ruff ruff check src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py`
- `uv run --frozen --python 3.9 --with pyright==1.1.399 --with pytest --with pytest-asyncio --with respx --with inline-snapshot pyright src/openai/lib/_parsing/_responses.py tests/lib/responses/test_responses.py` (`0 errors`)
