### PR TITLE
fix(types): type response annotation added event

### DIFF
--- a/src/openai/types/responses/response_output_text_annotation_added_event.py
+++ b/src/openai/types/responses/response_output_text_annotation_added_event.py
@@ -3,6 +3,7 @@
 from typing_extensions import Literal
 
 from ..._models import BaseModel
+from .response_output_text import Annotation
 
 __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 
@@ -10,8 +11,8 @@ __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 class ResponseOutputTextAnnotationAddedEvent(BaseModel):
     """Emitted when an annotation is added to output text content."""
 
-    annotation: object
-    """The annotation object being added. (See annotation schema for details.)"""
+    annotation: Annotation
+    """The annotation object being added."""
 
     annotation_index: int
     """The index of the annotation within the content part."""


### PR DESCRIPTION
## Summary
- type `ResponseOutputTextAnnotationAddedEvent.annotation` as the existing Responses `Annotation` union instead of plain `object`
- keep event parsing aligned with `ResponseOutputText.annotations`, so streamed annotation-added events expose typed citation/file-path models

Fixes #3419.

## Test plan
- `git diff --check`
- `uv run python - <<'PY' ... PY` validating a `url_citation` annotation parses as `AnnotationURLCitation`
- `uv run python -m py_compile src/openai/types/responses/response_output_text_annotation_added_event.py`
