### PR TITLE
fix(parsing): guard response.output None in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
`parse_response()` iterates `response.output` directly without a None check. The Codex backend (chatgpt.com) sometimes sends `response.output: null` in the `response.completed` event even when valid output items were streamed earlier, causing `TypeError: 'NoneType' object is not iterable` inside the stream accumulator.

Replacing `for output in response.output` with `for output in (response.output or [])` matches the existing null-safety pattern used elsewhere in the SDK and prevents the crash without changing behavior when output is non-null.

Fixes #3325