### PR TITLE
fix(client): log exceptions during client finalization in __del__

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -879,7 +879,7 @@ class SyncHttpxClientWrapper(DefaultHttpxClient):
         try:
             self.close()
         except Exception:
-            pass
+            log.debug("Failed to auto-close client during finalization", exc_info=True)
 
 
 class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
@@ -1505,7 +1505,7 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
             # TODO(someday): support non asyncio runtimes here
             asyncio.get_running_loop().create_task(self.aclose())
         except Exception:
-            pass
+            log.debug("Failed to schedule auto-close for async client during finalization", exc_info=True)
 
 
 class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):


### PR DESCRIPTION
### Summary
Addresses #3428 by adding debug logging for exceptions raised during client finalization in __del__.

### Description
Previously, exceptions raised in \SyncHttpxClientWrapper.__del__\ and \AsyncHttpxClientWrapper.__del__\ were silently swallowed via \pass\. Logging them with \log.debug(..., exc_info=True)\ provides diagnostic visibility during debugging without changing runtime error flow.

Authored by Carl Andrie Ellepure (@ZachDreamZ).