### PR TITLE
fix: handle bare dict in transform

### DIFF
--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,7 +180,11 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return data
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +350,11 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        args = get_args(stripped_type)
+        if len(args) < 2:
+            return data
+
+        items_type = args[1]
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -458,3 +458,11 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_transform_with_bare_dict_annotation(use_async: bool) -> None:
+    data = {"key": "value"}
+
+    assert await transform(data, dict, use_async) == data


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3338.

Return bare `dict` inputs unchanged in both sync and async transform paths when there is no value type to recurse into, and add a regression test that covers both code paths.

## Additional context & links

Validation:
- `uv run pytest tests/test_transform.py -k bare_dict_annotation`
- `uv run ruff check src/openai/_utils/_transform.py tests/test_transform.py`