### PR TITLE
fix: remove dead error event code in _streaming.py

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -67,20 +67,6 @@ class Stream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
-                        message = None
-                        error = data.get("error")
-                        if is_mapping(error):
-                            message = error.get("message")
-                        if not message or not isinstance(message, str):
-                            message = "An error occurred during streaming"
-
-                        raise APIError(
-                            message=message,
-                            request=self.response.request,
-                            body=data["error"],
-                        )
-
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
@@ -176,20 +162,6 @@ class AsyncStream(Generic[_T]):
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
-                        message = None
-                        error = data.get("error")
-                        if is_mapping(error):
-                            message = error.get("message")
-                        if not message or not isinstance(message, str):
-                            message = "An error occurred during streaming"
-
-                        raise APIError(
-                            message=message,
-                            request=self.response.request,
-                            body=data["error"],
-                        )
 
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:


### PR DESCRIPTION
## Summary

Removes unreachable error event handling code in both `Stream.__stream__` and `AsyncStream.__stream__`.

### What was dead

Inside the Assistants `thread.` event branch (`if sse.event.startswith("thread.")`), there was a check for `sse.event == "error"`. Since `"error"` never starts with `"thread."`, this branch could never execute — it was dead code.

The correct error handling for non-thread events already exists in the `else` branch.

### Changes

- Remove 28 lines of dead code (sync + async versions)
- No behavioral changes