### PR TITLE
Set up CodeQL code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,32 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        with:
+          languages: python
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4


### PR DESCRIPTION
## Summary

- add a CodeQL workflow for the repository's Python source
- scan pull requests and pushes to `main`
- allow manual scans through `workflow_dispatch`
- use least-privilege workflow permissions and immutable action SHAs

## Why

This enables GitHub code scanning so security findings can be surfaced directly on pull requests and in the repository's Security tab. The workflow intentionally has no scheduled trigger.

## Validation

- parsed the workflow as YAML
- ran `git diff --check`
