### PR TITLE
fix: transform Omit values in pre-connect Realtime manager send()

### DIFF
--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -604,7 +604,7 @@ class AsyncRealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 
@@ -1072,7 +1072,7 @@ class RealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 

--- a/tests/test_realtime_manager_send_omit.py
+++ b/tests/test_realtime_manager_send_omit.py
@@ -1,0 +1,131 @@
+"""Regression tests for issue #3402: Pre-connect Realtime manager.send crashes on Omit in dict events.
+
+These tests verify that the pre-connect send() methods on both sync and async
+RealtimeConnectionManager properly transform Omit values before JSON serialization,
+matching the behavior of the connected send() methods.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from openai._types import omit
+from openai.resources.realtime.realtime import (
+    AsyncRealtimeConnectionManager,
+    RealtimeConnectionManager,
+)
+
+
+def _make_sync_manager() -> RealtimeConnectionManager:
+    """Create a minimal RealtimeConnectionManager for testing."""
+    return RealtimeConnectionManager(
+        client=MagicMock(),
+        call_id="test-call-id",
+        model="gpt-4o-realtime-preview",
+        extra_query={},
+        extra_headers={},
+        websocket_connection_options=MagicMock(),
+    )
+
+
+def _make_async_manager() -> AsyncRealtimeConnectionManager:
+    """Create a minimal AsyncRealtimeConnectionManager for testing."""
+    return AsyncRealtimeConnectionManager(
+        client=MagicMock(),
+        call_id="test-call-id",
+        model="gpt-4o-realtime-preview",
+        extra_query={},
+        extra_headers={},
+        websocket_connection_options=MagicMock(),
+    )
+
+
+class TestRealtimeConnectionManagerSendOmit:
+    """Test that RealtimeConnectionManager.send() handles Omit values."""
+
+    def test_send_dict_with_omit_strips_omit_values(self) -> None:
+        """Pre-connect send() should strip Omit values from dict events before JSON serialization."""
+        manager = _make_sync_manager()
+
+        event = {"type": "response.cancel", "event_id": omit}
+
+        # This should NOT raise TypeError: Object of type Omit is not JSON serializable
+        manager.send(event)
+
+        # Verify the queued data has Omit stripped
+        items = manager._RealtimeConnectionManager__send_queue.drain()
+        assert len(items) == 1
+        data = json.loads(items[0])
+        assert data == {"type": "response.cancel"}
+        assert "event_id" not in data
+
+    def test_send_dict_without_omit_preserves_all_fields(self) -> None:
+        """Pre-connect send() should preserve all fields when no Omit values present."""
+        manager = _make_sync_manager()
+
+        event = {"type": "response.cancel", "event_id": "evt_123"}
+        manager.send(event)
+
+        items = manager._RealtimeConnectionManager__send_queue.drain()
+        assert len(items) == 1
+        data = json.loads(items[0])
+        assert data == {"type": "response.cancel", "event_id": "evt_123"}
+
+    def test_send_dict_with_multiple_omit_fields(self) -> None:
+        """Pre-connect send() should strip all Omit values from dict events."""
+        manager = _make_sync_manager()
+
+        event = {"type": "response.create", "event_id": omit, "response": {"modalities": omit}}
+        manager.send(event)
+
+        items = manager._RealtimeConnectionManager__send_queue.drain()
+        assert len(items) == 1
+        data = json.loads(items[0])
+        assert data == {"type": "response.create", "response": {}}
+
+
+class TestAsyncRealtimeConnectionManagerSendOmit:
+    """Test that AsyncRealtimeConnectionManager.send() handles Omit values."""
+
+    def test_send_dict_with_omit_strips_omit_values(self) -> None:
+        """Pre-connect send() should strip Omit values from dict events before JSON serialization."""
+        manager = _make_async_manager()
+
+        event = {"type": "response.cancel", "event_id": omit}
+
+        # This should NOT raise TypeError: Object of type Omit is not JSON serializable
+        manager.send(event)
+
+        # Verify the queued data has Omit stripped
+        items = manager._AsyncRealtimeConnectionManager__send_queue.drain()
+        assert len(items) == 1
+        data = json.loads(items[0])
+        assert data == {"type": "response.cancel"}
+        assert "event_id" not in data
+
+    def test_send_dict_without_omit_preserves_all_fields(self) -> None:
+        """Pre-connect send() should preserve all fields when no Omit values present."""
+        manager = _make_async_manager()
+
+        event = {"type": "response.cancel", "event_id": "evt_123"}
+        manager.send(event)
+
+        items = manager._AsyncRealtimeConnectionManager__send_queue.drain()
+        assert len(items) == 1
+        data = json.loads(items[0])
+        assert data == {"type": "response.cancel", "event_id": "evt_123"}
+
+    def test_send_dict_with_multiple_omit_fields(self) -> None:
+        """Pre-connect send() should strip all Omit values from dict events."""
+        manager = _make_async_manager()
+
+        event = {"type": "response.create", "event_id": omit, "response": {"modalities": omit}}
+        manager.send(event)
+
+        items = manager._AsyncRealtimeConnectionManager__send_queue.drain()
+        assert len(items) == 1
+        data = json.loads(items[0])
+        assert data == {"type": "response.create", "response": {}}


### PR DESCRIPTION
Fixes #3402.

## Summary

The pre-connect `send()` methods on both `AsyncRealtimeConnectionManager` and `RealtimeConnectionManager` called `json.dumps(event)` directly on dict payloads, which crashed with `TypeError` when the event contained `Omit` values (e.g. `event_id=omit`).

The connected `send()` methods already used `maybe_transform()` to strip `Omit` values before serialization. This PR applies the same transformation to the pre-connect `send()` methods for consistency.

## Changes

- `src/openai/resources/realtime/realtime.py`: Updated both sync and async pre-connect `send()` methods to use `maybe_transform(event, RealtimeClientEventParam)` before `json.dumps()`
- `tests/test_realtime_manager_send_omit.py`: Added regression tests verifying:
  - Dict events with `omit` values are properly stripped before serialization
  - Dict events without `omit` values preserve all fields
  - Multiple `omit` fields are all stripped correctly

## Reproduction

Before this fix:
```python
from openai import OpenAI
from openai._types import omit

client = OpenAI()
manager = client.realtime.connect(model='gpt-4o-realtime-preview')
manager.send({'type': 'response.cancel', 'event_id': omit})
# TypeError: Object of type Omit is not JSON serializable
```

After this fix, the `omit` value is stripped and the event is serialized correctly.