### PR TITLE
fix: coerce numeric API error codes to strings

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -58,7 +58,8 @@ class APIError(OpenAIError):
         self.body = body
 
         if is_dict(body):
-            self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
+            code = body.get("code")
+            self.code = str(code) if code is not None else None
             self.param = cast(Any, construct_type(type_=Optional[str], value=body.get("param")))
             self.type = cast(Any, construct_type(type_=str, value=body.get("type")))
         else:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,12 @@
+import httpx
+
+from openai import APIStatusError
+
+
+def test_integer_error_code_is_coerced_to_string() -> None:
+    request = httpx.Request("GET", "https://api.openai.com/v1/models")
+    response = httpx.Response(404, request=request)
+
+    error = APIStatusError("Not found", response=response, body={"code": 404})
+
+    assert error.code == "404"


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Normalize non-null API error codes to strings when constructing `APIError`, so the runtime value matches the documented `str | None` contract even when an endpoint or compatible gateway returns a numeric JSON code.

Add a focused regression test covering a numeric `404` error code.

Fixes #3531

## Additional context & links

Validation:

- `.venv/bin/python -m pytest tests/test_exceptions.py -q`
- `.venv/bin/ruff check src/openai/_exceptions.py tests/test_exceptions.py`
- `.venv/bin/ruff format --check src/openai/_exceptions.py tests/test_exceptions.py`
- `.venv/bin/mypy src/openai/_exceptions.py`
