### PR TITLE
fix: coerce APIStatusError.code to str to match Optional[str] annotation

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -1,4 +1,4 @@
-# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+﻿# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from __future__ import annotations
 
@@ -71,7 +71,8 @@ class APIError(OpenAIError):
         self.body = body
 
         if is_dict(body):
-            self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
+            code_val = body.get("code")
+            self.code = str(code_val) if code_val is not None else None
             self.param = cast(Any, construct_type(type_=Optional[str], value=body.get("param")))
             self.type = cast(Any, construct_type(type_=str, value=body.get("type")))
         else:


### PR DESCRIPTION
## Summary

Fixes #3531 — `APIStatusError.code` is annotated `Optional[str]` but `construct_type(type_=Optional[str], value=...)` passes through non-str values unchanged (`int`, `bool`, etc.), and the `cast(Any, ...)` silences the type checker. Downstream code that trusts the annotation and calls `exc.code.strip()` crashes with `AttributeError`.

## Fix

Replace the `construct_type` + `cast` pattern with an explicit `str()` coercion guarded by a `None` check:

- Non-`None` code values (int, bool, float, etc.) → `str(value)`
- `None` → `None` (unchanged)
- String codes pass through `str()` as identity (unchanged)

## Testing

Verified all six coercion cases pass:

- `{"code": 404}` → `"404"`
- `{"code": "rate_limit"}` → `"rate_limit"`
- `{"message": "nope"}` → `None`
- `{"code": true}` → `"True"`
- `{"code": null}` → `None`
- Not a dict body → `None`