### PR TITLE
ci: prepare checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - '**'
+      - '!gh-readonly-queue/**'
       - '!integrated/**'
       - '!stl-preview-head/**'
       - '!stl-preview-base/**'
@@ -13,6 +14,9 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
     inputs:
       release_pr:
@@ -33,7 +37,7 @@ jobs:
     timeout-minutes: 10
     name: lint
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -50,7 +54,7 @@ jobs:
         run: ./scripts/lint
 
   build:
-    if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     timeout-minutes: 10
     name: build
     permissions:
@@ -146,7 +150,7 @@ jobs:
     timeout-minutes: 15
     name: test (Python ${{ matrix.python-version }})
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork
     strategy:
       fail-fast: false
       matrix:
@@ -182,7 +186,7 @@ jobs:
     timeout-minutes: 20
     name: test (HTTPX2)
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       - next
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
     inputs:
       release_pr:
@@ -23,9 +26,9 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    if: github.repository == 'openai/openai-python' && (github.event_name == 'pull_request' || (inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main'))
+    if: github.repository == 'openai/openai-python' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main'))
     env:
-      BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_sha }}
+      BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || inputs.base_sha }}
       FETCH_DEPTH: 0
     steps:
       - name: Calculate fetch-depth
@@ -37,7 +40,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # Ensure we can check out the pull request base in the script below.
+          # Ensure the comparison base is available to the scripts below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - name: Set up Rye


### PR DESCRIPTION
## Summary

- run all required Python CI checks for GitHub merge-group commits
- compare breaking changes against the merge group base SHA
- exclude `gh-readonly-queue/**` from ordinary push runs

## Why

GitHub Actions required checks must subscribe to the separate `merge_group: checks_requested` event before merge queue can be enabled. Without this prerequisite, queued pull requests can wait indefinitely for checks that never report.

The queue-branch push exclusion makes the merge-group run authoritative and avoids duplicate queue-ref push runs.

## Impact

Once the merge queue is enabled, required CI will run again when an approved PR enters the queue, validating the queued commit against the latest `main`. Existing fork, Stainless staging, Release Please, schedule, and manual-dispatch behavior remains unchanged.

The breaking-change check uses `merge_group.base_sha` for queued commits while retaining the existing PR and manual base-SHA paths.

## Validation

- YAML parsed successfully
- `git diff --check`
- `./scripts/lint`
- required-check trigger and job-gate audit
- thermo-nuclear code-quality review (no findings)

## Follow-up

After this PR lands, update the existing `main` ruleset to enable the merge queue while preserving every existing protection and bypass actor, then independently read back the effective rules and live queue configuration.