### PR TITLE
fix: handle bare dict/list annotations in construct_type and transform

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,8 +657,11 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
-        return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
+        dict_args = get_args(type_)
+        if len(dict_args) >= 2:
+            items_type = dict_args[1]
+            return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
+        return dict(value)
 
     if (
         not is_literal_type(type_)
@@ -678,8 +681,10 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_list(value):
             return value
 
-        inner_type = args[0]  # List[inner_type]
-        return [construct_type(value=entry, type_=inner_type) for entry in value]
+        if args:
+            inner_type = args[0]  # List[inner_type]
+            return [construct_type(value=entry, type_=inner_type) for entry in value]
+        return list(value)
 
     if origin == float:
         if isinstance(value, int):

--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,8 +180,11 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        args = get_args(stripped_type)
+        if len(args) >= 2:
+            items_type = args[1]
+            return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        return dict(data)
 
     if (
         # List[T]
@@ -195,6 +198,12 @@ def _transform_recursive(
         # intended as an iterable, so we don't transform it.
         if isinstance(data, dict):
             return cast(object, data)
+
+        # bare list/iterable/sequence with no type args - return as-is
+        if not get_args(stripped_type):
+            if is_list(data):
+                return data
+            return list(data)
 
         inner_type = extract_type_arg(stripped_type, 0)
         if _no_transform_needed(inner_type):
@@ -346,8 +355,11 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        args = get_args(stripped_type)
+        if len(args) >= 2:
+            items_type = args[1]
+            return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        return dict(data)
 
     if (
         # List[T]
@@ -361,6 +373,12 @@ async def _async_transform_recursive(
         # intended as an iterable, so we don't transform it.
         if isinstance(data, dict):
             return cast(object, data)
+
+        # bare list/iterable/sequence with no type args - return as-is
+        if not get_args(stripped_type):
+            if is_list(data):
+                return data
+            return list(data)
 
         inner_type = extract_type_arg(stripped_type, 0)
         if _no_transform_needed(inner_type):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1015,3 +1015,25 @@ def test_iterable_construction_str_falls_back_to_list() -> None:
     # falls back to list of chars rather than calling str(["h", "e", "l", "l", "o"])
     assert m.data["items"] == ["h", "e", "l", "l", "o"]
     assert m.model_dump()["data"]["items"] == ["h", "e", "l", "l", "o"]
+
+
+def test_bare_dict_annotation() -> None:
+    result = construct_type(value={"key": "value"}, type_=dict)
+    assert result == {"key": "value"}
+
+    result = construct_type(value={"a": 1, "b": 2}, type_=dict)
+    assert result == {"a": 1, "b": 2}
+
+    result = construct_type(value="not a dict", type_=dict)
+    assert result == "not a dict"
+
+
+def test_bare_list_annotation() -> None:
+    result = construct_type(value=[1, 2, 3], type_=list)
+    assert result == [1, 2, 3]
+
+    result = construct_type(value=["a", "b"], type_=list)
+    assert result == ["a", "b"]
+
+    result = construct_type(value="not a list", type_=list)
+    assert result == "not a list"

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -458,3 +458,25 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+class BareDictParams(TypedDict, total=False):
+    metadata: dict
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_in_typeddict(use_async: bool) -> None:
+    result = await transform({"metadata": {"key": "value"}}, BareDictParams, use_async)
+    assert result == {"metadata": {"key": "value"}}
+
+
+class BareListParams(TypedDict, total=False):
+    items: list
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_list_in_typeddict(use_async: bool) -> None:
+    result = await transform({"items": [1, 2, 3]}, BareListParams, use_async)
+    assert result == {"items": [1, 2, 3]}


### PR DESCRIPTION
## Problem

Using bare  or  annotations (without type parameters) crashes the SDK:

-  raises 
-  raises 
-  raises 

This affects users who annotate fields as plain  or  instead of  or .

Fixes #3338
Fixes #3341

## Root Cause

The code unconditionally unpacks type args without checking if they exist:
-  line 660:  — crashes on bare 
-  line 681:  — crashes on bare 
-  line 183:  — crashes on bare 

## Fix

Guard the type args access:
- For : check  before unpacking
- For : check  before accessing 
- When type args are missing, return the data as-is (graceful fallback)

## Testing

Added 6 new tests covering bare dict/list in both  and  (sync + async). All 120 tests pass (114 existing + 6 new).