### PR TITLE
fix(client): use async transform for Dict[str, T] request params

### DIFF
--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -347,7 +347,7 @@ async def _async_transform_recursive(
 
     if origin == dict and is_mapping(data):
         items_type = get_args(stripped_type)[1]
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        return {key: await _async_transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
         # List[T]

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -436,6 +436,53 @@ async def test_base64_file_input(use_async: bool) -> None:
 
 @parametrize
 @pytest.mark.asyncio
+async def test_dict_of_base64_file_input(use_async: bool) -> None:
+    # a base64 file field nested inside a `Dict[str, T]` value is still transformed correctly
+    assert await transform({"key": {"foo": SAMPLE_FILE_PATH}}, Dict[str, TypedDictBase64Input], use_async) == {
+        "key": {"foo": "SGVsbG8sIHdvcmxkIQo="}
+    }  # type: ignore[comparison-overlap]
+
+
+@pytest.mark.asyncio
+async def test_async_dict_values_use_async_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression test: the async transform pipeline must recurse into `Dict[str, T]`
+    # values using the *async* helpers so that file/base64 reads don't block the event
+    # loop. Previously the async dict branch mistakenly called the synchronous
+    # `_transform_recursive`, which reads files with a blocking `Path.read_bytes()`
+    # instead of the non-blocking `anyio.Path(...).read_bytes()`.
+    import openai._utils._transform as transform_mod
+
+    sync_calls = 0
+    async_calls = 0
+
+    real_format_data = transform_mod._format_data
+    real_async_format_data = transform_mod._async_format_data
+
+    def counting_format_data(*args: Any, **kwargs: Any) -> object:
+        nonlocal sync_calls
+        sync_calls += 1
+        return real_format_data(*args, **kwargs)
+
+    async def counting_async_format_data(*args: Any, **kwargs: Any) -> object:
+        nonlocal async_calls
+        async_calls += 1
+        return await real_async_format_data(*args, **kwargs)
+
+    monkeypatch.setattr(transform_mod, "_format_data", counting_format_data)
+    monkeypatch.setattr(transform_mod, "_async_format_data", counting_async_format_data)
+
+    result = await _async_transform(
+        {"key": {"foo": SAMPLE_FILE_PATH}},
+        expected_type=Dict[str, TypedDictBase64Input],
+    )
+
+    assert result == {"key": {"foo": "SGVsbG8sIHdvcmxkIQo="}}
+    assert async_calls >= 1, "async transform must use the async file-read path for dict values"
+    assert sync_calls == 0, "async transform must not fall back to the blocking sync file-read path"
+
+
+@parametrize
+@pytest.mark.asyncio
 async def test_transform_skipping(use_async: bool) -> None:
     # lists of ints are left as-is
     data = [1, 2, 3]


### PR DESCRIPTION
## Summary

`_async_transform_recursive` (in `src/openai/_utils/_transform.py`) recurses into `Dict[str, T]` values by calling the **synchronous** `_transform_recursive` instead of its async counterpart:

```python
# async def _async_transform_recursive(...)
if origin == dict and is_mapping(data):
    items_type = get_args(stripped_type)[1]
    return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
    #                ^^^^^^^^^^^^^^^^^^ synchronous — should be `await _async_transform_recursive(...)`
```

Every other recursive call in that async function already uses the async variants — `_async_transform_typeddict` and, in the list branch immediately below, `await _async_transform_recursive(...)`. The identical dict branch in the *sync* `_transform_recursive` legitimately calls sync, so this looks like a copy‑paste slip when the async pipeline was added.

## Why it's a bug

`async_transform` exists specifically to keep file/base64 I/O off the event loop. For any `Dict[str, T]`‑typed request param whose values carry file content (a `PropertyInfo(format="base64")` field), routing dict values through the sync pipeline means the `AsyncOpenAI` client reads the file with a **blocking** `pathlib.Path.read_bytes()` (`_format_data`) on the event loop instead of the non‑blocking `await anyio.Path(...).read_bytes()` (`_async_format_data`). Output bytes are identical, but the async guarantee is silently violated.

Demonstrated by instrumenting the two format helpers while transforming `Dict[str, T]` vs `List[T]`:

| input | sync `_format_data` calls | async `_async_format_data` calls |
|---|---|---|
| `Dict[str, Inner]` (before fix) | ≥1 (blocking) | 0 |
| `List[Inner]` (already correct) | 0 | ≥1 |

## Fix

Route dict values through `await _async_transform_recursive(...)`, mirroring the list branch just below it. The synchronous branch is unchanged.

```diff
-        return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
+        return {key: await _async_transform_recursive(value, annotation=items_type) for key, value in data.items()}
```

## Tests

Adds two tests to `tests/test_transform.py`:

- `test_dict_of_base64_file_input` — a base64 `Path` field nested inside a `Dict[str, T]` value transforms correctly under both sync and async.
- `test_async_dict_values_use_async_transform` — a regression guard that spies on the sync/async format helpers and asserts the **async** file‑read path is used and the **blocking sync** path is not. This test fails on the current code (`async_calls == 0`) and passes with the fix.

## Verification

```
$ pytest tests/test_transform.py -q
59 passed
$ ruff check src/openai/_utils/_transform.py tests/test_transform.py
All checks passed!
$ ruff format --check src/openai/_utils/_transform.py tests/test_transform.py
2 files already formatted
```

Confirmed the new regression test fails on `main` (reverting only the one‑line fix) and passes with it.

This is distinct from the existing bare‑`dict`‑annotation transform PRs (which address `IndexError`/`ValueError` on `dict` with no type args) — this is a sync‑vs‑async routing correctness fix for `Dict[str, T]` values.
