### PR TITLE
fix: expand SENSITIVE_HEADERS to cover proxy and gateway credential headers

### DIFF
--- a/src/openai/_utils/_logs.py
+++ b/src/openai/_utils/_logs.py
@@ -8,7 +8,15 @@ logger: logging.Logger = logging.getLogger("openai")
 httpx_logger: logging.Logger = logging.getLogger("httpx")
 
 
-SENSITIVE_HEADERS = {"api-key", "authorization", "x-amz-security-token"}
+SENSITIVE_HEADERS = {
+    "api-key",
+    "authorization",
+    "cookie",
+    "proxy-authorization",
+    "set-cookie",
+    "x-amz-security-token",
+    "x-api-key",
+}
 
 
 def _basic_config() -> None:

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -94,6 +94,29 @@ def test_headers_without_sensitive_info(logger_with_filter: logging.Logger, capl
     )
 
 
+def test_proxy_credential_headers_redacted(logger_with_filter: logging.Logger, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.DEBUG):
+        logger_with_filter.debug(
+            "Request options: %s",
+            {
+                "method": "post",
+                "url": "chat/completions",
+                "headers": {
+                    "x-api-key": "gateway-secret",
+                    "Proxy-Authorization": "Basic dXNlcjpwYXNz",
+                    "Cookie": "session=abc123",
+                    "Set-Cookie": "token=xyz",
+                },
+            },
+        )
+
+    log_record = cast(Dict[str, Any], caplog.records[0].args)
+    assert log_record["headers"]["x-api-key"] == "<redacted>"
+    assert log_record["headers"]["Proxy-Authorization"] == "<redacted>"
+    assert log_record["headers"]["Cookie"] == "<redacted>"
+    assert log_record["headers"]["Set-Cookie"] == "<redacted>"
+
+
 def test_standard_debug_msg(logger_with_filter: logging.Logger, caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.DEBUG):
         logger_with_filter.debug("Sending HTTP Request: %s %s", "POST", "chat/completions")


### PR DESCRIPTION
## Summary

`SensitiveHeadersFilter` was introduced to keep credentials out of debug logs, but `SENSITIVE_HEADERS` only covers 3 header names:

```python
# before
SENSITIVE_HEADERS = {"api-key", "authorization", "x-amz-security-token"}
```

This means credentials passed via `extra_headers` or `default_headers` to common proxy/gateway setups are logged verbatim when `OPENAI_LOG=debug`:

- `x-api-key` - used by AWS API Gateway, Kong, LiteLLM, and Anthropic-style proxies
- `proxy-authorization` - standard HTTP proxy credential header (httpx itself redacts this in its repr)
- `cookie` / `set-cookie` - session-authenticated gateways

## Change

```python
# after
SENSITIVE_HEADERS = {
    "api-key",
    "authorization",
    "cookie",
    "proxy-authorization",
    "set-cookie",
    "x-amz-security-token",
    "x-api-key",
}
```

One test added covering all 4 new headers with mixed-case variants (the filter already lowercases before matching).

## Verification

```
pytest tests/test_utils/test_logging.py  # 6 passed
```