### PR TITLE
fix(exceptions): support integer error codes in APIError validationfix(exceptions): support integer error codes in APIError validation

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, cast, Union
 from typing_extensions import Literal
 
 import httpx
@@ -60,7 +60,7 @@ class APIError(OpenAIError):
     If there was no response associated with this error then it will be `None`.
     """
 
-    code: Optional[str] = None
+    code: Optional[Union[str, int]] = None
     param: Optional[str] = None
     type: Optional[str]
 
@@ -71,7 +71,7 @@ class APIError(OpenAIError):
         self.body = body
 
         if is_dict(body):
-            self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
+            self.code = cast(Any, construct_type(type_=Optional[Union[str, int]], value=body.get("code")))
             self.param = cast(Any, construct_type(type_=Optional[str], value=body.get("param")))
             self.type = cast(Any, construct_type(type_=str, value=body.get("type")))
         else:

--- a/src/openai/types/shared/error_object.py
+++ b/src/openai/types/shared/error_object.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import Optional, Union
 
 from ..._models import BaseModel
 
@@ -8,7 +8,7 @@ __all__ = ["ErrorObject"]
 
 
 class ErrorObject(BaseModel):
-    code: Optional[str] = None
+    code: Optional[Union[str, int]] = None
 
     message: str
 

--- a/tests/test_exceptions_custom.py
+++ b/tests/test_exceptions_custom.py
@@ -1,0 +1,33 @@
+import httpx
+import pytest
+import openai
+from openai import OpenAI, BadRequestError
+from respx import MockRouter
+
+base_url = "https://api.openai.com/v1"
+
+@pytest.mark.respx(base_url=base_url)
+def test_error_code_integer_parsing(respx_mock: MockRouter) -> None:
+    respx_mock.post("/chat/completions").mock(
+        return_value=httpx.Response(
+            400,
+            json={
+                "error": {
+                    "message": "The request is invalid.",
+                    "type": "invalid_request_error",
+                    "code": 400,
+                    "param": "model"
+                }
+            }
+        )
+    )
+
+    client = OpenAI(base_url=base_url, api_key="test-api-key")
+    
+    with pytest.raises(BadRequestError) as exc_info:
+        client.chat.completions.create(messages=[{"role": "user", "content": "hello"}], model="gpt-4")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.code == 400
+    assert "The request is invalid." in exc_info.value.message
+    assert exc_info.value.param == "model"


### PR DESCRIPTION
### Summary
This PR fixes an issue where error responses containing integer/numeric error codes (e.g. `{"error": {"code": 400}}` instead of `{"error": {"code": "invalid_request"}}`) raise a runtime validation/type error because `APIError.code` and `ErrorObject.code` were strictly typed as `Optional[str]`.

This is common when using various OpenAI-compatible gateways or proxy endpoints that return integer codes.

### Key Changes
* Widen type of `APIError.code` in `src/openai/_exceptions.py` to `Optional[Union[str, int]]` and update `construct_type` to allow both types.
* * Widen type of `ErrorObject.code` in `src/openai/types/shared/error_object.py` to `Optional[Union[str, int]]`.
* * Add a mock integration test in `tests/test_exceptions_custom.py` to verify that numeric error codes are correctly parsed and mapped to the exception attributes without throwing a type validation error.
Closes #3531