### PR TITLE
fix(files): support PathLike objects inside upload tuples

### DIFF
--- a/src/openai/_files.py
+++ b/src/openai/_files.py
@@ -27,13 +27,11 @@ def is_base64_file_input(obj: object) -> TypeGuard[Base64FileInput]:
 
 
 def is_file_content(obj: object) -> TypeGuard[FileContent]:
-    return (
-        isinstance(obj, bytes) or isinstance(obj, tuple) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
-    )
+    return isinstance(obj, bytes) or isinstance(obj, io.IOBase) or isinstance(obj, os.PathLike)
 
 
 def assert_is_file_content(obj: object, *, key: str | None = None) -> None:
-    if not is_file_content(obj):
+    if not (is_file_content(obj) or isinstance(obj, tuple)):
         prefix = f"Expected entry at `{key}`" if key is not None else f"Expected file input `{obj!r}`"
         raise RuntimeError(
             f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/openai/openai-python/tree/main#file-uploads"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -43,6 +43,19 @@ async def test_async_tuple_input() -> None:
     assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
 
 
+def test_tuple_in_mapping_normalizes_path() -> None:
+    result = to_httpx_files({"file": ("custom_name.txt", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("custom_name.txt", IsBytes())})
+
+
+@pytest.mark.asyncio
+async def test_async_tuple_in_mapping_normalizes_path() -> None:
+    result = await async_to_httpx_files({"file": ("custom_name.txt", readme_path)})
+    print(result)
+    assert result == IsDict({"file": IsTuple("custom_name.txt", IsBytes())})
+
+
 def test_string_not_allowed() -> None:
     with pytest.raises(TypeError, match="Expected file types input to be a FileContent type or to be a tuple"):
         to_httpx_files(


### PR DESCRIPTION
### Summary
This PR fixes a bug where `PathLike` objects passed inside custom upload tuples (e.g. `("custom_name.txt", Path("file.txt"))`) were not normalized to bytes, causing `httpx` to raise an `AttributeError` at runtime (see #3473).

### Changes
1. **`src/openai/_files.py`**:
   - Excluded `tuple` from `is_file_content` so that custom upload tuples fall through to the `is_tuple_t` block in `_transform_file` and `_async_transform_file`, which successfully normalizes the nested `PathLike` object.
   - Updated `assert_is_file_content` to check for `is_file_content(obj) or isinstance(obj, tuple)` to preserve tuple input validation.
2. **`tests/test_files.py`**:
   - Added `test_tuple_in_mapping_normalizes_path` and `test_async_tuple_in_mapping_normalizes_path` to verify the fix for both sync and async paths.

All 16 file tests pass successfully.
