### PR TITLE
fix: use running loop in audio helpers

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -71,7 +71,7 @@ class LocalAudioPlayer:
         else:
             audio_content = await self._tts_response_to_buffer(input)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         idx = 0
 
@@ -105,7 +105,7 @@ class LocalAudioPlayer:
         self,
         buffer_stream: AsyncGenerator[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None], None],
     ) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         buffer_queue: queue.Queue[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None]] = queue.Queue(maxsize=50)
 

--- a/src/openai/helpers/microphone.py
+++ b/src/openai/helpers/microphone.py
@@ -54,7 +54,7 @@ class Microphone(Generic[DType]):
     async def record(self, return_ndarray: None = ...) -> FileTypes: ...
 
     async def record(self, return_ndarray: Union[bool, None] = False) -> Union[npt.NDArray[DType], FileTypes]:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         self.buffer_chunks: list[npt.NDArray[DType]] = []
         start_time = time.perf_counter()


### PR DESCRIPTION
## Summary
- replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` inside async audio helper methods
- keep the existing callback behavior by retaining the captured running loop for thread-safe callback notifications and executor calls

## Problem
`asyncio.get_event_loop()` is legacy behavior in modern async code and can behave differently depending on thread/policy state. These methods are already executing inside a running coroutine, so the running loop is the precise loop the helper should capture.

## Before / after
Before, `Microphone.record()`, `LocalAudioPlayer.play()`, and `LocalAudioPlayer.play_stream()` asked asyncio for the ambient event loop.

After, they capture the currently running loop directly with `asyncio.get_running_loop()`.

## Verification
- `python -m py_compile src\openai\helpers\microphone.py src\openai\helpers\local_audio_player.py`
- `git diff --check`
- confirmed no remaining `get_event_loop()` calls in the touched helper files