### PR TITLE
fix(lib): apply strict JSON schema transform to tuple prefixItems

### DIFF
--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -66,6 +66,15 @@ def _ensure_strict_json_schema(
     if is_dict(items):
         json_schema["items"] = _ensure_strict_json_schema(items, path=(*path, "items"), root=root)
 
+    # tuples / positional arrays
+    # { 'type': 'array', 'prefixItems': [{...}, {...}] }
+    prefix_items = json_schema.get("prefixItems")
+    if is_list(prefix_items):
+        json_schema["prefixItems"] = [
+            _ensure_strict_json_schema(item, path=(*path, "prefixItems", str(i)), root=root)
+            for i, item in enumerate(prefix_items)
+        ]
+
     # unions
     any_of = json_schema.get("anyOf")
     if is_list(any_of):

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Tuple
+from typing_extensions import Annotated
 
+import pytest
 from pydantic import Field, BaseModel
 from inline_snapshot import snapshot
 
@@ -167,6 +170,78 @@ def test_most_types() -> None:
                 },
             }
         )
+
+
+class Location(BaseModel):
+    lat: float
+    long: float
+
+
+class Route(BaseModel):
+    endpoints: Tuple[
+        Annotated[Location, Field(description="The starting point.")],
+        Annotated[Location, Field(description="The ending point.")],
+    ]
+
+
+@pytest.mark.skipif(PYDANTIC_V1, reason="`prefixItems` is only emitted by pydantic v2")
+def test_tuple_prefix_items_ref_expansion() -> None:
+    # tuple elements are emitted under `prefixItems`; the strict transform must
+    # recurse into them the same way it does for `items`, otherwise a `$ref` that
+    # carries sibling keys (e.g. a field description) is left un-expanded and the
+    # API rejects the resulting schema.
+    assert to_strict_json_schema(Route) == snapshot(
+        {
+            "$defs": {
+                "Location": {
+                    "properties": {
+                        "lat": {"title": "Lat", "type": "number"},
+                        "long": {"title": "Long", "type": "number"},
+                    },
+                    "required": ["lat", "long"],
+                    "title": "Location",
+                    "type": "object",
+                    "additionalProperties": False,
+                }
+            },
+            "properties": {
+                "endpoints": {
+                    "maxItems": 2,
+                    "minItems": 2,
+                    "prefixItems": [
+                        {
+                            "description": "The starting point.",
+                            "properties": {
+                                "lat": {"title": "Lat", "type": "number"},
+                                "long": {"title": "Long", "type": "number"},
+                            },
+                            "required": ["lat", "long"],
+                            "title": "Location",
+                            "type": "object",
+                            "additionalProperties": False,
+                        },
+                        {
+                            "description": "The ending point.",
+                            "properties": {
+                                "lat": {"title": "Lat", "type": "number"},
+                                "long": {"title": "Long", "type": "number"},
+                            },
+                            "required": ["lat", "long"],
+                            "title": "Location",
+                            "type": "object",
+                            "additionalProperties": False,
+                        },
+                    ],
+                    "title": "Endpoints",
+                    "type": "array",
+                }
+            },
+            "required": ["endpoints"],
+            "title": "Route",
+            "type": "object",
+            "additionalProperties": False,
+        }
+    )
 
 
 class Color(Enum):


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`src/openai/lib/_pydantic.py` is hand-maintained (one of the files the Stainless generator leaves untouched, alongside `examples/`), so this fix belongs here rather than in the spec. It sits in the same function that PR history already patches for strict-schema handling (`test_nested_inline_ref_expansion` covers the adjacent `$ref`-expansion behavior).

### Problem

`_ensure_strict_json_schema` walks a Pydantic-generated JSON schema and applies the transforms the API's `strict` mode requires: forcing `additionalProperties: false`, marking every property `required`, and — importantly — unravelling any `$ref` that also carries sibling keys (a `$ref` with siblings is rejected in strict mode). It recurses into `items`, `anyOf`, `allOf`, `properties`, `$defs` and `definitions`.

It does **not** recurse into `prefixItems`, which Pydantic v2 emits for `tuple[...]` fields. So any subschema reached only through a tuple element is skipped. The most visible symptom is a tuple element that is a model with a field-level description: Pydantic emits `{"$ref": "...", "description": "..."}`, and because it is never unravelled the generated schema still contains a `$ref` with sibling keys — which the API rejects. The identical construct inside a `list[...]` works, because `list` uses `items` (which is recursed).

### Reproduction (before the fix)

```python
from typing import Tuple
from typing_extensions import Annotated
from pydantic import BaseModel, Field
from openai.lib._pydantic import to_strict_json_schema


class Location(BaseModel):
    lat: float
    long: float


class Route(BaseModel):
    endpoints: Tuple[
        Annotated[Location, Field(description="The starting point.")],
        Annotated[Location, Field(description="The ending point.")],
    ]


print(to_strict_json_schema(Route)["properties"]["endpoints"]["prefixItems"][0])
```

Before:

```python
{"$ref": "#/$defs/Location", "description": "The starting point."}   # $ref + sibling key -> rejected by strict mode
```

After:

```python
{
    "description": "The starting point.",
    "properties": {"lat": {"title": "Lat", "type": "number"}, "long": {"title": "Long", "type": "number"}},
    "required": ["lat", "long"],
    "title": "Location",
    "type": "object",
    "additionalProperties": False,
}
```

This now matches exactly what `list[Annotated[Location, Field(description=...)]]` already produces.

### Fix

Recurse into `prefixItems` just like `items`/`anyOf` — nine lines, no behavior change for schemas that don't use tuples.

### Tests

Added `test_tuple_prefix_items_ref_expansion` in `tests/lib/test_pydantic.py`, guarded with `skipif(PYDANTIC_V1)` since `prefixItems` is a Pydantic-v2 / JSON-Schema-2020-12 construct (v1 emits list-form `items`, an unrelated path this change does not touch). The test fails on `main` (the `$ref` is left with a sibling `description`) and passes with this change.

### Validation (no network / no API key required — pure schema generation)

- `pytest -o addopts= tests/lib/test_pydantic.py` — `4 passed` (new test fails on `main`).
- `pytest -o addopts= tests/lib/chat tests/lib/responses tests/lib/test_pydantic.py` — `43 passed`.
- `ruff check` + `ruff format --check` on both files — clean.
- `pyright src/openai/lib/_pydantic.py` — 0 errors.

### Compatibility

Non-breaking. `prefixItems` only appears for tuple types; the added branch is a no-op for every schema that doesn't contain one, and for those that do it makes the output consistent with `list`/`items`.
