### PR TITLE
fix callable api_key_provider refresh in beta.responses.connect

### DIFF
--- a/src/openai/resources/beta/responses/responses.py
+++ b/src/openai/resources/beta/responses/responses.py
@@ -4371,6 +4371,7 @@ class AsyncResponsesConnectionManager:
         except ImportError as exc:
             raise OpenAIError("You need to install `openai[realtime]` to use this method") from exc
 
+        await self.__client._refresh_api_key()
         url = self._prepare_url().copy_with(
             params={
                 **self.__client.base_url.params,
@@ -4816,6 +4817,7 @@ class ResponsesConnectionManager:
         except ImportError as exc:
             raise OpenAIError("You need to install `openai[realtime]` to use this method") from exc
 
+        self.__client._refresh_api_key()
         url = self._prepare_url().copy_with(
             params={
                 **self.__client.base_url.params,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

> [!WARNING]
> Clients using `callable` API key providers can't reliably use `beta.responses.connect`; manual fetch/refresh and management of credential lifetime is necessary without a fix.

Refresh callable API-key providers before opening sync and async Responses API WebSocket connections.

Normal HTTP requests, including `client.responses.create()`, refresh a callable `api_key` during request preparation. However, `client.beta.responses.connect()` reads `client.auth_headers` directly without first invoking `_refresh_api_key()`.

When a client is constructed with a callable provider, its initial `api_key` is empty. Consequently, the WebSocket handshake may be sent without an `Authorization` header. The same provider works with HTTP requests but fails with the Responses WebSocket API.

This change calls:

- `self.__client._refresh_api_key()` before a sync WebSocket handshake
- `await self.__client._refresh_api_key()` before an async WebSocket handshake

The refresh occurs inside `_connect_ws()`, ensuring that it applies to both initial connections and reconnection attempts. Static API keys retain their existing behavior.

Focused tests verify that:

- sync and async callable providers are invoked before connecting;
- the refreshed bearer token is included in the handshake;
- each subsequent connection attempt obtains a fresh token.

## Additional context & links

The issue was reproduced against a Foundry Responses WebSocket endpoint using an Azure Identity bearer-token provider.

Observed behavior before the change:

- `client.responses.create()` completed successfully and invoked the provider once.
- Sync `client.beta.responses.connect()` failed its handshake and invoked the provider zero times.
- Async `client.beta.responses.connect()` likewise failed because its handshake lacked a refreshed credential.
- Direct WebSocket code worked because it explicitly invoked the provider before constructing the `Authorization` header.

Observed behavior after the change:

- Both sync and async Responses WebSocket requests completed successfully.
- The callable provider was invoked before the handshake.
- The end-to-end reproduction application completed successfully.

Local validation performed:

- Focused WebSocket regression tests: 2 passed
- Existing callable API-key refresh tests: 6 passed
- Sync Foundry WebSocket request: completed
- Async Foundry WebSocket request: completed
- Ruff formatting and lint checks: passed
- Pyright: 0 errors and 0 warnings
- `git diff --check`: passed