### PR TITLE
fix(streaming): drain remaining bytes after [DONE] before closing response

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,12 +61,27 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
-                    # Drain the remaining bytes from the underlying iterator so that
-                    # the HTTP/1.1 chunked terminator (0\r\n\r\n) is fully consumed.
-                    # Without this, h11's `their_state` is still SEND_RESPONSE when
-                    # response.close() is called, causing httpcore to destroy the
-                    # connection (TCP FIN) instead of returning it to the pool.
-                    for _ in iterator:
+                    # Best-effort drain: consume the remaining bytes so that
+                    # the HTTP/1.1 chunked terminator (0\r\n\r\n) is read by
+                    # h11 before response.close() is called. Without this,
+                    # h11's `their_state` stays SEND_RESPONSE and httpcore
+                    # destroys the socket (TCP FIN) instead of returning the
+                    # connection to the pool.
+                    #
+                    # The drain is wrapped in try/except for two reasons:
+                    # 1. Suppress post-DONE transport errors: if the proxy
+                    #    closes the connection abruptly after [DONE], the
+                    #    read raises a protocol error that is irrelevant
+                    #    because the application-level stream is already done.
+                    # 2. Bound the drain: if the server keeps the SSE
+                    #    connection open indefinitely after [DONE], the
+                    #    user's configured read timeout will eventually fire
+                    #    as an exception here, which we catch and ignore so
+                    #    the stream still closes cleanly.
+                    try:
+                        for _ in iterator:
+                            pass
+                    except Exception:
                         pass
                     break
 
@@ -178,13 +193,27 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
-                    # Drain the remaining bytes from the underlying async iterator so
-                    # that the HTTP/1.1 chunked terminator (0\r\n\r\n) is fully
-                    # consumed. Without this, h11's `their_state` is still
-                    # SEND_RESPONSE when aclose() is called, causing httpcore to
-                    # destroy the connection (TCP FIN) instead of returning it to the
-                    # pool.
-                    async for _ in iterator:
+                    # Best-effort drain: consume the remaining bytes so that
+                    # the HTTP/1.1 chunked terminator (0\r\n\r\n) is read by
+                    # h11 before aclose() is called. Without this, h11's
+                    # `their_state` stays SEND_RESPONSE and httpcore destroys
+                    # the socket (TCP FIN) instead of returning the connection
+                    # to the pool.
+                    #
+                    # The drain is wrapped in try/except for two reasons:
+                    # 1. Suppress post-DONE transport errors: if the proxy
+                    #    closes the connection abruptly after [DONE], the
+                    #    read raises a protocol error that is irrelevant
+                    #    because the application-level stream is already done.
+                    # 2. Bound the drain: if the server keeps the SSE
+                    #    connection open indefinitely after [DONE], the
+                    #    user's configured read timeout will eventually fire
+                    #    as an exception here, which we catch and ignore so
+                    #    the stream still closes cleanly.
+                    try:
+                        async for _ in iterator:
+                            pass
+                    except Exception:
                         pass
                     break
 

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,6 +61,13 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain the remaining bytes from the underlying iterator so that
+                    # the HTTP/1.1 chunked terminator (0\r\n\r\n) is fully consumed.
+                    # Without this, h11's `their_state` is still SEND_RESPONSE when
+                    # response.close() is called, causing httpcore to destroy the
+                    # connection (TCP FIN) instead of returning it to the pool.
+                    for _ in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
@@ -171,6 +178,14 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain the remaining bytes from the underlying async iterator so
+                    # that the HTTP/1.1 chunked terminator (0\r\n\r\n) is fully
+                    # consumed. Without this, h11's `their_state` is still
+                    # SEND_RESPONSE when aclose() is called, causing httpcore to
+                    # destroy the connection (TCP FIN) instead of returning it to the
+                    # pool.
+                    async for _ in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,23 +61,9 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
-                    # Best-effort drain: consume the remaining bytes so that
-                    # the HTTP/1.1 chunked terminator (0\r\n\r\n) is read by
-                    # h11 before response.close() is called. Without this,
-                    # h11's `their_state` stays SEND_RESPONSE and httpcore
-                    # destroys the socket (TCP FIN) instead of returning the
-                    # connection to the pool.
-                    #
-                    # The drain is wrapped in try/except for two reasons:
-                    # 1. Suppress post-DONE transport errors: if the proxy
-                    #    closes the connection abruptly after [DONE], the
-                    #    read raises a protocol error that is irrelevant
-                    #    because the application-level stream is already done.
-                    # 2. Bound the drain: if the server keeps the SSE
-                    #    connection open indefinitely after [DONE], the
-                    #    user's configured read timeout will eventually fire
-                    #    as an exception here, which we catch and ignore so
-                    #    the stream still closes cleanly.
+                    # Drain remaining bytes so h11 fully parses the chunked terminator
+                    # before close(), allowing the connection to be returned to the pool.
+                    # Errors are suppressed — the stream is done at [DONE] regardless.
                     try:
                         for _ in iterator:
                             pass
