### PR TITLE
fix: document suppressed client cleanup errors

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -839,7 +839,7 @@ class SyncHttpxClientWrapper(DefaultHttpxClient):
         except Exception:
             # Suppress destructor cleanup errors; object finalizers should not raise
             # during garbage collection or interpreter shutdown.
-            return
+            log.debug("Failed to close sync HTTP client during object finalization", exc_info=True)
 
 
 class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
@@ -1438,7 +1438,7 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
         except Exception:
             # Suppress destructor cleanup errors; object finalizers should not raise
             # during garbage collection or interpreter shutdown.
-            return
+            log.debug("Failed to close async HTTP client during object finalization", exc_info=True)
 
 
 class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -837,7 +837,9 @@ class SyncHttpxClientWrapper(DefaultHttpxClient):
         try:
             self.close()
         except Exception:
-            pass
+            # Suppress destructor cleanup errors; object finalizers should not raise
+            # during garbage collection or interpreter shutdown.
+            return
 
 
 class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
@@ -1434,7 +1436,9 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
             # TODO(someday): support non asyncio runtimes here
             asyncio.get_running_loop().create_task(self.aclose())
         except Exception:
-            pass
+            # Suppress destructor cleanup errors; object finalizers should not raise
+            # during garbage collection or interpreter shutdown.
+            return
 
 
 class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Replace empty `except Exception: pass` handlers in the sync and async HTTP client wrapper destructors with explicit comments and `return` statements. This keeps destructor cleanup failures suppressed intentionally while making the behavior clear.

Fixes #3428

## Additional context & links

Tests run:

- `ruff check src/openai/_base_client.py`
- `ruff format --check src/openai/_base_client.py`
- `git diff --check`
- `pytest tests/test_client.py::TestOpenAI::test_parse_retry_after_header tests/test_client.py::TestAsyncOpenAI::test_parse_retry_after_header` (32 passed)
