### PR TITLE
Fix/drain stream after done

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -61,6 +61,10 @@ class Stream(Generic[_T]):
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain remaining bytes so close() can return the connection to the pool
+                    # instead of discarding it because the body was only partially read.
+                    for _sse in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
@@ -171,6 +175,10 @@ class AsyncStream(Generic[_T]):
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
+                    # Drain remaining bytes so aclose() can return the connection to the pool
+                    # instead of discarding it because the body was only partially read.
+                    async for _sse in iterator:
+                        pass
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -9,7 +9,7 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 
 import httpx
 
-from ._utils import is_mapping, extract_type_var_from_base
+from ._utils import is_mapping, consume_sync_iterator, consume_async_iterator, extract_type_var_from_base
 from ._exceptions import APIError
 
 if TYPE_CHECKING:
@@ -63,8 +63,7 @@ class Stream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     # Drain remaining bytes so close() can return the connection to the pool
                     # instead of discarding it because the body was only partially read.
-                    for _sse in iterator:
-                        pass
+                    consume_sync_iterator(iterator)
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
@@ -177,8 +176,7 @@ class AsyncStream(Generic[_T]):
                 if sse.data.startswith("[DONE]"):
                     # Drain remaining bytes so aclose() can return the connection to the pool
                     # instead of discarding it because the body was only partially read.
-                    async for _sse in iterator:
-                        pass
+                    await consume_async_iterator(iterator)
                     break
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -216,6 +216,33 @@ async def test_multi_byte_character_multiple_chunks(
     assert sse.json() == {"content": "известни"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_done_drains_remaining_body(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    """After [DONE], remaining body bytes must be consumed so close() can reuse the connection."""
+    exhausted = False
+
+    def body() -> Iterator[bytes]:
+        nonlocal exhausted
+        yield b'data: {"foo":true}\n\n'
+        yield b"data: [DONE]\n\n"
+        yield b": trailing comment after done\n\n"
+        exhausted = True
+
+    content: Iterator[bytes] | AsyncIterator[bytes] = body() if sync else to_aiter(body())
+    response = httpx.Response(200, content=content)
+
+    if sync:
+        stream: Stream[object] | AsyncStream[object] = Stream(cast_to=object, client=client, response=response)
+        chunks = list(stream)
+    else:
+        stream = AsyncStream(cast_to=object, client=async_client, response=response)
+        chunks = [chunk async for chunk in stream]
+
+    assert chunks == [{"foo": True}]
+    assert exhausted is True
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

When using a connection-pooled OpenAI client, each request was adding ~300ms of overhead. Digging in, SSE streams break on `data: [DONE]` without fully reading the remaining response body. Closing that partially-read response drops the connection from the pool instead of reusing it, so the next request pays for a new TCP/TLS handshake.

After `[DONE]`, drain the remaining iterator with `consume_sync_iterator` / `consume_async_iterator` before close, so the body is fully consumed and the pooled connection can be reused.

Added a regression test covering trailing bytes after `[DONE]`.

## Additional context & links

- Symptom: ~300ms extra latency per request with a pooled client
- Root cause: unread bytes after `[DONE]` → `response.close()` / `aclose()` evicts the connection from the pool
- Files: `src/openai/_streaming.py`, `tests/test_streaming.py`
- Verified with streaming tests and the full suite against the local Steady mock