### PR TITLE
fix: type response output text annotation events

### DIFF
--- a/src/openai/types/responses/response_output_text_annotation_added_event.py
+++ b/src/openai/types/responses/response_output_text_annotation_added_event.py
@@ -3,6 +3,7 @@
 from typing_extensions import Literal
 
 from ..._models import BaseModel
+from .response_output_text import Annotation
 
 __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 
@@ -10,7 +11,7 @@ __all__ = ["ResponseOutputTextAnnotationAddedEvent"]
 class ResponseOutputTextAnnotationAddedEvent(BaseModel):
     """Emitted when an annotation is added to output text content."""
 
-    annotation: object
+    annotation: Annotation
     """The annotation object being added. (See annotation schema for details.)"""
 
     annotation_index: int

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ import pydantic
 from pydantic import Field
 
 from openai._utils import PropertyInfo
-from openai._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
+from openai._compat import PYDANTIC_V1, model_dump, model_json, model_parse, parse_obj
 from openai._models import DISCRIMINATOR_CACHE, BaseModel, construct_type
 from openai.types.responses import ResponseOutputTextAnnotationAddedEvent
 from openai.types.responses.response_output_text import AnnotationURLCitation
@@ -966,7 +966,8 @@ def test_extra_properties() -> None:
 
 
 def test_response_output_text_annotation_added_event_uses_annotation_union() -> None:
-    event = ResponseOutputTextAnnotationAddedEvent.model_validate(
+    event = model_parse(
+        ResponseOutputTextAnnotationAddedEvent,
         {
             "annotation": {
                 "type": "url_citation",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,8 @@ from pydantic import Field
 from openai._utils import PropertyInfo
 from openai._compat import PYDANTIC_V1, parse_obj, model_dump, model_json
 from openai._models import DISCRIMINATOR_CACHE, BaseModel, construct_type
+from openai.types.responses import ResponseOutputTextAnnotationAddedEvent
+from openai.types.responses.response_output_text import AnnotationURLCitation
 
 
 class BasicModel(BaseModel):
@@ -961,3 +963,26 @@ def test_extra_properties() -> None:
     assert model.a.prop == 1
     assert isinstance(model.a, Item)
     assert model.other == "foo"
+
+
+def test_response_output_text_annotation_added_event_uses_annotation_union() -> None:
+    event = ResponseOutputTextAnnotationAddedEvent.model_validate(
+        {
+            "annotation": {
+                "type": "url_citation",
+                "title": "Example",
+                "url": "https://example.com",
+                "start_index": 0,
+                "end_index": 7,
+            },
+            "annotation_index": 0,
+            "content_index": 0,
+            "item_id": "item_123",
+            "output_index": 0,
+            "sequence_number": 1,
+            "type": "response.output_text.annotation.added",
+        }
+    )
+
+    assert isinstance(event.annotation, AnnotationURLCitation)
+    assert event.annotation.url == "https://example.com"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3419.

Use the existing `Annotation` discriminated union for `ResponseOutputTextAnnotationAddedEvent.annotation` instead of `object`, and add a regression test that validates URL citation payloads are parsed into the typed annotation model.

## Additional context & links

Validation:
- `.venv/bin/python -m pytest -o addopts= tests/test_models.py -k response_output_text_annotation_added_event`