### PR TITLE
Fix output text annotation event typing

### DIFF
--- a/src/openai/types/responses/response_output_text_annotation_added_event.py
+++ b/src/openai/types/responses/response_output_text_annotation_added_event.py
@@ -3,6 +3,7 @@
 from typing_extensions import Literal
 
 from ..._models import BaseModel
+from .response_output_text import Annotation
 
 __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 
@@ -10,7 +11,7 @@ __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 class ResponseOutputTextAnnotationAddedEvent(BaseModel):
     """Emitted when an annotation is added to output text content."""
 
-    annotation: object
+    annotation: Annotation
     """The annotation object being added. (See annotation schema for details.)"""
 
     annotation_index: int

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,8 @@ from pydantic import Field
 from openai._utils import PropertyInfo
 from openai._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
 from openai._models import DISCRIMINATOR_CACHE, BaseModel, EagerIterable, construct_type
+from openai.types.responses import ResponseOutputTextAnnotationAddedEvent
+from openai.types.responses.response_output_text import AnnotationURLCitation
 
 
 class BasicModel(BaseModel):
@@ -131,6 +133,27 @@ def test_raw_dictionary() -> None:
     # mismatched types
     m = NestedModel.construct(nested=False)
     assert cast(Any, m.nested) is False
+
+
+def test_response_output_text_annotation_added_event_constructs_annotation() -> None:
+    event = ResponseOutputTextAnnotationAddedEvent(
+        annotation={
+            "type": "url_citation",
+            "title": "Example",
+            "url": "https://example.com",
+            "start_index": 0,
+            "end_index": 10,
+        },
+        annotation_index=0,
+        content_index=0,
+        item_id="item_123",
+        output_index=0,
+        sequence_number=1,
+        type="response.output_text.annotation.added",
+    )
+
+    assert isinstance(event.annotation, AnnotationURLCitation)
+    assert event.annotation.url == "https://example.com"
 
 
 def test_nested_dictionary_model() -> None:


### PR DESCRIPTION
Fixes #3419.

## Summary
- Type `ResponseOutputTextAnnotationAddedEvent.annotation` as the existing `Annotation` union instead of `object`.
- Add regression coverage that constructs a URL citation annotation event and verifies the annotation is materialized as `AnnotationURLCitation`.

## Root Cause
`ResponseOutputText.annotations` already uses the generated `Annotation` union, but the streaming `response.output_text.annotation.added` event exposed its `annotation` payload as `object`. That weakens static typing for consumers and also leaves constructed events with an untyped `dict` annotation payload.

## Validation
- `env HTTP_PROXY= HTTPS_PROXY= ALL_PROXY= NO_PROXY='*' http_proxy= https_proxy= all_proxy= no_proxy='*' uv run --with pytest --with pytest-asyncio --with pytest-xdist --with dirty-equals --with respx --with time-machine --with 'httpx[socks]' pytest tests/test_models.py -q` -> 59 passed
- `uv run --with ruff ruff format --check src/openai/types/responses/response_output_text_annotation_added_event.py tests/test_models.py`
- `uv run --with ruff ruff check src/openai/types/responses/response_output_text_annotation_added_event.py tests/test_models.py`
- `git diff --check`
