### PR TITLE
fix(streaming): return final response for incomplete and failed events

### DIFF
--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -78,11 +78,14 @@ class ResponseStream(Generic[TextFormatT]):
     def get_final_response(self) -> ParsedResponse[TextFormatT]:
         """Waits until the stream has been read to completion and returns
         the accumulated `ParsedResponse` object.
+
+        A terminal `response.completed`, `response.incomplete`, or
+        `response.failed` event is required.
         """
         self.until_done()
         response = self._state._completed_response
         if not response:
-            raise RuntimeError("Didn't receive a `response.completed` event.")
+            raise RuntimeError("Didn't receive a terminal response event.")
 
         return response
 
@@ -180,11 +183,14 @@ class AsyncResponseStream(Generic[TextFormatT]):
     async def get_final_response(self) -> ParsedResponse[TextFormatT]:
         """Waits until the stream has been read to completion and returns
         the accumulated `ParsedResponse` object.
+
+        A terminal `response.completed`, `response.incomplete`, or
+        `response.failed` event is required.
         """
         await self.until_done()
         response = self._state._completed_response
         if not response:
-            raise RuntimeError("Didn't receive a `response.completed` event.")
+            raise RuntimeError("Didn't receive a terminal response event.")
 
         return response
 
@@ -357,6 +363,18 @@ class ResponseStreamState(Generic[TextFormatT]):
             if output.type == "function_call":
                 output.arguments += event.delta
         elif event.type == "response.completed":
+            self._completed_response = parse_response(
+                text_format=self._text_format,
+                response=event.response,
+                input_tools=self._input_tools,
+            )
+        elif event.type == "response.incomplete":
+            self._completed_response = parse_response(
+                text_format=self._text_format,
+                response=event.response,
+                input_tools=self._input_tools,
+            )
+        elif event.type == "response.failed":
             self._completed_response = parse_response(
                 text_format=self._text_format,
                 response=event.response,

--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -369,16 +369,18 @@ class ResponseStreamState(Generic[TextFormatT]):
                 input_tools=self._input_tools,
             )
         elif event.type == "response.incomplete":
+            # Don't strictly parse structured output: truncation often yields invalid JSON.
             self._completed_response = parse_response(
-                text_format=self._text_format,
+                text_format=omit,
                 response=event.response,
-                input_tools=self._input_tools,
+                input_tools=omit,
             )
         elif event.type == "response.failed":
+            # Same as incomplete: preserve the terminal Response without strict parsing.
             self._completed_response = parse_response(
-                text_format=self._text_format,
+                text_format=omit,
                 response=event.response,
-                input_tools=self._input_tools,
+                input_tools=omit,
             )
 
         return snapshot

