### PR TITLE
ci: use GitHub App for Release Please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,6 @@ on:
     types:
       - checks_requested
   workflow_dispatch:
-    inputs:
-      release_pr:
-        description: Run required CI for a Release Please branch
-        required: false
-        default: false
-        type: boolean
   # Exercise the complete supported matrix and the next CPython prerelease
   # even when the repository has not changed.
   schedule:
@@ -37,7 +31,7 @@ jobs:
     timeout-minutes: 10
     name: lint
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -54,7 +48,7 @@ jobs:
         run: ./scripts/lint
 
   build:
-    if: (github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     timeout-minutes: 10
     name: build
     permissions:
@@ -150,7 +144,7 @@ jobs:
     timeout-minutes: 15
     name: test (Python ${{ matrix.python-version }})
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
     strategy:
       fail-fast: false
       matrix:
@@ -192,7 +186,7 @@ jobs:
     timeout-minutes: 20
     name: test (HTTPX2)
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main') || github.event.pull_request.head.repo.fork
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -230,7 +224,7 @@ jobs:
     name: examples
     environment: ci
     runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.repository == 'openai/openai-python' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: github.repository == 'openai/openai-python' && github.ref != 'refs/heads/release-please--branches--main' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -270,7 +264,7 @@ jobs:
     timeout-minutes: 20
     name: compatibility (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && !inputs.release_pr)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -9,7 +9,7 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-python'
     runs-on: ubuntu-latest
-    environment: castiron-promotion
+    environment: release
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     permissions: {}

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -9,98 +9,29 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-python'
     runs-on: ubuntu-latest
+    environment: castiron-promotion
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
-      release_pr_branch: ${{ steps.release_pr.outputs.branch }}
-      release_pr_number: ${{ steps.release_pr.outputs.number }}
-    # Release Please writes its PR branch, tags/releases, PR, and PR labels.
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    permissions: {}
 
     steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Capture release PR
-        if: steps.release.outputs.prs_created == 'true'
-        id: release_pr
-        env:
-          RELEASE_PR: ${{ steps.release.outputs.pr }}
-        run: |
-          branch="$(jq -er '.headBranchName | select(. == "release-please--branches--main")' <<<"$RELEASE_PR")"
-          number="$(jq -er '.number | select(type == "number")' <<<"$RELEASE_PR")"
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "number=$number" >> "$GITHUB_OUTPUT"
-
-  release-pr-ci:
-    name: release PR CI
-    needs: release
-    if: ${{ needs.release.outputs.release_pr_branch != '' }}
-    runs-on: ubuntu-latest
-    # Read the release PR's current base SHA, then dispatch its required
-    # workflows. Keeping this separate prevents Release Please from receiving
-    # Actions write access.
-    permissions:
-      actions: write
-      pull-requests: read
-
-    steps:
-      - name: Run required checks for release PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        env:
-          RELEASE_PR_BRANCH: ${{ needs.release.outputs.release_pr_branch }}
-          RELEASE_PR_NUMBER: ${{ needs.release.outputs.release_pr_number }}
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const expectedRef = process.env.RELEASE_PR_BRANCH;
-            const pullNumber = Number(process.env.RELEASE_PR_NUMBER);
-            if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
-              throw new Error('Release Please returned an invalid PR number');
-            }
-
-            const { data: pull } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullNumber,
-            });
-            if (pull.head.ref !== expectedRef) {
-              throw new Error(`Release PR branch changed: expected ${expectedRef}, got ${pull.head.ref}`);
-            }
-
-            const ref = pull.head.ref;
-            await Promise.all([
-              github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci.yml',
-                ref,
-                inputs: { release_pr: 'true' },
-              }),
-              github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'detect-breaking-changes.yml',
-                ref,
-                inputs: {
-                  release_pr: 'true',
-                  base_sha: pull.base.sha,
-                },
-              }),
-              github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'codeql.yml',
-                ref,
-              }),
-            ]);
 
   build:
     name: build

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -7,17 +7,6 @@ on:
   merge_group:
     types:
       - checks_requested
-  workflow_dispatch:
-    inputs:
-      release_pr:
-        description: Run checks for a Release Please branch
-        required: false
-        default: false
-        type: boolean
-      base_sha:
-        description: Base commit for breaking-change comparison
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -26,9 +15,9 @@ jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
     name: detect-breaking-changes
-    if: github.repository == 'openai/openai-python' && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main'))
+    if: github.repository == 'openai/openai-python' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
     env:
-      BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event_name == 'merge_group' && github.event.merge_group.base_sha || inputs.base_sha }}
+      BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
       FETCH_DEPTH: 0
     steps:
       - name: Calculate fetch-depth
@@ -63,7 +52,7 @@ jobs:
   agents_sdk:
     runs-on: 'ubuntu-latest'
     name: Detect Agents SDK regressions
-    if: github.repository == 'openai/openai-python' && (github.event_name == 'pull_request' || (inputs.release_pr && github.ref == 'refs/heads/release-please--branches--main'))
+    if: github.repository == 'openai/openai-python' && github.event_name == 'pull_request'
     steps:
       # Setup this sdk
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the `openai-sdks` GitHub App from environment configuration
- pass that token to Release Please and disable the release job's built-in `GITHUB_TOKEN` permissions
- remove the manual workflow-dispatch workaround now that release branch pushes and pull-request events trigger Actions normally
- keep API-key-backed example jobs off the automated Release Please branch

## Why

Release Please currently authenticates with `GITHUB_TOKEN`. Events created with that token do not normally start downstream workflows, which required a separate dispatch job and release-specific workflow inputs. A GitHub App installation token triggers the normal push and pull-request workflows, so the workaround can be deleted.

## Repository configuration

- verified App: `openai-sdks` (App ID `3705508`, client ID `Iv23li2AtcmhLHO07J87`)
- dedicated environment: `release`
- environment variable: `OPENAI_SDKS_APP_CLIENT_ID`
- environment secret: `OPENAI_SDKS_APP_PRIVATE_KEY`
- the environment is restricted to `main` and has no required-reviewer or wait-timer gate

The `release` environment now contains both App credentials expected by the workflow.

## Validation

- `./scripts/lint`
- `actionlint` v1.7.7 on the changed workflows
- `git diff origin/main...HEAD --check`
