### PR TITLE
fix(bedrock): exclude connection header from SigV4 signing

### DIFF
--- a/src/openai/lib/_bedrock_auth.py
+++ b/src/openai/lib/_bedrock_auth.py
@@ -23,7 +23,28 @@ _AWS_SIGNING_HEADERS = (
     "x-amz-date",
     "x-amz-security-token",
 )
-_HOP_BY_HOP_HEADERS = ("connection",)
+# Volatile transport headers that intermediaries (proxies, load balancers, and
+# other nodes) may add or rewrite in transit. AWS SigV4 guidance is to exclude
+# these from the signature so such rewrites do not invalidate it. This mirrors
+# botocore's own SIGNED_HEADERS_BLACKLIST so signing behavior is identical across
+# the supported botocore>=1.40.0 range, including releases that predate the
+# equivalent upstream fix (boto/botocore#3643).
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
+_UNSIGNED_HEADERS = frozenset(
+    {
+        "connection",
+        "expect",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        "user-agent",
+        "x-amzn-trace-id",
+    }
+)
 
 
 def _load_botocore() -> tuple[Any, Any, Any, Any]:
@@ -145,7 +166,7 @@ class BedrockAwsAuth:
             signed_headers = {
                 name: value
                 for name, value in headers.items()
-                if name.lower() not in _AWS_SIGNING_HEADERS and name.lower() not in _HOP_BY_HOP_HEADERS
+                if name.lower() not in _AWS_SIGNING_HEADERS and name.lower() not in _UNSIGNED_HEADERS
             }
             signed_headers["X-Amz-Content-SHA256"] = hashlib.sha256(body or b"").hexdigest()
             aws_request = self._aws_request_cls(
@@ -163,7 +184,15 @@ class BedrockAwsAuth:
                 "or runtime identity configuration and try again."
             ) from exc
 
