### PR TITLE
Fix case-insensitive header overrides

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -455,7 +455,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
 
     def _build_headers(self, options: FinalRequestOptions, *, retries_taken: int = 0) -> httpx.Headers:
         custom_headers = options.headers or {}
-        headers_dict = _merge_mappings({**self._auth_headers(options.security), **self.default_headers}, custom_headers)
+        headers_dict = _merge_headers(self._auth_headers(options.security), self.default_headers, custom_headers)
         self._validate_headers(headers_dict, custom_headers)
 
         # headers are case-insensitive while dictionaries are not.
@@ -2212,3 +2212,17 @@ def _merge_mappings(
     """
     merged = {**obj1, **obj2}
     return {key: value for key, value in merged.items() if not isinstance(value, Omit)}
+
+
+def _merge_headers(*mappings: Headers) -> dict[str, str]:
+    """Merge headers case-insensitively, with later mappings taking precedence."""
+    merged: dict[str, tuple[str, str]] = {}
+    for mapping in mappings:
+        for name, value in mapping.items():
+            normalized_name = name.lower()
+            if isinstance(value, Omit):
+                merged.pop(normalized_name, None)
+            else:
+                merged[normalized_name] = (name, value)
+
+    return {name: value for name, value in merged.values()}

--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -31,7 +31,7 @@ from ...._compat import cached_property
 from ...._models import construct_type_unchecked
 from ...._resource import SyncAPIResource, AsyncAPIResource
 from ...._exceptions import OpenAIError
-from ...._base_client import _merge_mappings
+from ...._base_client import _merge_headers
 from ....types.beta.realtime import (
     session_update_event_param,
     response_create_event_param,
@@ -378,7 +378,7 @@ class AsyncRealtimeConnectionManager:
             await connect(
                 str(url),
                 user_agent_header=self.__client.user_agent,
-                additional_headers=_merge_mappings(
+                additional_headers=_merge_headers(
                     {
                         **auth_headers,
                         "OpenAI-Beta": "realtime=v1",
@@ -561,7 +561,7 @@ class RealtimeConnectionManager:
             connect(
                 str(url),
                 user_agent_header=self.__client.user_agent,
-                additional_headers=_merge_mappings(
+                additional_headers=_merge_headers(
                     {
                         **auth_headers,
                         "OpenAI-Beta": "realtime=v1",

--- a/src/openai/resources/beta/responses/responses.py
+++ b/src/openai/resources/beta/responses/responses.py
@@ -45,7 +45,7 @@ from ....types.beta import (
 )
 from ...._exceptions import OpenAIError, WebSocketConnectionClosedError
 from ...._send_queue import SendQueue
-from ...._base_client import _merge_mappings, make_request_options
+from ...._base_client import _merge_headers, make_request_options
 from ...._event_handler import EventHandlerRegistry
 from ....types.beta.beta_response import BetaResponse
 from ....types.beta.beta_tool_param import BetaToolParam
@@ -4384,7 +4384,7 @@ class AsyncResponsesConnectionManager:
         return await connect(
             str(url),
             user_agent_header=self.__client.user_agent,
-            additional_headers=_merge_mappings(
+            additional_headers=_merge_headers(
                 {
                     **self.__client.auth_headers,
                 },
@@ -4829,7 +4829,7 @@ class ResponsesConnectionManager:
         return connect(
             str(url),
             user_agent_header=self.__client.user_agent,
-            additional_headers=_merge_mappings(
+            additional_headers=_merge_headers(
                 {
                     **self.__client.auth_headers,
                 },

--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -34,7 +34,7 @@ from ..._models import construct_type_unchecked
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._exceptions import OpenAIError, WebSocketConnectionClosedError
 from ..._send_queue import SendQueue
-from ..._base_client import _merge_mappings
+from ..._base_client import _merge_headers
 from .client_secrets import (
     ClientSecrets,
     AsyncClientSecrets,
@@ -710,7 +710,7 @@ class AsyncRealtimeConnectionManager:
         return await connect(
             str(url),
             user_agent_header=self.__client.user_agent,
-            additional_headers=_merge_mappings(
+            additional_headers=_merge_headers(
                 {
                     **auth_headers,
                 },
@@ -1178,7 +1178,7 @@ class RealtimeConnectionManager:
         return connect(
             str(url),
             user_agent_header=self.__client.user_agent,
-            additional_headers=_merge_mappings(
+            additional_headers=_merge_headers(
                 {
                     **auth_headers,
                 },

--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -55,7 +55,7 @@ from .input_tokens import (
 )
 from ..._exceptions import OpenAIError, WebSocketConnectionClosedError
 from ..._send_queue import SendQueue
-from ..._base_client import _merge_mappings, make_request_options
+from ..._base_client import _merge_headers, make_request_options
 from ..._event_handler import EventHandlerRegistry
 from ...types.responses import (
     response_create_params,
@@ -4335,7 +4335,7 @@ class AsyncResponsesConnectionManager:
         return await connect(
             str(url),
             user_agent_header=self.__client.user_agent,
-            additional_headers=_merge_mappings(
+            additional_headers=_merge_headers(
                 {
                     **self.__client.auth_headers,
                 },
@@ -4780,7 +4780,7 @@ class ResponsesConnectionManager:
         return connect(
             str(url),
             user_agent_header=self.__client.user_agent,
-            additional_headers=_merge_mappings(
+            additional_headers=_merge_headers(
                 {
                     **self.__client.auth_headers,
                 },

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,6 +35,7 @@ from openai._base_client import (
     DefaultHttpxClient,
     DefaultAsyncHttpxClient,
     get_platform,
+    _merge_headers,
     make_request_options,
 )
 
@@ -124,6 +125,14 @@ def _get_open_connections(client: OpenAI | AsyncOpenAI) -> int:
 
 
 class TestOpenAI:
+    def test_merge_headers_case_insensitively(self) -> None:
+        headers = _merge_headers(
+            {"Authorization": "Bearer real", "X-Remove": "value"},
+            {"authorization": "Bearer custom", "x-remove": Omit()},
+        )
+
+        assert headers == {"authorization": "Bearer custom"}
+
     @pytest.mark.respx(base_url=base_url)
     def test_raw_response(self, respx_mock: MockRouter, client: OpenAI) -> None:
         respx_mock.post("/foo").mock(return_value=httpx.Response(200, json={"foo": "bar"}))
@@ -453,6 +462,16 @@ class TestOpenAI:
         request = client._build_request(options)
 
         assert request.headers.get("Authorization") == f"Bearer {api_key}"
+
+        lowercase_auth_request = client._build_request(
+            FinalRequestOptions(method="get", url="/foo", headers={"authorization": "Bearer custom"})
+        )
+        assert lowercase_auth_request.headers.get_list("Authorization") == ["Bearer custom"]
+
+        omitted_auth_request = client._build_request(
+            FinalRequestOptions(method="get", url="/foo", headers={"authorization": Omit()})
+        )
+        assert "Authorization" not in omitted_auth_request.headers
 
         admin_request = client._build_request(
             FinalRequestOptions(
@@ -1717,6 +1736,16 @@ class TestAsyncOpenAI:
         options = await client._prepare_options(FinalRequestOptions(method="get", url="/foo"))
         request = client._build_request(options)
         assert request.headers.get("Authorization") == f"Bearer {api_key}"
+
+        lowercase_auth_request = client._build_request(
+            FinalRequestOptions(method="get", url="/foo", headers={"authorization": "Bearer custom"})
+        )
+        assert lowercase_auth_request.headers.get_list("Authorization") == ["Bearer custom"]
+
+        omitted_auth_request = client._build_request(
+            FinalRequestOptions(method="get", url="/foo", headers={"authorization": Omit()})
+        )
+        assert "Authorization" not in omitted_auth_request.headers
 
         admin_request = client._build_request(
             FinalRequestOptions(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

HTTP header names are case-insensitive, but the SDK currently merges them with a normal dictionary. A lowercase per-request `authorization` override therefore does not replace the generated `Authorization` header; both values are sent. A lowercase `authorization: Omit()` also fails to remove the generated credential.

This change adds a header-specific case-insensitive merge helper and uses it for HTTP requests and realtime/response websocket connections. Later header mappings keep taking precedence, and `Omit()` removes matching headers regardless of casing. The generic mapping helper remains unchanged so query and JSON keys stay case-sensitive.

Regression coverage verifies lowercase authorization replacement and removal for sync and async clients, including an assertion that only one authorization value remains.

## Additional context & links

Validated with 177 client tests, 59 Azure tests, focused Bedrock auth/header tests, Ruff, Pyright, and mypy.