### PR TITLE
Fix pre-connect Realtime manager event transforms

### DIFF
--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -65,6 +65,14 @@ __all__ = ["Realtime", "AsyncRealtime"]
 log: logging.Logger = logging.getLogger(__name__)
 
 
+def _serialize_realtime_client_event(event: RealtimeClientEvent | RealtimeClientEventParam) -> str:
+    return (
+        event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
+        if isinstance(event, BaseModel)
+        else json.dumps(maybe_transform(event, RealtimeClientEventParam))
+    )
+
+
 class Realtime(SyncAPIResource):
     @cached_property
     def client_secrets(self) -> ClientSecrets:
@@ -601,11 +609,7 @@ class AsyncRealtimeConnectionManager:
         This can be called before entering the context manager. Queued messages
         are automatically sent once the WebSocket connection opens.
         """
-        data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
-            if isinstance(event, BaseModel)
-            else json.dumps(event)
-        )
+        data = _serialize_realtime_client_event(event)
         self.__send_queue.enqueue(data)
 
     def on(
@@ -823,11 +827,7 @@ class RealtimeConnection:
         return message
 
     def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
-        data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
-            if isinstance(event, BaseModel)
-            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
-        )
+        data = _serialize_realtime_client_event(event)
         if self._is_reconnecting:
             self._send_queue.enqueue(data)
             return
@@ -1069,11 +1069,7 @@ class RealtimeConnectionManager:
         This can be called before entering the context manager. Queued messages
         are automatically sent once the WebSocket connection opens.
         """
-        data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
-            if isinstance(event, BaseModel)
-            else json.dumps(event)
-        )
+        data = _serialize_realtime_client_event(event)
         self.__send_queue.enqueue(data)
 
     def on(

--- a/tests/api_resources/test_realtime.py
+++ b/tests/api_resources/test_realtime.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import os
+import json
 
 import pytest
+
+from openai import OpenAI, AsyncOpenAI, omit
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -12,8 +15,28 @@ base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 class TestRealtime:
     parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
 
+    @parametrize
+    def test_connection_manager_send_strips_omit_values(self, client: OpenAI) -> None:
+        manager = client.realtime.connect(model="gpt-4o-realtime-preview")
+
+        manager.send({"type": "response.cancel", "event_id": omit})
+
+        queued = manager._RealtimeConnectionManager__send_queue.drain()
+        assert len(queued) == 1
+        assert json.loads(queued[0]) == {"type": "response.cancel"}
+
 
 class TestAsyncRealtime:
     parametrize = pytest.mark.parametrize(
         "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
     )
+
+    @parametrize
+    async def test_connection_manager_send_strips_omit_values(self, async_client: AsyncOpenAI) -> None:
+        manager = async_client.realtime.connect(model="gpt-4o-realtime-preview")
+
+        manager.send({"type": "response.cancel", "event_id": omit})
+
+        queued = manager._AsyncRealtimeConnectionManager__send_queue.drain()
+        assert len(queued) == 1
+        assert json.loads(queued[0]) == {"type": "response.cancel"}


### PR DESCRIPTION
Fixes #3402.

## Summary
- route queued Realtime manager events through the same transform path used by connected sync sends
- strip `Omit` values from dict events before serializing them into the pre-connect send queue
- add sync and async manager regression coverage for `response.cancel` with `event_id=omit`

## Validation
- `env HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= NO_PROXY='*' http_proxy= https_proxy= all_proxy= no_proxy='*' uv run --with pytest --with pytest-asyncio --with pytest-xdist --with dirty-equals --with respx --with time-machine --with 'httpx[socks]' --with aiohttp --with httpx-aiohttp pytest tests/api_resources/test_realtime.py -q`
- `uv run --with ruff ruff format --check src/openai/resources/realtime/realtime.py tests/api_resources/test_realtime.py`
- `uv run --with ruff ruff check src/openai/resources/realtime/realtime.py tests/api_resources/test_realtime.py`
- `git diff --check`