### PR TITLE
fix: raise APIError for top-level Responses API error events during streaming

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -84,9 +84,12 @@ class Stream(Generic[_T]):
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
-                    if is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and (data.get("error") or sse.event == "error"):
                         message = None
-                        error = data.get("error")
+                        # some events (e.g. the Responses API's `response.error` event) carry
+                        # the error fields directly on the event body instead of nesting them
+                        # under an "error" key, so fall back to the top-level body in that case.
+                        error = data.get("error") if is_mapping(data.get("error")) else data
                         if is_mapping(error):
                             message = error.get("message")
                         if not message or not isinstance(message, str):
@@ -95,7 +98,7 @@ class Stream(Generic[_T]):
                         raise APIError(
                             message=message,
                             request=self.response.request,
-                            body=data["error"],
+                            body=data.get("error") if data.get("error") is not None else data,
                         )
 
                     yield process_data(
@@ -194,9 +197,12 @@ class AsyncStream(Generic[_T]):
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
-                    if is_mapping(data) and data.get("error"):
+                    if is_mapping(data) and (data.get("error") or sse.event == "error"):
                         message = None
-                        error = data.get("error")
+                        # some events (e.g. the Responses API's `response.error` event) carry
+                        # the error fields directly on the event body instead of nesting them
+                        # under an "error" key, so fall back to the top-level body in that case.
+                        error = data.get("error") if is_mapping(data.get("error")) else data
                         if is_mapping(error):
                             message = error.get("message")
                         if not message or not isinstance(message, str):
@@ -205,7 +211,7 @@ class AsyncStream(Generic[_T]):
                         raise APIError(
                             message=message,
                             request=self.response.request,
-                            body=data["error"],
+                            body=data.get("error") if data.get("error") is not None else data,
                         )
 
                     yield process_data(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,7 +5,7 @@ from typing import Iterator, AsyncIterator
 import httpx
 import pytest
 
-from openai import OpenAI, AsyncOpenAI
+from openai import OpenAI, APIError, AsyncOpenAI
 from openai._streaming import Stream, AsyncStream, ServerSentEvent
 
 
@@ -216,6 +216,44 @@ async def test_multi_byte_character_multiple_chunks(
     assert sse.json() == {"content": "известни"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_response_error_event_raises_api_error(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    # Per https://platform.openai.com/docs/api-reference/responses-streaming/error, the
+    # Responses API's `error` event carries its fields directly on the event body, e.g.
+    # {"type": "error", "code": "...", "message": "...", "param": null, "sequence_number": 1}
+    # -- there is no nested "error" key.
+    def body() -> Iterator[bytes]:
+        yield b"event: error\n"
+        yield b'data: {"type":"error","code":"server_error","message":"boom","param":null,"sequence_number":1}\n'
+        yield b"\n"
+
+    stream = make_stream(content=body(), sync=sync, client=client, async_client=async_client)
+
+    with pytest.raises(APIError) as exc_info:
+        await stream_next(stream, sync=sync)
+
+    assert exc_info.value.message == "boom"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_response_error_event_without_message_uses_default(
+    sync: bool, client: OpenAI, async_client: AsyncOpenAI
+) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"event: error\n"
+        yield b'data: {"type":"error","code":"server_error","param":null,"sequence_number":1}\n'
+        yield b"\n"
+
+    stream = make_stream(content=body(), sync=sync, client=client, async_client=async_client)
+
+    with pytest.raises(APIError) as exc_info:
+        await stream_next(stream, sync=sync)
+
+    assert exc_info.value.message == "An error occurred during streaming"
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk
@@ -246,3 +284,31 @@ def make_event_iterator(
     return AsyncStream(
         cast_to=object, client=async_client, response=httpx.Response(200, content=to_aiter(content))
     )._iter_events()
+
+
+def make_stream(
+    content: Iterator[bytes],
+    *,
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> Stream[object] | AsyncStream[object]:
+    request = httpx.Request("POST", "http://localhost")
+
+    if sync:
+        return Stream(cast_to=object, client=client, response=httpx.Response(200, content=content, request=request))
+
+    return AsyncStream(
+        cast_to=object,
+        client=async_client,
+        response=httpx.Response(200, content=to_aiter(content), request=request),
+    )
+
+
+async def stream_next(stream: Stream[object] | AsyncStream[object], *, sync: bool) -> object:
+    if sync:
+        assert isinstance(stream, Stream)
+        return next(stream)
+
+    assert isinstance(stream, AsyncStream)
+    return await stream.__anext__()


### PR DESCRIPTION
## Summary

Fixes #2487.

`Stream.__stream__` / `AsyncStream.__stream__` in `src/openai/_streaming.py` only raise an `APIError` when the SSE event body has a *nested* `"error"` key:

```python
if is_mapping(data) and data.get("error"):
    ...
    raise APIError(..., body=data["error"])
```

But per the [Responses API streaming error spec](https://platform.openai.com/docs/api-reference/responses-streaming/error), the `error` event carries its fields (`type`, `code`, `message`, `param`, `sequence_number`) directly on the event body -- there is no nested `"error"` key:

```json
{"type": "error", "code": "...", "message": "Something went wrong", "param": null, "sequence_number": 1}
```

Because `data.get("error")` is `None` for these events, the condition never matches, so the event is silently passed to `process_data(...)` as if it were ordinary stream data instead of raising a clear `APIError`. Depending on the expected type being cast to, this can surface as a confusing Pydantic validation error deep in the stack instead of the server's actual error message.

### Fix

In both the sync `Stream` and `AsyncStream` `__stream__` methods, also treat `sse.event == "error"` as an error condition, falling back to the top-level event body for the message/body when there's no nested `"error"` key (kept for backwards compatibility with any caller still relying on that shape):

```python
if is_mapping(data) and (data.get("error") or sse.event == "error"):
    ...
    error = data.get("error") if is_mapping(data.get("error")) else data
    message = error.get("message") if is_mapping(error) else None
    ...
    raise APIError(
        message=message,
        request=self.response.request,
        body=data.get("error") if data.get("error") is not None else data,
    )
```

This is a minimal, targeted change -- no unrelated refactors.

### Tests

Added regression tests in `tests/test_streaming.py` (for both `Stream` and `AsyncStream`, via the existing `sync` parametrization):

- `test_response_error_event_raises_api_error` -- a top-level `response.error`-shaped SSE `error` event raises `APIError` with the server's `message`.
- `test_response_error_event_without_message_uses_default` -- the same event without a `message` field raises `APIError` with the existing default message.

Both tests fail on `main` (`DID NOT RAISE APIError`) and pass with this fix.

```
$ pytest tests/test_streaming.py -q
24 passed
```

`ruff check` and `ruff format --check` pass on both changed files.
