### PR TITLE
Use UTF-8 when reading Bedrock test fixtures

### DIFF
--- a/tests/lib/bedrock_live.py
+++ b/tests/lib/bedrock_live.py
@@ -43,7 +43,7 @@ def _load_env_file() -> None:
             raise RuntimeError(f"BEDROCK_LIVE_ENV_FILE does not exist: {path}")
         return
 
-    for line_number, raw_line in enumerate(path.read_text().splitlines(), start=1):
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         line = raw_line.strip()
         if not line or line.startswith("#"):
             continue

--- a/tests/lib/test_bedrock_auth_conformance.py
+++ b/tests/lib/test_bedrock_auth_conformance.py
@@ -22,9 +22,9 @@ from openai.lib._bedrock_auth import BedrockAwsAuth, BedrockAwsAuthConfig
 FIXTURE_PATH = Path(__file__).parents[1] / "fixtures" / "bedrock_auth" / "v1" / "cases.json"
 SCHEMA_PATH = FIXTURE_PATH.with_name("schema.json")
 SHARED_SIGV4_FIXTURE_PATH = Path(__file__).parents[1] / "fixtures" / "bedrock" / "v1" / "sigv4.json"
-FIXTURES = cast(dict[str, Any], json.loads(FIXTURE_PATH.read_text()))
-SCHEMA = cast(dict[str, Any], json.loads(SCHEMA_PATH.read_text()))
-SHARED_SIGV4_FIXTURE = cast(dict[str, Any], json.loads(SHARED_SIGV4_FIXTURE_PATH.read_text()))
+FIXTURES = cast(dict[str, Any], json.loads(FIXTURE_PATH.read_text(encoding="utf-8")))
+SCHEMA = cast(dict[str, Any], json.loads(SCHEMA_PATH.read_text(encoding="utf-8")))
+SHARED_SIGV4_FIXTURE = cast(dict[str, Any], json.loads(SHARED_SIGV4_FIXTURE_PATH.read_text(encoding="utf-8")))
 
 
 def _cases(kind: str) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- Read Bedrock JSON/JSONL fixture files with `encoding="utf-8"` instead of the platform default encoding.
- Keep the opt-in Bedrock live env-file reader deterministic across developer machines.

## Problem
These test fixtures and optional live-test env files are text inputs with repo-controlled formats, but `Path.read_text()` defaults to the host locale. On Windows or other non-UTF-8 locales, that can make the Bedrock tests less portable than they need to be.

## Before / After
Before: Bedrock fixture loading depended on the platform default text encoding.

After: the fixture and env-file readers explicitly decode as UTF-8.

## Verification
- `python -m py_compile tests/lib/test_bedrock_auth_conformance.py tests/lib/bedrock_live.py`
- `uv run --with pytest --with pytest-asyncio --with pytest-xdist --with jsonschema --with respx --with botocore python -m pytest -q tests/lib/test_bedrock_auth_conformance.py` (`20 passed`)