### PR TITLE
fix(streaming): drain response body after [DONE] to prevent connection destruction

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,6 +61,13 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain any remaining bytes from the response body so that
+                    # h11 can parse the HTTP/1.1 chunked transfer-encoding
+                    # terminator (0\r\n\r\n) and advance its state to DONE.
+                    # Without this, response.close() destroys the connection
+                    # (TCP FIN) instead of returning it to the pool.  See #3440.
+                    for _remaining in self.response.iter_bytes():
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
@@ -171,6 +178,10 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain any remaining bytes so h11 parses the chunked
+                    # terminator before we close.  See #3440.
+                    async for _remaining in self.response.aiter_bytes():
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data


### PR DESCRIPTION
## Summary

Fixes #3440.

### Problem

When `Stream.__stream__` (sync) or `AsyncStream.__stream__` (async) encounters the `[DONE]` SSE event, it breaks out of the iteration loop and calls `response.close()` / `await response.aclose()` in the `finally` block. At this point, the underlying `iter_bytes()` / `aiter_bytes()` has **not** been fully consumed — the HTTP/1.1 chunked transfer-encoding terminator (`0\r\n\r\n`) may still be buffered in the kernel or in h11.

Because h11's `their_state` is still `SEND_RESPONSE` (not `DONE`), httpcore takes the "destroy the connection" branch instead of the "return to pool (IDLE)" branch. This causes:

1. **TCP FIN** emitted immediately after `[DONE]`, producing `downstream_remote_disconnect` spikes on upstream proxies (envoy, nginx, custom gateways).
2. Occasional `httpcore.RemoteProtocolError` / `httpx.RemoteProtocolError: peer closed connection without sending complete message body` on subsequent requests.

### Fix

Drain the remaining bytes from `iter_bytes()` / `aiter_bytes()` after observing `[DONE]`, before the `finally` block calls `close()`. This allows h11 to parse the chunked terminator and advance to `DONE` state, enabling graceful connection reuse.

### Regression History

This drain was originally present in `7e2b2544` (2023-11, "fix(client): correctly flush the stream response body") and was removed in `6132922c` (2025-10-29, "fix(client): close streams without requiring full consumption"). This commit restores the drain for both sync and async paths.

### Changes

- **`src/openai/_streaming.py`**: Added drain loops after `[DONE]` break in both `Stream.__stream__` and `AsyncStream.__stream__`.
