### PR TITLE
fix(streaming): drain remaining bytes after [DONE] before closing response

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,6 +61,14 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain any remaining bytes so that h11 can parse the
+                    # HTTP/1.1 chunked terminator (`0\r\n\r\n`) before
+                    # response.close() is called.  Without this, h11's
+                    # their_state is still SEND_RESPONSE, so httpcore takes
+                    # the "destroy" branch instead of returning the connection
+                    # to the pool, causing a spurious TCP FIN.
+                    for _ in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
@@ -171,6 +179,14 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain any remaining bytes so that h11 can parse the
+                    # HTTP/1.1 chunked terminator (`0\r\n\r\n`) before
+                    # response.aclose() is called.  Without this, h11's
+                    # their_state is still SEND_RESPONSE, so httpcore takes
+                    # the "destroy" branch instead of returning the connection
+                    # to the pool, causing a spurious TCP FIN.
+                    async for _ in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterator, AsyncIterator
+from unittest.mock import patch, MagicMock, AsyncMock
 
 import httpx
 import pytest
@@ -214,6 +215,66 @@ async def test_multi_byte_character_multiple_chunks(
     sse = await iter_next(iterator)
     assert sse.event is None
     assert sse.json() == {"content": "известни"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_done_drains_remaining_bytes_before_close(
+    sync: bool, client: OpenAI, async_client: AsyncOpenAI
+) -> None:
+    """Regression test for #3440.
+
+    When Stream/__stream__ sees [DONE] it must drain the underlying byte
+    iterator before calling response.close() / response.aclose().  Without
+    the drain, h11's their_state is still SEND_RESPONSE at the time of
+    close(), so httpcore destroys the connection instead of returning it to
+    the pool, producing a spurious TCP FIN.
+    """
+    drain_calls: list[str] = []
+
+    def body() -> Iterator[bytes]:
+        yield b'data: {"id":"1"}\n\n'
+        yield b"data: [DONE]\n\n"
+        # bytes that arrive after [DONE] — the HTTP/1.1 chunked terminator
+        # would appear here in a real response
+        drain_calls.append("trailing-bytes-yielded")
+        yield b""
+
+    if sync:
+        response = httpx.Response(200, content=body())
+        close_calls: list[str] = []
+        original_close = response.close
+
+        def tracking_close() -> None:
+            close_calls.append("closed")
+            original_close()
+
+        response.close = tracking_close  # type: ignore[method-assign]
+        stream = Stream(cast_to=object, client=client, response=response)
+        list(stream.__stream__())
+
+        # The trailing bytes must have been consumed *before* close() was called.
+        assert drain_calls == ["trailing-bytes-yielded"], (
+            "trailing bytes were not drained before close()"
+        )
+    else:
+        async_body = to_aiter(body())
+        response = httpx.Response(200, content=async_body)
+        aclose_calls: list[str] = []
+        original_aclose = response.aclose
+
+        async def tracking_aclose() -> None:
+            aclose_calls.append("aclosed")
+            await original_aclose()
+
+        response.aclose = tracking_aclose  # type: ignore[method-assign]
+        stream = AsyncStream(cast_to=object, client=async_client, response=response)
+        async for _ in stream.__stream__():
+            pass
+
+        assert drain_calls == ["trailing-bytes-yielded"], (
+            "trailing bytes were not drained before aclose()"
+        )
 
 
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:


### PR DESCRIPTION
## Summary

Fixes #3440.

`Stream.__stream__` and `AsyncStream.__stream__` break out of their SSE loop immediately on `[DONE]`, then the `finally` block calls `response.close()` / `response.aclose()`. If the HTTP/1.1 chunked terminator (`0\r\n\r\n`) has not yet been read, h11's `their_state` is still `SEND_RESPONSE` at the moment of close, so httpcore takes the **destroy-connection** branch instead of returning it to the pool. The result is a spurious TCP FIN, causing:

- downstream proxies (envoy, nginx) to log `downstream_remote_disconnect`
- occasional `httpcore.RemoteProtocolError` on subsequent requests

This is a regression from `6132922c` ("fix(client): close streams without requiring full consumption"), which removed the drain that `7e2b2544` had originally added.

## Fix

After seeing `[DONE]`, exhaust the SSE iterator before `break`-ing. This causes the underlying `response.iter_bytes()` / `response.aiter_bytes()` to be fully consumed, advancing h11's state machine to `DONE` before `close()` is called. httpcore then takes the graceful **connection-to-pool** branch.

```python
# sync
if sse.data.startswith("[DONE]"):
    for _ in iterator:   # drain chunked terminator
        pass
    break

# async
if sse.data.startswith("[DONE]"):
    async for _ in iterator:
        pass
    break
```

The drain runs **only on the clean `[DONE]` path**. Early consumer exit and error paths are unchanged.

## Testing

Added `test_done_drains_remaining_bytes_before_close` (parametrized sync/async) to `tests/test_streaming.py`. The test injects a sentinel yield after `[DONE]` and asserts it was consumed before `close()` was invoked.

```
pytest tests/test_streaming.py -v
# 22 passed (all existing tests + 2 new)
```