@@ -193,23 +179,9 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
-                    # Best-effort drain: consume the remaining bytes so that
-                    # the HTTP/1.1 chunked terminator (0\r\n\r\n) is read by
-                    # h11 before aclose() is called. Without this, h11's
-                    # `their_state` stays SEND_RESPONSE and httpcore destroys
-                    # the socket (TCP FIN) instead of returning the connection
-                    # to the pool.
-                    #
-                    # The drain is wrapped in try/except for two reasons:
-                    # 1. Suppress post-DONE transport errors: if the proxy
-                    #    closes the connection abruptly after [DONE], the
-                    #    read raises a protocol error that is irrelevant
-                    #    because the application-level stream is already done.
-                    # 2. Bound the drain: if the server keeps the SSE
-                    #    connection open indefinitely after [DONE], the
-                    #    user's configured read timeout will eventually fire
-                    #    as an exception here, which we catch and ignore so
-                    #    the stream still closes cleanly.
+                    # Drain remaining bytes so h11 fully parses the chunked terminator
+                    # before aclose(), allowing the connection to be returned to the pool.
+                    # Errors are suppressed — the stream is done at [DONE] regardless.
                     try:
                         async for _ in iterator:
                             pass


### PR DESCRIPTION
Closes #3440

## Problem

When `Stream.__stream__` (and `AsyncStream.__stream__`) encounters the `[DONE]` SSE event, it immediately `break`s out of the loop and the `finally` block calls `response.close()` / `await response.aclose()`.

At that moment, the **underlying HTTP/1.1 chunked transfer iterator has not been read to EOF**. Specifically, the chunked terminator (`0\r\n\r\n`) may still be buffered in the kernel or in h11's receive buffer. h11 tracks the remote connection state machine. When `response.close()` is called while `h11`'s `their_state` is still `SEND_RESPONSE` (terminator not yet parsed), `httpcore` takes the **destroy-the-connection** branch instead of the **return-to-pool (IDLE)** branch. This emits an immediate TCP FIN on the socket.

Observable symptoms:
- **Upstream proxy logs**: spike of `downstream_remote_disconnect` (Envoy / nginx / any HTTP/1.1 chunked-forwarding gateway)
- **Client side**: occasional `httpcore.RemoteProtocolError` / `httpx.RemoteProtocolError: peer closed connection without sending complete message body` on the next request

## Root Cause & Regression History

This was originally fixed in `7e2b2544` ("fix(client): correctly flush the stream response body"). It was accidentally removed in `6132922c` ("fix(client): close streams without requiring full consumption") and has been present in all releases since `2.15.0`, including the current `2.44.0`.

## Fix

After observing `[DONE]`, exhaust the remaining SSE iterator before `break`ing. This drains the chunked terminator through h11's state machine so that `their_state` reaches `DONE`, and `response.close()` then takes the **graceful path** (back to `IDLE`, connection returned to the pool).

### Sync path (`Stream.__stream__`)
```python
if sse.data.startswith("[DONE]"):
    # Drain remaining bytes so h11 state reaches DONE before close.
    for _ in iterator:
        pass
    break
```

### Async path (`AsyncStream.__stream__`)
```python
if sse.data.startswith("[DONE]"):
    # Drain remaining bytes so h11 state reaches DONE before aclose.
    async for _ in iterator:
        pass
    break
```

## Impact

This fix restores the connection-pooling behaviour that existed before `6132922c`. High-throughput applications using streaming completions behind a reverse proxy (Envoy, nginx, etc.) will immediately see a reduction in spurious `downstream_remote_disconnect` errors and improved connection reuse / latency.