### PR TITLE
fix: remove duplicate accumulate_delta in assistants streaming

### DIFF
--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -5,7 +5,8 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, Callable, Iterable, Iterator, cast
 from typing_extensions import Awaitable, AsyncIterable, AsyncIterator, assert_never
 
-from ..._utils import is_dict, is_list, consume_sync_iterator, consume_async_iterator
+from ._deltas import accumulate_delta
+from ..._utils import consume_sync_iterator, consume_async_iterator
 from ..._compat import model_dump
 from ..._httpx2 import timeout_exceptions
 from ..._models import construct_type
@@ -978,64 +979,3 @@ def accumulate_event(
                 )
 
     return current_message_snapshot, new_content
-
-
-def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
-    for key, delta_value in delta.items():
-        if key not in acc:
-            acc[key] = delta_value
-            continue
-
-        acc_value = acc[key]
-        if acc_value is None:
-            acc[key] = delta_value
-            continue
-
-        # the `index` property is used in arrays of objects so it should
-        # not be accumulated like other values e.g.
-        # [{'foo': 'bar', 'index': 0}]
-        #
-        # the same applies to `type` properties as they're used for
-        # discriminated unions
-        if key == "index" or key == "type":
-            acc[key] = delta_value
-            continue
-
-        if isinstance(acc_value, str) and isinstance(delta_value, str):
-            acc_value += delta_value
-        elif isinstance(acc_value, (int, float)) and isinstance(delta_value, (int, float)):
-            acc_value += delta_value
-        elif is_dict(acc_value) and is_dict(delta_value):
-            acc_value = accumulate_delta(acc_value, delta_value)
-        elif is_list(acc_value) and is_list(delta_value):
-            # for lists of non-dictionary items we'll only ever get new entries
-            # in the array, existing entries will never be changed
-            if all(isinstance(x, (str, int, float)) for x in acc_value):
-                acc_value.extend(delta_value)
-                continue
-
-            for delta_entry in delta_value:
-                if not is_dict(delta_entry):
-                    raise TypeError(f"Unexpected list delta entry is not a dictionary: {delta_entry}")
-
-                try:
-                    index = delta_entry["index"]
-                except KeyError as exc:
-                    raise RuntimeError(f"Expected list delta entry to have an `index` key; {delta_entry}") from exc
-
-                if not isinstance(index, int):
-                    raise TypeError(f"Unexpected, list delta entry `index` value is not an integer; {index}")
-
-                try:
-                    acc_entry = acc_value[index]
-                except IndexError:
-                    acc_value.insert(index, delta_entry)
-                else:
-                    if not is_dict(acc_entry):
-                        raise TypeError("not handled yet")
-
-                    acc_value[index] = accumulate_delta(acc_entry, delta_entry)
-
-        acc[key] = acc_value
-
-    return acc


### PR DESCRIPTION
## Summary

`lib/streaming/_assistants.py` contained a private copy of `accumulate_delta` (lines 983-1041) that was byte-for-byte identical to the canonical version in `lib/streaming/_deltas.py:6-64`.

The chat streaming path already imports from `_deltas` (see `lib/streaming/chat/_completions.py:25`), but assistants streaming maintained its own duplicate - meaning any bugfix to one copy would silently miss the other.

## Change

- Remove the 59-line duplicate from `_assistants.py`
- Import `accumulate_delta` from `._deltas` (same as chat streaming already does)
- Remove the now-unused `is_dict`/`is_list` imports from `_utils`

## Verification

```
ruff check src/openai/lib/streaming/_assistants.py  # all checks passed
pytest tests/lib/test_assistants.py tests/test_streaming.py  # 28 passed
```

No behavior change - both call sites (lines 910, 961) continue calling the same function, now through the shared import.