-        return dict(aws_request.headers.items())
+        result = dict(aws_request.headers.items())
+        # Preserve the caller's volatile transport headers (e.g. an explicit
+        # `Connection: close`) on the outgoing request. They were excluded from
+        # the signature above, not from the request itself, matching how botocore
+        # leaves blacklisted headers on the request while keeping them unsigned.
+        for name, value in headers.items():
+            if name.lower() in _UNSIGNED_HEADERS and name not in result:
+                result[name] = value
+        return result
 
 
 def resolve_aws_region_with_source(

--- a/src/openai/lib/_bedrock_auth.py
+++ b/src/openai/lib/_bedrock_auth.py
@@ -23,6 +23,7 @@ _AWS_SIGNING_HEADERS = (
     "x-amz-date",
     "x-amz-security-token",
 )
+_HOP_BY_HOP_HEADERS = ("connection",)
 
 
 def _load_botocore() -> tuple[Any, Any, Any, Any]:
@@ -142,7 +143,9 @@ class BedrockAwsAuth:
                 credentials = get_frozen_credentials()
 
             signed_headers = {
-                name: value for name, value in headers.items() if name.lower() not in _AWS_SIGNING_HEADERS
+                name: value
+                for name, value in headers.items()
+                if name.lower() not in _AWS_SIGNING_HEADERS and name.lower() not in _HOP_BY_HOP_HEADERS
             }
             signed_headers["X-Amz-Content-SHA256"] = hashlib.sha256(body or b"").hexdigest()
             aws_request = self._aws_request_cls(

--- a/tests/lib/test_bedrock_auth_conformance.py
+++ b/tests/lib/test_bedrock_auth_conformance.py
@@ -113,7 +113,28 @@ def test_shared_sigv4_fixture_matches_node(monkeypatch: pytest.MonkeyPatch) -> N
     assert signed_headers["x-amz-date"] == fixture["expected"]["date"]
 
 
-def test_sign_excludes_connection_header() -> None:
+# Volatile transport headers that intermediaries may add or rewrite in transit.
+# These must be excluded from the SigV4 signature (but left on the request) so a
+# rewrite does not cause a signature mismatch. Mirrors botocore's
+# SIGNED_HEADERS_BLACKLIST and the AWS SigV4 guidance:
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
+_UNSIGNED_TRANSPORT_HEADERS = [
+    "connection",
+    "expect",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "user-agent",
+    "x-amzn-trace-id",
+]
+
+
+@pytest.mark.parametrize("header_name", _UNSIGNED_TRANSPORT_HEADERS)
+def test_sign_excludes_volatile_transport_header(header_name: str) -> None:
     auth = BedrockAwsAuth(
         BedrockAwsAuthConfig(
             region="us-east-1",
@@ -123,22 +144,26 @@ def test_sign_excludes_connection_header() -> None:
             session_token="session-token",
         )
     )
-    signed_headers = _lower_headers(
-        auth.sign(
-            method="POST",
-            url="https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses",
-            headers={
-                "content-type": "application/json",
-                "host": "bedrock-mantle.us-east-1.api.aws",
-                "connection": "keep-alive",
-            },
-            body=b"{}",
-        )
+    # Send the header with a mixed-case name to exercise case-insensitive matching.
+    mixed_case_name = header_name.title()
+    result = auth.sign(
+        method="POST",
+        url="https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses",
+        headers={
+            "content-type": "application/json",
+            "host": "bedrock-mantle.us-east-1.api.aws",
+            mixed_case_name: "example-value",
+        },
+        body=b"{}",
     )
+    signed_headers = _lower_headers(result)
     signed_header_names = signed_headers["authorization"].split("SignedHeaders=", 1)[1].split(",", 1)[0].split(";")
 
-    assert "connection" not in signed_headers
-    assert "connection" not in signed_header_names
+    # Excluded from the signature so an intermediary rewriting it cannot break signing.
+    assert header_name not in signed_header_names
+    # But preserved on the outgoing request (unsigned), matching botocore's behavior.
+    assert header_name in signed_headers
+    assert signed_headers[header_name] == "example-value"
 
 
 @pytest.mark.parametrize("case", _cases("auth_selection"), ids=lambda case: case["id"])

--- a/tests/lib/test_bedrock_auth_conformance.py
+++ b/tests/lib/test_bedrock_auth_conformance.py
@@ -113,6 +113,34 @@ def test_shared_sigv4_fixture_matches_node(monkeypatch: pytest.MonkeyPatch) -> N
     assert signed_headers["x-amz-date"] == fixture["expected"]["date"]
 
 
+def test_sign_excludes_connection_header() -> None:
+    auth = BedrockAwsAuth(
+        BedrockAwsAuthConfig(
+            region="us-east-1",
+            source="static",
+            access_key_id="AKIDEXAMPLE",
+            secret_access_key="wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            session_token="session-token",
+        )
+    )
+    signed_headers = _lower_headers(
+        auth.sign(
+            method="POST",
+            url="https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses",
+            headers={
+                "content-type": "application/json",
+                "host": "bedrock-mantle.us-east-1.api.aws",
+                "connection": "keep-alive",
+            },
+            body=b"{}",
+        )
+    )
+    signed_header_names = signed_headers["authorization"].split("SignedHeaders=", 1)[1].split(",", 1)[0].split(";")
+
+    assert "connection" not in signed_headers
+    assert "connection" not in signed_header_names
+
+
 @pytest.mark.parametrize("case", _cases("auth_selection"), ids=lambda case: case["id"])
 def test_auth_selection_fixture(case: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`BedrockAwsAuth.sign` passes the hop-by-hop `Connection` header to the SigV4 signer. Proxies like Bedrock Mantle rewrite or drop that header on the way through, so Bedrock rebuilds a different canonical request and rejects valid AWS credentials with a 401 signature mismatch. This drops `connection` before signing, the same way botocore leaves hop-by-hop headers out of the signature.

`src/openai/lib/` is hand-written and the generator does not touch it, per CONTRIBUTING.md.

## Additional context & links

Fixes #3563
