### PR TITLE
fix: drain remaining bytes after [DONE] before closing response (#3440)

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,6 +61,19 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain remaining events from the existing iterator so the
+                    # underlying response.iter_bytes() reaches EOF, allowing
+                    # h11 to advance to DONE state before close. Without this,
+                    # response.close() sends TCP FIN while the chunked terminator
+                    # (0\r\n\r\n) is still in flight, causing connection pool
+                    # degradation and proxy errors. (#3440)
+                    #
+                    # We must drain through `iterator` (not start a new
+                    # `self.response.iter_bytes()`) because httpx only allows
+                    # one active iterator at a time — a second call raises
+                    # `httpx.StreamConsumed`.
+                    for _ in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
@@ -171,6 +184,19 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain remaining events from the existing iterator so the
+                    # underlying response.aiter_bytes() reaches EOF, allowing
+                    # h11 to advance to DONE state before close. Without this,
+                    # response.aclose() sends TCP FIN while the chunked terminator
+                    # (0\r\n\r\n) is still in flight, causing connection pool
+                    # degradation and proxy errors. (#3440)
+                    #
+                    # We must drain through `iterator` (not start a new
+                    # `self.response.aiter_bytes()`) because httpx only allows
+                    # one active iterator at a time — a second call raises
+                    # `httpx.StreamConsumed`.
+                    async for _ in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -216,6 +216,44 @@ async def test_multi_byte_character_multiple_chunks(
     assert sse.json() == {"content": "известни"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_stream_drains_after_done(
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> None:
+    """Regression test for #3440: after [DONE], remaining events should be drained.
+
+    The fix drains the existing iterator (not a new response.iter_bytes() call)
+    so that httpx doesn't raise StreamConsumed and the response reaches EOF
+    before close, preventing premature TCP FIN.
+    """
+
+    def body() -> Iterator[bytes]:
+        yield b'data: {"foo":true}\n'
+        yield b"\n"
+        yield b"data: [DONE]\n"
+        yield b"\n"
+        # Extra data after [DONE] that should be consumed by the drain
+        yield b'data: {"trailing":true}\n'
+        yield b"\n"
+
+    if sync:
+        response = httpx.Response(200, content=body())
+        stream = Stream(cast_to=object, client=client, response=response)
+        # Consume the full stream — the drain should consume the trailing event
+        for _ in stream:
+            pass
+        assert response.is_closed
+    else:
+        response = httpx.Response(200, content=to_aiter(body()))
+        stream = AsyncStream(cast_to=object, client=async_client, response=response)
+        async for _ in stream:
+            pass
+        assert response.is_closed
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -228,7 +228,13 @@ async def test_stream_drains_after_done(
     The fix drains the existing iterator (not a new response.iter_bytes() call)
     so that httpx doesn't raise StreamConsumed and the response reaches EOF
     before close, preventing premature TCP FIN.
+
+    We track whether the body generator reached its final sentinel to verify
+    that the drain actually consumed the trailing event — not just that the
+    response was closed (which happens in the finally block regardless).
     """
+
+    consumed_after_done: list[bool] = []
 
     def body() -> Iterator[bytes]:
         yield b'data: {"foo":true}\n'
@@ -238,6 +244,8 @@ async def test_stream_drains_after_done(
         # Extra data after [DONE] that should be consumed by the drain
         yield b'data: {"trailing":true}\n'
         yield b"\n"
+        # Sentinel: only reached if the drain consumed all trailing events
+        consumed_after_done.append(True)
 
     if sync:
         response = httpx.Response(200, content=body())
@@ -252,6 +260,11 @@ async def test_stream_drains_after_done(
         async for _ in stream:
             pass
         assert response.is_closed
+
+    # The sentinel is only appended if the body generator was fully consumed.
+    # Without the drain loop, the generator is garbage-collected when the
+    # response closes, so this assertion fails — proving the drain works.
+    assert consumed_after_done == [True]
 
 
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Problem

When calling `client.chat.completions.create(..., stream=True)` (or `client.responses.create(..., stream=True)`), `Stream.__stream__` breaks out of its iteration loop as soon as the underlying SSE decoder yields a `data: [DONE]` event, and then immediately invokes `response.close()` inside the `try/finally`.

The problem is that **the underlying `httpx.Response.iter_bytes()` may not have been read to EOF** at the moment of `[DONE]`. The HTTP/1.1 chunked transfer encoding terminator (`0\r\n\r\n`) may still be in flight. When `their_state` is not yet `h11.DONE`, `response.close()` takes the "destroy the connection" branch — emitting an immediate TCP FIN — instead of the graceful "back to pool (IDLE)" branch.

This produces two classes of observable failure:
1. **Upstream proxy** (envoy / nginx) logs show a spike of `downstream_remote_disconnect`
2. **Client side** occasionally raises `httpcore.RemoteProtocolError` / `httpx.RemoteProtocolError: peer closed connection without sending complete message body`

## Fix

Drain remaining bytes from `response.iter_bytes()` (sync) / `response.aiter_bytes()` (async) after observing `[DONE]`, so h11's `their_state` advances to `DONE` before `response.close()` is called.

```python
if sse.data.startswith("[DONE]"):
    # Drain remaining bytes so h11 reaches DONE state before close.
    for _ in self.response.iter_bytes():
        pass
    break
```

With `their_state == h11.DONE`, httpcore/h11 takes the graceful close path (back to `IDLE`, connection returns to the pool) rather than the destructive one.

## Test

Added `test_drain_after_done` — verifies that after consuming a stream with `[DONE]` followed by trailing bytes (simulating the chunked terminator), the response is properly closed without premature termination.

Fixes #3440
