### PR TITLE
fix: guard response parsing for null output

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/tests/lib/test_responses_parsing.py
+++ b/tests/lib/test_responses_parsing.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from openai.lib._parsing._responses import parse_response
+from openai.types.responses.response import Response
+from openai import NOT_GIVEN
+
+
+def test_parse_response_handles_none_output() -> None:
+    response = Response.model_construct(output=None)
+
+    parsed = parse_response(
+        text_format=NOT_GIVEN,
+        input_tools=NOT_GIVEN,
+        response=response,
+    )
+
+    assert parsed.output == []


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Guard `parse_response()` against `response.output=None` by iterating over `response.output or []` instead of assuming a list is always present. Added a regression test covering `Response.model_construct(output=None)`.

Fixes #3459.

## Additional context & links

Local test run:
- `PYTHONPATH=src python3.11 -m pytest tests/lib/test_responses_parsing.py -q -n0`
