### PR TITLE
fix: handle bare dict in construct_type

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -577,7 +577,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        args = get_args(type_)
+        items_type = args[1] if len(args) >= 2 else object
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -961,3 +961,9 @@ def test_extra_properties() -> None:
     assert model.a.prop == 1
     assert isinstance(model.a, Item)
     assert model.other == "foo"
+
+
+def test_construct_type_with_bare_dict() -> None:
+    value = {"key": "value"}
+
+    assert construct_type(value=value, type_=dict) == value


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3341.

Treat bare `dict` annotations as untyped mappings in `construct_type()` instead of unpacking missing type arguments, and add a focused regression test for `construct_type(value={...}, type_=dict)`.

## Additional context & links

Validation:
- `uv run pytest tests/test_models.py -k bare_dict`
- `uv run ruff check src/openai/_models.py tests/test_models.py`