### PR TITLE
fix: strip api key on cross-origin redirects

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -809,12 +809,28 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         return f"stainless-python-retry-{uuid.uuid4()}"
 
 
+def _strip_api_key_on_cross_origin_redirect(original: httpx.Request, redirect: httpx.Request) -> httpx.Request:
+    def origin(url: URL) -> tuple[str, str, int | None]:
+        default_port = 443 if url.scheme == "https" else 80 if url.scheme == "http" else None
+        port = url.port if url.port is not None else default_port
+        return url.scheme, url.host, port
+
+    if origin(original.url) != origin(redirect.url):
+        redirect.headers.pop("api-key", None)
+    return redirect
+
+
 class _DefaultHttpxClient(httpx.Client):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
         kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
         kwargs.setdefault("follow_redirects", True)
         super().__init__(**kwargs)
+
+    @override
+    def _build_redirect_request(self, request: httpx.Request, response: httpx.Response) -> httpx.Request:
+        redirect = super()._build_redirect_request(request, response)
+        return _strip_api_key_on_cross_origin_redirect(request, redirect)
 
 
 if TYPE_CHECKING:
@@ -1390,6 +1406,11 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         kwargs.setdefault("follow_redirects", True)
         super().__init__(**kwargs)
 
+    @override
+    def _build_redirect_request(self, request: httpx.Request, response: httpx.Response) -> httpx.Request:
+        redirect = super()._build_redirect_request(request, response)
+        return _strip_api_key_on_cross_origin_redirect(request, redirect)
+
 
 try:
     import httpx_aiohttp
@@ -1407,6 +1428,11 @@ else:
             kwargs.setdefault("follow_redirects", True)
 
             super().__init__(**kwargs)
+
+        @override
+        def _build_redirect_request(self, request: httpx.Request, response: httpx.Response) -> httpx.Request:
+            redirect = super()._build_redirect_request(request, response)
+            return _strip_api_key_on_cross_origin_redirect(request, redirect)
 
 
 if TYPE_CHECKING:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1067,6 +1067,18 @@ class TestOpenAI:
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
 
+    @pytest.mark.parametrize("client_cls", [DefaultHttpxClient, DefaultAsyncHttpxClient])
+    def test_cross_origin_redirect_strips_api_key(
+        self, client_cls: type[httpx.Client] | type[httpx.AsyncClient]
+    ) -> None:
+        client = client_cls()
+        request = httpx.Request("GET", "https://azure.example/v1/models", headers={"api-key": "secret"})
+        response = httpx.Response(302, headers={"Location": "https://other.example/target"}, request=request)
+
+        redirect = client._build_redirect_request(request, response)
+
+        assert "api-key" not in redirect.headers
+
     @pytest.mark.respx(base_url=base_url)
     def test_follow_redirects_disabled(self, respx_mock: MockRouter, client: OpenAI) -> None:
         # Test that follow_redirects=False prevents following redirects


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes openai/openai-python#3516.

Strip the Azure `api-key` credential when the SDK's default HTTP clients follow a redirect to a different origin. This keeps the existing same-origin redirect behavior and covers the synchronous, asynchronous, and aiohttp-backed default clients.

The origin comparison normalizes default HTTP/HTTPS ports, and a regression test exercises both the sync and async client implementations.

## Additional context & links

Validation completed:

- `.venv/bin/pytest -q tests/test_client.py -k 'cross_origin_redirect_strips_api_key or follow_redirects'` — 6 passed.
- `.venv/bin/ruff format --check src/openai/_base_client.py tests/test_client.py` — passed.
- `.venv/bin/ruff check src/openai/_base_client.py tests/test_client.py` — passed.
- `.venv/bin/pyright --pythonpath .venv/bin/python src/openai/_base_client.py` — passed with 0 errors.
- `.venv/bin/mypy src/openai/_base_client.py` — passed with 0 issues.
