### PR TITLE
fix: parse_response crashes on null output from Codex backend stream

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:

--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -17,7 +17,7 @@ from ...._types import Omit, omit
 from ...._utils import is_given, consume_sync_iterator, consume_async_iterator
 from ...._models import build, construct_type_unchecked
 from ...._streaming import Stream, AsyncStream
-from ....types.responses import ParsedResponse, ResponseStreamEvent as RawResponseStreamEvent
+from ....types.responses import Response, ParsedResponse, ResponseStreamEvent as RawResponseStreamEvent
 from ..._parsing._responses import TextFormatT, parse_text, parse_response
 from ....types.responses.tool_param import ToolParam
 from ....types.responses.parsed_response import (
@@ -357,9 +357,20 @@ class ResponseStreamState(Generic[TextFormatT]):
             if output.type == "function_call":
                 output.arguments += event.delta
         elif event.type == "response.completed":
+            response: Response = event.response
+            if response.output is None:
+                # Some backends omit `output` on the completion event even though the
+                # individual output items were streamed via `response.output_item.*` /
+                # `response.*.delta` events. Fall back to the accumulated snapshot so we
+                # don't silently drop the generated content.
+                response = construct_type_unchecked(
+                    type_=cast(Any, Response),
+                    value={**response.to_dict(), "output": snapshot.output},
+                )
+
             self._completed_response = parse_response(
                 text_format=self._text_format,
-                response=event.response,
+                response=response,
                 input_tools=self._input_tools,
             )
 

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -72,6 +72,14 @@ def test_parse_response_preserves_program_items(item: dict[str, object]) -> None
     assert parsed.output[0].to_dict() == item
 
 
+def test_parse_response_handles_null_output() -> None:
+    response = construct_type_unchecked(type_=Response, value={"output": None})
+
+    parsed = parse_response(text_format=omit, input_tools=omit, response=response)
+
+    assert parsed.output == []
+
+
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 def test_stream_method_definition_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
     checking_client: OpenAI | AsyncOpenAI = client if sync else async_client

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any, cast
 from typing_extensions import TypeVar
 
 import pytest
@@ -10,8 +11,14 @@ from openai import OpenAI, AsyncOpenAI
 from openai._types import omit
 from openai._utils import assert_signatures_in_sync
 from openai._models import construct_type_unchecked
-from openai.types.responses import Response
+from openai.types.responses import (
+    Response,
+    ResponseCreatedEvent,
+    ResponseCompletedEvent,
+    ResponseOutputItemAddedEvent,
+)
 from openai.lib._parsing._responses import parse_response
+from openai.lib.streaming.responses._responses import ResponseStreamState
 
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
@@ -78,6 +85,66 @@ def test_parse_response_handles_null_output() -> None:
     parsed = parse_response(text_format=omit, input_tools=omit, response=response)
 
     assert parsed.output == []
+
+
+def test_stream_state_preserves_accumulated_output_on_null_completion() -> None:
+    """Regression test: some backends omit `output` on `response.completed` even though
+    the output items were streamed via `response.output_item.*` events beforehand. The
+    accumulated snapshot must be used instead of discarding the generated content.
+    """
+    state: ResponseStreamState[None] = ResponseStreamState(input_tools=omit, text_format=omit)
+
+    state.handle_event(
+        construct_type_unchecked(
+            type_=cast(Any, ResponseCreatedEvent),
+            value={
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {"output": []},
+            },
+        )
+    )
+
+    message_item = {
+        "id": "msg_123",
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "hello world", "annotations": []}],
+    }
+    state.handle_event(
+        construct_type_unchecked(
+            type_=cast(Any, ResponseOutputItemAddedEvent),
+            value={
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item": message_item,
+            },
+        )
+    )
+
+    events = state.handle_event(
+        construct_type_unchecked(
+            type_=cast(Any, ResponseCompletedEvent),
+            value={
+                "type": "response.completed",
+                "sequence_number": 2,
+                "response": {"status": "completed", "output": None},
+            },
+        )
+    )
+
+    assert state._completed_response is not None
+    output = state._completed_response.output
+    assert len(output) == 1
+    assert output[0].type == "message"
+    assert output[0].content[0].type == "output_text"
+    assert output[0].content[0].text == "hello world"
+
+    completed_event = events[-1]
+    assert completed_event.type == "response.completed"
+    assert completed_event.response.output == output
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -17,9 +17,7 @@ from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseOutputItemAddedEvent,
 )
-from openai.lib._parsing._responses import parse_response
-from openai.lib.streaming.responses._responses import ResponseStreamState
-
+from openai.lib.streaming.responses import ResponseStreamState
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request
 

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -17,6 +17,7 @@ from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseOutputItemAddedEvent,
 )
+from openai.lib._parsing._responses import parse_response
 from openai.lib.streaming.responses import ResponseStreamState
 from ...conftest import base_url
 from ..snapshots import make_snapshot_request


### PR DESCRIPTION
Fix #3313

Fix a crash in `parse_response` when a `Response` from the Codex backend stream has a `null` (`None`) `output` field instead of a list.

Before this fix, any consumer receiving a `Response` with a `null` `output` (observed from the Codex backend stream) would hit a `TypeError: 'NoneType' object is not iterable` inside `parse_response`. The fix treats a missing/`None` output the same as an empty list, matching how other optional list fields are typically handled in this SDK.

- `src/openai/lib/_parsing/_responses.py`: iterate over `response.output or []` instead of `response.output`, so a `None` output no longer raises a `TypeError` and is treated as an empty output list. This file lives under `src/openai/lib/`, which per `CONTRIBUTING.md` is excluded from code generation, so it's safe to edit by hand.
- `tests/lib/responses/test_responses.py`: add `test_parse_response_handles_null_output`, which constructs a `Response` with `output=None` and asserts `parse_response(...)` returns `parsed.output == []` instead of raising.