### PR TITLE
docs: correct Server-Sent Events spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Parsed API models are unchanged, but requests, raw and streaming responses, and 
 
 ## Streaming responses
 
-We provide support for streaming responses using Server Side Events (SSE).
+We provide support for streaming responses using Server-Sent Events (SSE).
 
 ```python
 from openai import OpenAI


### PR DESCRIPTION
Closing this PR — the change was too low-value (drive-by docs nit). Sorry for the noise.