### PR TITLE
feat: Enable HTTP/2 by default in httpx client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Repository = "https://github.com/openai/openai-python"
 
 [project.optional-dependencies]
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
+http2 = ["httpx[http2]"]
 realtime = ["websockets >= 13, < 16"]
 datalib = ["numpy >= 1", "pandas >= 1.2.3", "pandas-stubs >= 1.1.0.11"]
 voice_helpers = ["sounddevice>=0.5.1", "numpy>=2.0.2"]

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -39,6 +39,13 @@ import pydantic
 from httpx import URL
 from pydantic import PrivateAttr
 
+try:
+    import h2  # noqa: F401
+
+    _HTTP2_AVAILABLE = True
+except ImportError:
+    _HTTP2_AVAILABLE = False
+
 from . import _exceptions
 from ._qs import Querystring
 from ._files import to_httpx_files, async_to_httpx_files
@@ -836,7 +843,7 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        kwargs.setdefault("http2", True)
+        kwargs.setdefault("http2", _HTTP2_AVAILABLE)
         super().__init__(**kwargs)
 
 
@@ -1424,7 +1431,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
-        kwargs.setdefault("http2", True)
+        kwargs.setdefault("http2", _HTTP2_AVAILABLE)
         super().__init__(**kwargs)
 
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -836,6 +836,7 @@ class _DefaultHttpxClient(httpx.Client):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        kwargs.setdefault("http2", True)
         super().__init__(**kwargs)
 
 
@@ -1423,6 +1424,7 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
+        kwargs.setdefault("http2", True)
         super().__init__(**kwargs)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1304,6 +1304,52 @@ class TestOpenAI:
             limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
         )
 
+    @pytest.fixture
+    def _http2_sync_spy(self) -> dict[str, Any]:
+        """Spy on httpx.Client.__init__ to capture http2 kwarg."""
+        captured: dict[str, Any] = {}
+        original_init = httpx.Client.__init__
+
+        def fake_init(self: Any, **kwargs: Any) -> None:
+            captured.update(kwargs)
+            return original_init(self, **kwargs)
+
+        with mock.patch.object(httpx.Client, "__init__", fake_init):
+            yield captured
+
+    def test_default_http2_enabled_when_h2_available(self, _http2_sync_spy: dict[str, Any]) -> None:
+        """http2=True should be passed through to httpx.Client when h2 is present."""
+        from openai._base_client import _HTTP2_AVAILABLE, _DefaultHttpxClient
+
+        # h2 is installed in the test environment, so _HTTP2_AVAILABLE should be True
+        assert _HTTP2_AVAILABLE is True
+
+        _DefaultHttpxClient()
+
+        assert _http2_sync_spy.get("http2") is True
+
+    def test_default_http2_can_be_explicitly_overridden(self, _http2_sync_spy: dict[str, Any]) -> None:
+        """Explicit http2=False should override the default when h2 is available."""
+        from openai._base_client import _DefaultHttpxClient
+
+        _DefaultHttpxClient(http2=False)
+
+        assert _http2_sync_spy.get("http2") is False
+
+    def test_construction_with_http2_when_h2_not_available(
+        self, monkeypatch: pytest.MonkeyPatch, _http2_sync_spy: dict[str, Any]
+    ) -> None:
+        """Construction should not break and http2 should default to False when h2 is absent."""
+        import openai._base_client as base_client_module
+
+        monkeypatch.setattr(base_client_module, "_HTTP2_AVAILABLE", False)
+
+        from openai._base_client import _DefaultHttpxClient
+
+        _DefaultHttpxClient()
+
+        assert _http2_sync_spy.get("http2") is False
+
     @pytest.mark.respx(base_url=base_url)
     def test_follow_redirects(self, respx_mock: MockRouter, client: OpenAI) -> None:
         # Test that the default follow_redirects=True allows following redirects
@@ -2563,6 +2609,52 @@ class TestAsyncOpenAI:
             http2=False,
             limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
         )
+
+    @pytest.fixture
+    def _http2_async_spy(self) -> dict[str, Any]:
+        """Spy on httpx.AsyncClient.__init__ to capture http2 kwarg."""
+        captured: dict[str, Any] = {}
+        original_init = httpx.AsyncClient.__init__
+
+        def fake_init(self: Any, **kwargs: Any) -> None:
+            captured.update(kwargs)
+            return original_init(self, **kwargs)
+
+        with mock.patch.object(httpx.AsyncClient, "__init__", fake_init):
+            yield captured
+
+    async def test_default_http2_enabled_when_h2_available(self, _http2_async_spy: dict[str, Any]) -> None:
+        """http2=True should be passed through to httpx.AsyncClient when h2 is present."""
+        from openai._base_client import _HTTP2_AVAILABLE, _DefaultAsyncHttpxClient
+
+        # h2 is installed in the test environment, so _HTTP2_AVAILABLE should be True
+        assert _HTTP2_AVAILABLE is True
+
+        _DefaultAsyncHttpxClient()
+
+        assert _http2_async_spy.get("http2") is True
+
+    async def test_default_http2_can_be_explicitly_overridden(self, _http2_async_spy: dict[str, Any]) -> None:
+        """Explicit http2=False should override the default when h2 is available."""
+        from openai._base_client import _DefaultAsyncHttpxClient
+
+        _DefaultAsyncHttpxClient(http2=False)
+
+        assert _http2_async_spy.get("http2") is False
+
+    async def test_construction_with_http2_when_h2_not_available(
+        self, monkeypatch: pytest.MonkeyPatch, _http2_async_spy: dict[str, Any]
+    ) -> None:
+        """Construction should not break and http2 should default to False when h2 is absent."""
+        import openai._base_client as base_client_module
+
+        monkeypatch.setattr(base_client_module, "_HTTP2_AVAILABLE", False)
+
+        from openai._base_client import _DefaultAsyncHttpxClient
+
+        _DefaultAsyncHttpxClient()
+
+        assert _http2_async_spy.get("http2") is False
 
     @pytest.mark.respx(base_url=base_url)
     async def test_follow_redirects(self, respx_mock: MockRouter, async_client: AsyncOpenAI) -> None:


### PR DESCRIPTION
Adds http2=True to both _DefaultHttpxClient and _DefaultAsyncHttpxClient, and provides an [http2] optional dependency extra for httpx[http2].

HTTP/2 offers meaningful performance benefits: connection reuse, multiplexing, HPACK header compression, and 1-RTT TLS handshake. All major LLM API providers (OpenAI, DeepSeek, Anthropic) already support HTTP/2 via ALPN negotiation.

Falls back gracefully to HTTP/1.1 if the server doesn't support h2, or if the h2 package is not installed.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Enable HTTP/2 by default in the SDK's httpx client for both sync (`_DefaultHttpxClient`) and async (`_DefaultAsyncHttpxClient`) clients.

## Additional context & links
#3476