### PR TITLE
fix: sanitize NO_PROXY values before client setup

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -5,12 +5,14 @@ import json
 import time
 import uuid
 import email
+import os
 import asyncio
 import inspect
 import logging
 import platform
 import warnings
 import email.utils
+from contextlib import contextmanager
 from types import TracebackType
 from random import random
 from typing import (
@@ -79,6 +81,30 @@ from ._constants import (
     OVERRIDE_CAST_TO_HEADER,
     DEFAULT_CONNECTION_LIMITS,
 )
+
+
+def _normalize_no_proxy_value(value: str) -> str:
+    entries = [entry.strip() for entry in value.replace("\r", ",").replace("\n", ",").split(",")]
+    return ",".join(entry for entry in entries if entry)
+
+
+@contextmanager
+def _sanitized_proxy_env() -> Generator[None, None, None]:
+    original: dict[str, str] = {}
+
+    try:
+        for key in ("NO_PROXY", "no_proxy"):
+            value = os.environ.get(key)
+            if value is None or ("\n" not in value and "\r" not in value):
+                continue
+
+            original[key] = value
+            os.environ[key] = _normalize_no_proxy_value(value)
+
+        yield
+    finally:
+        for key, value in original.items():
+            os.environ[key] = value
 from ._streaming import Stream, SSEDecoder, AsyncStream, SSEBytesDecoder
 from ._exceptions import (
     APIStatusError,
@@ -814,7 +840,8 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        super().__init__(**kwargs)
+        with _sanitized_proxy_env():
+            super().__init__(**kwargs)
 
 
 if TYPE_CHECKING:
@@ -1388,7 +1415,8 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        super().__init__(**kwargs)
+        with _sanitized_proxy_env():
+            super().__init__(**kwargs)
 
 
 try:

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -1434,7 +1434,8 @@ else:
             kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
             kwargs.setdefault("follow_redirects", True)
 
-            super().__init__(**kwargs)
+            with _sanitized_proxy_env():
+                super().__init__(**kwargs)
 
 
 if TYPE_CHECKING:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -414,6 +414,12 @@ class TestOpenAI:
                 client2 = OpenAI(base_url=base_url, api_key=None, _strict_response_validation=True)
             _ = client2
 
+    def test_no_proxy_with_newlines_is_sanitized_for_default_http_client(self) -> None:
+        with update_env(NO_PROXY="localhost\n127.0.0.1"):
+            client = OpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
+            assert os.environ["NO_PROXY"] == "localhost\n127.0.0.1"
+            client.close()
+
     def test_default_query_option(self) -> None:
         client = OpenAI(
             base_url=base_url, api_key=api_key, _strict_response_validation=True, default_query={"query_param": "bar"}
@@ -1437,6 +1443,12 @@ class TestAsyncOpenAI:
             with update_env(**{"OPENAI_API_KEY": Omit()}):
                 client2 = AsyncOpenAI(base_url=base_url, api_key=None, _strict_response_validation=True)
             _ = client2
+
+    async def test_no_proxy_with_newlines_is_sanitized_for_default_http_client(self) -> None:
+        with update_env(NO_PROXY="localhost\n127.0.0.1"):
+            client = AsyncOpenAI(base_url=base_url, api_key=api_key, _strict_response_validation=True)
+            assert os.environ["NO_PROXY"] == "localhost\n127.0.0.1"
+            await client.close()
 
     async def test_default_query_option(self) -> None:
         client = AsyncOpenAI(


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3303.

Sanitize newline-delimited `NO_PROXY` / `no_proxy` environment values while constructing the default sync and async HTTP clients, then restore the original environment values after initialization. Added regression coverage for both client types.

## Additional context & links

Validation:
- `.venv/bin/python -m pytest -o addopts= tests/test_client.py -k no_proxy_with_newlines_is_sanitized_for_default_http_client`