### PR TITLE
fix: normalize PathLike tuple upload content

### DIFF
--- a/src/openai/_files.py
+++ b/src/openai/_files.py
@@ -61,15 +61,15 @@ def to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles | None:
 
 
 def _transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = pathlib.Path(file)
             return (path.name, path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 
@@ -103,15 +103,15 @@ async def async_to_httpx_files(files: RequestFiles | None) -> HttpxRequestFiles 
 
 
 async def _async_transform_file(file: FileTypes) -> HttpxFileTypes:
+    if is_tuple_t(file):
+        return (file[0], await async_read_file_content(file[1]), *file[2:])
+
     if is_file_content(file):
         if isinstance(file, os.PathLike):
             path = anyio.Path(file)
             return (path.name, await path.read_bytes())
 
         return file
-
-    if is_tuple_t(file):
-        return (file[0], await async_read_file_content(file[1]), *file[2:])
 
     raise TypeError(f"Expected file types input to be a FileContent type or to be a tuple")
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -21,6 +21,12 @@ def test_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_tuple_content_supports_pathlike() -> None:
+    result = to_httpx_files({"file": ("custom.txt", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("custom.txt", IsBytes())})
+
+
 @pytest.mark.asyncio
 async def test_async_pathlib_includes_file_name() -> None:
     result = await async_to_httpx_files({"file": readme_path})
@@ -40,6 +46,13 @@ async def test_async_tuple_input() -> None:
     result = await async_to_httpx_files([("file", readme_path)])
     print(result)
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_content_supports_pathlike() -> None:
+    result = await async_to_httpx_files({"file": ("custom.txt", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("custom.txt", IsBytes())})
 
 
 def test_string_not_allowed() -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3473.

Handle tuple uploads before the generic file-content branch so tuple payloads like `(filename, Path(...))` normalize their inner `PathLike` contents the same way direct file inputs already do.

## Additional context & links

Local verification:
- `PYTHONPATH=/tmp/openai-python/src python3.9 -m pytest tests/test_files.py -k tuple_content_supports_pathlike -q -o addopts=`