### PR TITLE
fix: add logging to empty exception handlers in _base_client.py

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -894,7 +894,7 @@ class SyncHttpxClientWrapper(DefaultHttpxClient):
         try:
             self.close()
         except Exception:
-            log.debug("Failed to close client", exc_info=True)
+            pass  # best-effort; __del__ may run during interpreter teardown
 
 
 class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
@@ -1520,7 +1520,7 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
             # TODO(someday): support non asyncio runtimes here
             asyncio.get_running_loop().create_task(self.aclose())
         except Exception:
-            log.debug("Failed to close async client", exc_info=True)
+            pass  # expected when no event loop is running (GC / interpreter shutdown)
 
 
 class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -894,7 +894,7 @@ class SyncHttpxClientWrapper(DefaultHttpxClient):
         try:
             self.close()
         except Exception:
-            pass
+            log.debug("Failed to close client", exc_info=True)
 
 
 class SyncAPIClient(BaseClient[httpx.Client, Stream[Any]]):
@@ -1520,7 +1520,7 @@ class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
             # TODO(someday): support non asyncio runtimes here
             asyncio.get_running_loop().create_task(self.aclose())
         except Exception:
-            pass
+            log.debug("Failed to close async client", exc_info=True)
 
 
 class AsyncAPIClient(BaseClient[httpx.AsyncClient, AsyncStream[Any]]):


### PR DESCRIPTION
Fixes #3428

Found an empty exception handler `except: pass` pattern in _base_client.py. Empty exception handlers silently swallow errors, which can make debugging very difficult.

This PR replaces `pass` with a debug log message when closing the client connections.