### PR TITLE
fix: correct nested params README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,11 +379,11 @@ from openai import OpenAI
 
 client = OpenAI()
 
-response = client.chat.responses.create(
-    input=[
+response = client.chat.completions.create(
+    messages=[
         {
             "role": "user",
-            "content": "How much ?",
+            "content": "Generate an example JSON object describing a fruit.",
         }
     ],
     model="gpt-5.2",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3264.

This updates the README's "Nested params" example so it uses the real Chat Completions surface instead of the non-existent `client.chat.responses.create(...)` hybrid. The snippet now uses `client.chat.completions.create(...)` with `messages=[...]`, which matches the `response_format={"type": "json_object"}` example being demonstrated.

## Additional context & links

Local verification:
- `python3 -m pytest tests/test_files.py`