### PR TITLE
fix: normalize API error codes to strings

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -71,7 +71,8 @@ class APIError(OpenAIError):
         self.body = body
 
         if is_dict(body):
-            self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
+            code = body.get("code")
+            self.code = str(code) if code is not None else None
             self.param = cast(Any, construct_type(type_=Optional[str], value=body.get("param")))
             self.type = cast(Any, construct_type(type_=str, value=body.get("type")))
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,6 +125,12 @@ def _get_open_connections(client: OpenAI | AsyncOpenAI) -> int:
 
 
 class TestOpenAI:
+    def test_api_error_code_is_string(self) -> None:
+        response = httpx.Response(400, request=httpx.Request("GET", base_url))
+        error = APIStatusError("Error", response=response, body={"code": 404})
+
+        assert error.code == "404"
+
     @pytest.mark.respx(base_url=base_url)
     def test_raw_response(self, respx_mock: MockRouter, client: OpenAI) -> None:
         respx_mock.post("/foo").mock(return_value=httpx.Response(200, json={"foo": "bar"}))


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Normalize non-null API error codes to strings so runtime behavior matches the public `str | None` annotation. A regression test covers numeric error payloads.

## Additional context & links

Closes #3531
