### PR TITLE
fix(types): make ResponseFunctionWebSearch.action optional

### DIFF
--- a/src/openai/types/beta/beta_response_function_web_search.py
+++ b/src/openai/types/beta/beta_response_function_web_search.py
@@ -86,10 +86,13 @@ class BetaResponseFunctionWebSearch(BaseModel):
     id: str
     """The unique ID of the web search tool call."""
 
-    action: Action
+    action: Optional[Action] = None
     """
     An object describing the specific action taken in this web search call. Includes
     details on how the model used the web (search, open_page, find_in_page).
+
+    May be `None` when the web search call did not produce a specific action (e.g. some
+    completed calls return no `action` in the API response).
     """
 
     status: Literal["in_progress", "searching", "completed", "failed"]

--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -78,10 +78,13 @@ class ResponseFunctionWebSearch(BaseModel):
     id: str
     """The unique ID of the web search tool call."""
 
-    action: Action
+    action: Optional[Action] = None
     """
     An object describing the specific action taken in this web search call. Includes
     details on how the model used the web (search, open_page, find_in_page).
+
+    May be `None` when the web search call did not produce a specific action (e.g. some
+    completed calls return no `action` in the API response).
     """
 
     status: Literal["in_progress", "searching", "completed", "failed"]


### PR DESCRIPTION
The API returns `action=None` for some completed web search calls, but the response type declares `action` as required. This makes attribute access such as `item.action.type` break under strict typing (and raises at runtime for users who assumed the field is always present).

Make `action` `Optional[Action] = None` in both the stable and beta response types so the model matches the actual API payload.

Fixes #3179