### PR TITLE
Fix Azure deployment model request body

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -72,8 +72,15 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
     ) -> httpx.Request:
         if options.url in _deployments_endpoints and is_mapping(options.json_data):
             model = options.json_data.get("model")
-            if model is not None and "/deployments" not in str(self.base_url.path):
+            uses_deployment_path = "/deployments" in str(self.base_url.path)
+            if model is not None and not uses_deployment_path:
+                options = model_copy(options)
                 options.url = f"/deployments/{model}{options.url}"
+                uses_deployment_path = True
+
+            if uses_deployment_path and "model" in options.json_data:
+                options = model_copy(options)
+                options.json_data = {key: value for key, value in options.json_data.items() if key != "model"}
 
         return super()._build_request(options, retries_taken=retries_taken)
 

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Union, cast
 from typing_extensions import Literal, Protocol
@@ -538,6 +539,47 @@ def test_prepare_url_deployment_endpoint(
     )
     assert req.url == expected
     assert client.base_url == base_url
+
+
+@pytest.mark.parametrize(
+    "client",
+    [
+        AzureOpenAI(
+            api_version="2024-10-21",
+            api_key="example API key",
+            azure_endpoint="https://example-resource.azure.openai.com",
+        ),
+        AsyncAzureOpenAI(
+            api_version="2024-10-21",
+            api_key="example API key",
+            azure_endpoint="https://example-resource.azure.openai.com",
+        ),
+    ],
+)
+def test_deployment_endpoint_strips_model_from_request_body(client: Client) -> None:
+    body = {
+        "model": "gpt-image-1-5",
+        "prompt": "A sunset over mountains",
+        "size": "1024x1024",
+    }
+
+    req = client._build_request(
+        FinalRequestOptions.construct(
+            method="post",
+            url="/images/generations",
+            json_data=body,
+        )
+    )
+
+    assert req.url == httpx.URL(
+        "https://example-resource.azure.openai.com/openai/deployments/"
+        "gpt-image-1-5/images/generations?api-version=2024-10-21"
+    )
+    assert json.loads(req.content) == {
+        "prompt": "A sunset over mountains",
+        "size": "1024x1024",
+    }
+    assert body["model"] == "gpt-image-1-5"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #2892.

## Summary
- omit `model` from Azure deployment-based request bodies after using it to route `/deployments/{deployment}`
- preserve the caller-provided JSON body by copying request options before removing `model`
- add sync/async Azure regression coverage for image generation deployments whose names differ from model IDs

## Validation
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with pytest-xdist --with pytest-asyncio --with respx --with httpx --with rich pytest tests/lib/test_azure.py -q`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with ruff ruff check src/openai/lib/azure.py tests/lib/test_azure.py`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run python -m py_compile src/openai/lib/azure.py tests/lib/test_azure.py`