### PR TITLE
chore(ci): pin setup-uv v5 to its underlying commit

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -66,7 +66,7 @@ jobs:
           path: openai-agents-python
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
 


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/detect-breaking-changes.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
```

**Why this is wrong:**

- `e58605a9b6da7c637471fab8847a5e5a6b8df081` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v5`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v5` points to**: `d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
