### PR TITLE
fix: normalize realtime manager dict events

### DIFF
--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -604,7 +604,7 @@ class AsyncRealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 
@@ -1072,7 +1072,7 @@ class RealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 

--- a/tests/test_realtime_connection_manager.py
+++ b/tests/test_realtime_connection_manager.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+from openai.resources.realtime.realtime import AsyncRealtimeConnectionManager, RealtimeConnectionManager
+from openai._types import omit
+
+
+def _manager_kwargs() -> dict[str, object]:
+    return {
+        "client": mock.Mock(),
+        "extra_query": {},
+        "extra_headers": {},
+        "websocket_connection_options": {},
+    }
+
+
+def test_sync_manager_send_strips_omit_values() -> None:
+    manager = RealtimeConnectionManager(**_manager_kwargs())
+
+    manager.send({"type": "response.cancel", "event_id": omit})
+
+    payload = json.loads(manager._RealtimeConnectionManager__send_queue.drain()[0])
+    assert payload == {"type": "response.cancel"}
+
+
+def test_async_manager_send_strips_omit_values() -> None:
+    manager = AsyncRealtimeConnectionManager(**_manager_kwargs())
+
+    manager.send({"type": "response.cancel", "event_id": omit})
+
+    payload = json.loads(manager._AsyncRealtimeConnectionManager__send_queue.drain()[0])
+    assert payload == {"type": "response.cancel"}


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Normalize dict events passed to the realtime connection managers before JSON encoding them, so omitted values are stripped the same way they already are for typed events. Added sync and async regression tests for the pre-connect manager path.

Fixes #3402.

## Additional context & links

Local test run:
- `PYTHONPATH=src python3.11 -m pytest tests/test_realtime_connection_manager.py -q -n0`
