### PR TITLE
fix(lib): guard parse_response against response.output=None

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,10 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    # `response.output` can be None for incomplete/failed/reasoning-only
+    # responses (and via some proxy/aggregator backends); guard so the stream
+    # parser yields an empty output instead of raising TypeError.
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/responses/test_parse_response_none_output.py
+++ b/tests/lib/responses/test_parse_response_none_output.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from openai._types import omit
+from openai.lib._parsing._responses import parse_response
+from openai.types.responses import Response
+
+
+def _minimal_response(**overrides: object) -> Response:
+    # Build a Response with the required scalar fields set; `output` is the
+    # field under test. Uses construct() to avoid pulling a full live payload.
+    base: dict[str, object] = dict(
+        id="resp_test",
+        created_at=0.0,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata=None,
+        model="gpt-4o-mini",
+        object="response",
+        output=[],
+        parallel_tool_calls=True,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+    )
+    base.update(overrides)
+    return Response.construct(**base)
+
+
+def test_parse_response_handles_none_output() -> None:
+    # `output` can be None for incomplete/failed/reasoning-only responses and
+    # via some proxy/aggregator backends. parse_response must not raise
+    # TypeError('NoneType' object is not iterable) — it should yield empty output.
+    response = _minimal_response(output=None)
+
+    parsed = parse_response(text_format=omit, input_tools=None, response=response)
+
+    assert parsed.output == []


### PR DESCRIPTION
Fixes #3459

### Problem

`parse_response` in `src/openai/lib/_parsing/_responses.py` iterates `response.output` without guarding against `None`:

```python
for output in response.output:   # TypeError if response.output is None
```

When a completed `Response` has `output=None`, this raises `TypeError: 'NoneType' object is not iterable`. Because `parse_response` is invoked from the streaming accumulator (`lib/streaming/responses/_responses.py::accumulate_event` → `parse_response`), the exception crashes the **entire stream** rather than surfacing as a handleable result — and it originates deep in the SDK, so it isn't catchable as a normal API error.

`output` can be `None` for incomplete / failed / reasoning-only responses, and via some proxy/aggregator backends.

### Fix

Guard the iteration:

```python
-    for output in response.output:
+    for output in (response.output or []):
```

A `None`/absent `output` now yields a `ParsedResponse` with an empty `output` list instead of crashing.

### Test

Adds `tests/lib/responses/test_parse_response_none_output.py`, a focused regression test that calls `parse_response` with a `Response` whose `output` is `None`.

Validated in isolation:
- **Without** the guard: the test fails with exactly `TypeError: 'NoneType' object is not iterable` at `_parsing/_responses.py` (reproduces the bug).
- **With** the guard: the test passes.

The change is one line plus a test; happy to adjust naming/placement to match your conventions.