--- a/tests/lib/responses/test_response_stream_final.py
+++ b/tests/lib/responses/test_response_stream_final.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from typing import Any, Iterator, AsyncIterator, cast
+
+import httpx
+import pytest
+
+from openai import omit
+from openai._models import construct_type_unchecked
+from openai.types.responses import (
+    ResponseFailedEvent,
+    ResponseStreamEvent as RawResponseStreamEvent,
+    ResponseCreatedEvent,
+    ResponseCompletedEvent,
+    ResponseIncompleteEvent,
+)
+from openai.lib.streaming.responses import ResponseStream, AsyncResponseStream
+from openai.lib.streaming.responses._responses import ResponseStreamState
+
+
+def _response_payload(*, status: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": "resp_test",
+        "object": "response",
+        "created_at": 0,
+        "model": "gpt-4o-mini",
+        "output": [
+            {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "status": status if status != "failed" else "incomplete",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "partial answer",
+                        "annotations": [],
+                        "logprobs": [],
+                    }
+                ],
+            }
+        ],
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
+        "status": status,
+    }
+    payload.update(extra)
+    return payload
+
+
+def _event(type_: type[Any], value: dict[str, Any]) -> RawResponseStreamEvent:
+    return cast(RawResponseStreamEvent, construct_type_unchecked(type_=type_, value=value))
+
+
+def _drive_state_to_terminal(event_type: str, *, status: str, **extra: Any) -> ResponseStreamState[None]:
+    state: ResponseStreamState[None] = ResponseStreamState(input_tools=omit, text_format=omit)
+    state.handle_event(
+        _event(
+            ResponseCreatedEvent,
+            {
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": _response_payload(status="in_progress"),
+            },
+        )
+    )
+
+    terminal_type: type[Any]
+    if event_type == "response.completed":
+        terminal_type = ResponseCompletedEvent
+    elif event_type == "response.incomplete":
+        terminal_type = ResponseIncompleteEvent
+    elif event_type == "response.failed":
+        terminal_type = ResponseFailedEvent
+    else:
+        raise AssertionError(f"unexpected event type: {event_type}")
+
+    state.handle_event(
+        _event(
+            terminal_type,
+            {
+                "type": event_type,
+                "sequence_number": 1,
+                "response": _response_payload(status=status, **extra),
+            },
+        )
+    )
+    return state
+
+
+@pytest.mark.parametrize(
+    ("event_type", "status", "extra"),
+    [
+        ("response.completed", "completed", {}),
+        ("response.incomplete", "incomplete", {"incomplete_details": {"reason": "max_output_tokens"}}),
+        ("response.failed", "failed", {"error": {"code": "server_error", "message": "boom"}}),
+    ],
+)
+def test_stream_state_stores_final_response_for_terminal_events(
+    event_type: str,
+    status: str,
+    extra: dict[str, Any],
+) -> None:
+    state = _drive_state_to_terminal(event_type, status=status, **extra)
+
+    assert state._completed_response is not None
+    assert state._completed_response.status == status
+    assert state._completed_response.output_text == "partial answer"
+
+
+def test_stream_state_without_terminal_event_has_no_final_response() -> None:
+    state: ResponseStreamState[None] = ResponseStreamState(input_tools=omit, text_format=omit)
+    state.handle_event(
+        _event(
+            ResponseCreatedEvent,
+            {
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": _response_payload(status="in_progress"),
+            },
+        )
+    )
+
+    assert state._completed_response is None
+
+
+class _FakeRawStream:
+    def __init__(self, events: list[RawResponseStreamEvent], response: httpx.Response) -> None:
+        self._events = events
+        self.response = response
+
+    def __iter__(self) -> Iterator[RawResponseStreamEvent]:
+        return iter(self._events)
+
+    def close(self) -> None:
+        self.response.close()
+
+
+class _FakeAsyncRawStream:
+    def __init__(self, events: list[RawResponseStreamEvent], response: httpx.Response) -> None:
+        self._events = events
+        self.response = response
+
+    async def __aiter__(self) -> AsyncIterator[RawResponseStreamEvent]:
+        for event in self._events:
+            yield event
+
+    async def aclose(self) -> None:
+        self.response.close()
+
+
+def _terminal_events(event_type: str, *, status: str, **extra: Any) -> list[RawResponseStreamEvent]:
+    created = _event(
+        ResponseCreatedEvent,
+        {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": _response_payload(status="in_progress"),
+        },
+    )
+    terminal_type: type[Any]
+    if event_type == "response.completed":
+        terminal_type = ResponseCompletedEvent
+    elif event_type == "response.incomplete":
+        terminal_type = ResponseIncompleteEvent
+    else:
+        terminal_type = ResponseFailedEvent
+
+    terminal = _event(
+        terminal_type,
+        {
+            "type": event_type,
+            "sequence_number": 1,
+            "response": _response_payload(status=status, **extra),
+        },
+    )
+    return [created, terminal]
+
+
+@pytest.mark.parametrize(
+    ("event_type", "status", "extra"),
+    [
+        ("response.completed", "completed", {}),
+        ("response.incomplete", "incomplete", {"incomplete_details": {"reason": "max_output_tokens"}}),
+        ("response.failed", "failed", {"error": {"code": "server_error", "message": "boom"}}),
+    ],
+)
+def test_sync_get_final_response_accepts_terminal_events(
+    event_type: str,
+    status: str,
+    extra: dict[str, Any],
+) -> None:
+    response = httpx.Response(200, content=b"")
+    raw_stream = _FakeRawStream(_terminal_events(event_type, status=status, **extra), response)
+    stream = ResponseStream(
+        raw_stream=raw_stream,  # type: ignore[arg-type]
+        text_format=omit,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    final = stream.get_final_response()
+
+    assert final.status == status
+    assert final.output_text == "partial answer"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "status", "extra"),
+    [
+        ("response.completed", "completed", {}),
+        ("response.incomplete", "incomplete", {"incomplete_details": {"reason": "max_output_tokens"}}),
+        ("response.failed", "failed", {"error": {"code": "server_error", "message": "boom"}}),
+    ],
+)
+async def test_async_get_final_response_accepts_terminal_events(
+    event_type: str,
+    status: str,
+    extra: dict[str, Any],
+) -> None:
+    response = httpx.Response(200, content=b"")
+    raw_stream = _FakeAsyncRawStream(_terminal_events(event_type, status=status, **extra), response)
+    stream = AsyncResponseStream(
+        raw_stream=raw_stream,  # type: ignore[arg-type]
+        text_format=omit,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    final = await stream.get_final_response()
+
+    assert final.status == status
+    assert final.output_text == "partial answer"
+
+
+def test_sync_get_final_response_requires_terminal_event() -> None:
+    response = httpx.Response(200, content=b"")
+    created = _event(
+        ResponseCreatedEvent,
+        {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": _response_payload(status="in_progress"),
+        },
+    )
+    stream = ResponseStream(
+        raw_stream=_FakeRawStream([created], response),  # type: ignore[arg-type]
+        text_format=omit,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    with pytest.raises(RuntimeError, match="terminal response event"):
+        stream.get_final_response()
+
+
+@pytest.mark.asyncio
+async def test_async_get_final_response_requires_terminal_event() -> None:
+    response = httpx.Response(200, content=b"")
+    created = _event(
+        ResponseCreatedEvent,
+        {
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": _response_payload(status="in_progress"),
+        },
+    )
+    stream = AsyncResponseStream(
+        raw_stream=_FakeAsyncRawStream([created], response),  # type: ignore[arg-type]
+        text_format=omit,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    with pytest.raises(RuntimeError, match="terminal response event"):
+        await stream.get_final_response()

--- a/tests/lib/responses/test_response_stream_final.py
+++ b/tests/lib/responses/test_response_stream_final.py
@@ -4,6 +4,7 @@ from typing import Any, Iterator, AsyncIterator, cast
 
 import httpx
 import pytest
+import pydantic
 
 from openai import omit
 from openai._models import construct_type_unchecked
@@ -18,7 +19,11 @@ from openai.lib.streaming.responses import ResponseStream, AsyncResponseStream
 from openai.lib.streaming.responses._responses import ResponseStreamState
 
 
-def _response_payload(*, status: str, **extra: Any) -> dict[str, Any]:
+class _Answer(pydantic.BaseModel):
+    value: str
+
+
+def _response_payload(*, status: str, text: str = "partial answer", **extra: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "id": "resp_test",
         "object": "response",
@@ -33,7 +38,7 @@ def _response_payload(*, status: str, **extra: Any) -> dict[str, Any]:
                 "content": [
                     {
                         "type": "output_text",
-                        "text": "partial answer",
+                        "text": text,
                         "annotations": [],
                         "logprobs": [],
                     }
@@ -53,15 +58,22 @@ def _event(type_: type[Any], value: dict[str, Any]) -> RawResponseStreamEvent:
     return cast(RawResponseStreamEvent, construct_type_unchecked(type_=type_, value=value))
 
 
-def _drive_state_to_terminal(event_type: str, *, status: str, **extra: Any) -> ResponseStreamState[None]:
-    state: ResponseStreamState[None] = ResponseStreamState(input_tools=omit, text_format=omit)
+def _drive_state_to_terminal(
+    event_type: str,
+    *,
+    status: str,
+    text: str = "partial answer",
+    text_format: type[Any] | Any = omit,
+    **extra: Any,
+) -> ResponseStreamState[Any]:
+    state: ResponseStreamState[Any] = ResponseStreamState(input_tools=omit, text_format=text_format)
     state.handle_event(
         _event(
             ResponseCreatedEvent,
             {
                 "type": "response.created",
                 "sequence_number": 0,
-                "response": _response_payload(status="in_progress"),
+                "response": _response_payload(status="in_progress", text=""),
             },
         )
     )
@@ -82,7 +94,7 @@ def _drive_state_to_terminal(event_type: str, *, status: str, **extra: Any) -> R
             {
                 "type": event_type,
                 "sequence_number": 1,
-                "response": _response_payload(status=status, **extra),
+                "response": _response_payload(status=status, text=text, **extra),
             },
         )
     )
@@ -107,6 +119,52 @@ def test_stream_state_stores_final_response_for_terminal_events(
     assert state._completed_response is not None
     assert state._completed_response.status == status
     assert state._completed_response.output_text == "partial answer"
+
+
+@pytest.mark.parametrize(
+    ("event_type", "status", "extra"),
+    [
+        ("response.incomplete", "incomplete", {"incomplete_details": {"reason": "max_output_tokens"}}),
+        ("response.failed", "failed", {"error": {"code": "server_error", "message": "boom"}}),
+    ],
+)
+def test_stream_state_preserves_truncated_output_on_non_completed_terminal_events(
+    event_type: str,
+    status: str,
+    extra: dict[str, Any],
+) -> None:
+    truncated = '{"value":'
+    state = _drive_state_to_terminal(
+        event_type,
+        status=status,
+        text=truncated,
+        text_format=_Answer,
+        **extra,
+    )
+
+    assert state._completed_response is not None
+    assert state._completed_response.status == status
+    assert state._completed_response.output_text == truncated
+
+    content = state._completed_response.output[0]
+    assert content.type == "message"
+    assert content.content[0].type == "output_text"
+    assert content.content[0].parsed is None
+
+
+def test_stream_state_parses_structured_output_on_completed_event() -> None:
+    state = _drive_state_to_terminal(
+        "response.completed",
+        status="completed",
+        text='{"value":"done"}',
+        text_format=_Answer,
+    )
+
+    assert state._completed_response is not None
+    content = state._completed_response.output[0]
+    assert content.type == "message"
+    assert content.content[0].type == "output_text"
+    assert content.content[0].parsed == _Answer(value="done")
 
 
 def test_stream_state_without_terminal_event_has_no_final_response() -> None:
@@ -150,13 +208,19 @@ class _FakeAsyncRawStream:
         self.response.close()
 
 
-def _terminal_events(event_type: str, *, status: str, **extra: Any) -> list[RawResponseStreamEvent]:
+def _terminal_events(
+    event_type: str,
+    *,
+    status: str,
+    text: str = "partial answer",
+    **extra: Any,
+) -> list[RawResponseStreamEvent]:
     created = _event(
         ResponseCreatedEvent,
         {
             "type": "response.created",
             "sequence_number": 0,
-            "response": _response_payload(status="in_progress"),
+            "response": _response_payload(status="in_progress", text=""),
         },
     )
     terminal_type: type[Any]
@@ -172,7 +236,7 @@ def _terminal_events(event_type: str, *, status: str, **extra: Any) -> list[RawR
         {
             "type": event_type,
             "sequence_number": 1,
-            "response": _response_payload(status=status, **extra),
+            "response": _response_payload(status=status, text=text, **extra),
         },
     )
     return [created, terminal]
@@ -206,6 +270,40 @@ def test_sync_get_final_response_accepts_terminal_events(
     assert final.output_text == "partial answer"
 
 
+@pytest.mark.parametrize(
+    ("event_type", "status", "extra"),
+    [
+        ("response.incomplete", "incomplete", {"incomplete_details": {"reason": "max_output_tokens"}}),
+        ("response.failed", "failed", {"error": {"code": "server_error", "message": "boom"}}),
+    ],
+)
+def test_sync_get_final_response_preserves_truncated_structured_output(
+    event_type: str,
+    status: str,
+    extra: dict[str, Any],
+) -> None:
+    truncated = '{"value":'
+    response = httpx.Response(200, content=b"")
+    stream = ResponseStream(
+        raw_stream=_FakeRawStream(  # type: ignore[arg-type]
+            _terminal_events(event_type, status=status, text=truncated, **extra),
+            response,
+        ),
+        text_format=_Answer,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    final = stream.get_final_response()
+
+    assert final.status == status
+    assert final.output_text == truncated
+    content = final.output[0]
+    assert content.type == "message"
+    assert content.content[0].type == "output_text"
+    assert content.content[0].parsed is None
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("event_type", "status", "extra"),
@@ -233,6 +331,41 @@ async def test_async_get_final_response_accepts_terminal_events(
 
     assert final.status == status
     assert final.output_text == "partial answer"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_type", "status", "extra"),
+    [
+        ("response.incomplete", "incomplete", {"incomplete_details": {"reason": "max_output_tokens"}}),
+        ("response.failed", "failed", {"error": {"code": "server_error", "message": "boom"}}),
+    ],
+)
+async def test_async_get_final_response_preserves_truncated_structured_output(
+    event_type: str,
+    status: str,
+    extra: dict[str, Any],
+) -> None:
+    truncated = '{"value":'
+    response = httpx.Response(200, content=b"")
+    stream = AsyncResponseStream(
+        raw_stream=_FakeAsyncRawStream(  # type: ignore[arg-type]
+            _terminal_events(event_type, status=status, text=truncated, **extra),
+            response,
+        ),
+        text_format=_Answer,
+        input_tools=omit,
+        starting_after=None,
+    )
+
+    final = await stream.get_final_response()
+
+    assert final.status == status
+    assert final.output_text == truncated
+    content = final.output[0]
+    assert content.type == "message"
+    assert content.content[0].type == "output_text"
+    assert content.content[0].parsed is None
 
 
 def test_sync_get_final_response_requires_terminal_event() -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

### Summary

`ResponseStream.get_final_response()` / `AsyncResponseStream.get_final_response()` only stored a final `ParsedResponse` when a `response.completed` event arrived. Terminal `response.incomplete` and `response.failed` events already carry a full `Response` payload (for example after `max_output_tokens` truncation), but calling `get_final_response()` after those streams still raised:

```text
RuntimeError: Didn't receive a `response.completed` event.
```

This change treats `response.incomplete` and `response.failed` as terminal events in `ResponseStreamState.accumulate_event`, matching:

- the OpenAI Node SDK `ResponseAccumulator` (`response.completed` | `response.failed` | `response.incomplete`)
- Assistants streaming helpers, which update the final run on incomplete/failed
- Chat Completions `get_final_completion()`, which returns the snapshot regardless of `finish_reason`

The touched code lives under `src/openai/lib/`, which CONTRIBUTING.md states is not modified by the generator.

### Problem

Minimal reproduction (no API key):

```python
from openai import omit
from openai._models import construct_type
from openai.types.responses import ResponseCreatedEvent, ResponseIncompleteEvent
from openai.lib.streaming.responses._responses import ResponseStreamState

minimal = {
    "id": "resp_test",
    "object": "response",
    "created_at": 0,
    "status": "in_progress",
    "model": "gpt-4o-mini",
    "output": [],
    "parallel_tool_calls": True,
    "tool_choice": "auto",
    "tools": [],
}

state = ResponseStreamState(input_tools=omit, text_format=omit)
state.handle_event(construct_type(type_=ResponseCreatedEvent, value={
    "type": "response.created",
    "sequence_number": 0,
    "response": minimal,
}))
state.handle_event(construct_type(type_=ResponseIncompleteEvent, value={
    "type": "response.incomplete",
    "sequence_number": 1,
    "response": {**minimal, "status": "incomplete"},
}))
assert state._completed_response is None  # bug: should be the incomplete ParsedResponse
```

### Current behavior

- `response.completed` → `_completed_response` is set; `get_final_response()` succeeds
- `response.incomplete` / `response.failed` → `_completed_response` stays `None`; `get_final_response()` raises `RuntimeError`

### Corrected behavior

All three terminal events populate `_completed_response` via `parse_response(...)`. Sync and async `get_final_response()` return that parsed response. If no terminal event was seen, the error message now says a terminal response event was missing.

### Root cause

`accumulate_event` only handled `response.completed` when assigning `_completed_response`.

### Implementation

Smallest change in `src/openai/lib/streaming/responses/_responses.py`:

- store the parsed response for `response.incomplete` and `response.failed`
- document terminal-event requirement on sync/async `get_final_response()`
- update the missing-terminal-event `RuntimeError` message

No public request/response shapes changed. No generated API resources/types edited.

### Regression tests

Added `tests/lib/responses/test_response_stream_final.py`:

- stream state stores final response for completed / incomplete / failed
- no terminal event → no final response
- sync + async `get_final_response()` for all three terminal events
- sync + async error when the stream ends without a terminal event

### Validation

Pre-fix (expected failures on incomplete/failed paths):

```text
PYTHONPATH=src python -m pytest tests/lib/streaming/test_response_stream_final.py -q
# 8 failed, 4 passed
```

Post-fix:

```text
PYTHONPATH=src python -m pytest tests/lib/responses/test_response_stream_final.py tests/lib/responses/test_responses.py -q
# 19 passed

ruff format --check <changed files>   # pass
ruff check <changed files>            # pass
./scripts/run-pyright src/openai/lib/streaming/responses/_responses.py tests/lib/responses/test_response_stream_final.py
# 0 errors
mypy src/openai/lib/streaming/responses/_responses.py
# Success
python -m build
# Successfully built openai-2.48.0.tar.gz and openai-2.48.0-py3-none-any.whl
git diff --check
# clean
```

Not run / limitations:

- Full `./scripts/test` against the Steady mock server (requires `./scripts/mock`)
- Full `./scripts/lint` via Rye (local validation used the project `.venv` tools equivalent to ruff/pyright/mypy/import check for the changed files)
- Chat completions inline-snapshot tests fail under pytest-xdist on clean `upstream/main` as well (pre-existing; unrelated)

### Compatibility

- Successful `response.completed` streams are unchanged
- Callers that previously got `RuntimeError` on incomplete/failed streams now receive the terminal `ParsedResponse` (inspect `status` / `incomplete_details` / `error` as needed)
- Exception message text for the no-terminal-event case changed slightly

## Additional context & links

- Analyzed against `upstream/main` @ `8a6adcb3` (release 2.48.0)
- Related but distinct open work: #3263 / #3378 (defer structured-output parse until incomplete is known) — does not set `_completed_response` for incomplete/failed
- Node parity: `openai-node` `ResponseAccumulator` handles `response.completed` | `response.failed` | `response.incomplete` together
