### PR TITLE
fix: remove unreachable error check inside thread event block

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,24 +63,8 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     break
 
-                # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
-                        message = None
-                        error = data.get("error")
-                        if is_mapping(error):
-                            message = error.get("message")
-                        if not message or not isinstance(message, str):
-                            message = "An error occurred during streaming"
-
-                        raise APIError(
-                            message=message,
-                            request=self.response.request,
-                            body=data["error"],
-                        )
-
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
@@ -176,21 +160,6 @@ class AsyncStream(Generic[_T]):
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
-                        message = None
-                        error = data.get("error")
-                        if is_mapping(error):
-                            message = error.get("message")
-                        if not message or not isinstance(message, str):
-                            message = "An error occurred during streaming"
-
-                        raise APIError(
-                            message=message,
-                            request=self.response.request,
-                            body=data["error"],
-                        )
-
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()


### PR DESCRIPTION
In `src/openai/_streaming.py`, both the sync and async `__stream__` methods contain a dead code block:

```python
if sse.event and sse.event.startswith("thread."):
    data = sse.json()

    # DEAD CODE: "error" does not start with "thread.", so this check is unreachable
    if sse.event == "error" and is_mapping(data) and data.get("error"):
        ...
        raise APIError(...)

    yield process_data(...)
```

The `sse.event == "error"` check inside the `sse.event.startswith("thread.")` block can never be true. This was a regression from commit `abc25966` where the error check was incorrectly moved inside the thread branch during a refactor. The `else` branch already handles errors correctly for non-thread events.

Fixes #2796