### PR TITLE
fix(types): type annotation field as Annotation instead of object

### DIFF
--- a/src/openai/types/responses/response_output_text_annotation_added_event.py
+++ b/src/openai/types/responses/response_output_text_annotation_added_event.py
@@ -3,6 +3,7 @@
 from typing_extensions import Literal
 
 from ..._models import BaseModel
+from .response_output_text import Annotation
 
 __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 
@@ -10,8 +11,8 @@ __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 class ResponseOutputTextAnnotationAddedEvent(BaseModel):
     """Emitted when an annotation is added to output text content."""
 
-    annotation: object
-    """The annotation object being added. (See annotation schema for details.)"""
+    annotation: Annotation
+    """The annotation object being added."""
 
     annotation_index: int
     """The index of the annotation within the content part."""


### PR DESCRIPTION
`ResponseOutputTextAnnotationAddedEvent.annotation` is typed as `object`, forcing consumers to use `typing.cast` or suppress type errors to access typed fields like `title`, `url`, `file_id`.

`response_output_text.py` already defines the correct discriminated union `Annotation = Annotated[Union[AnnotationFileCitation, AnnotationURLCitation, AnnotationContainerFileCitation, AnnotationFilePath], PropertyInfo(discriminator="type")]`.

This PR imports and uses that type, removing the need for workarounds.

Fixes #3419