### PR TITLE
fix(helpers): reshape 1-D float32 audio in LocalAudioPlayer

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -65,7 +65,7 @@ class LocalAudioPlayer:
             if input.dtype == np.int16 and self.dtype == np.float32:
                 audio_content = (input.astype(np.float32) / 32767.0).reshape(-1, self.channels)
             elif input.dtype == np.float32:
-                audio_content = cast("npt.NDArray[np.float32]", input)
+                audio_content = cast("npt.NDArray[np.float32]", input).reshape(-1, self.channels)
             else:
                 raise ValueError(f"Unsupported dtype: {input.dtype}")
         else:
@@ -136,6 +136,8 @@ class LocalAudioPlayer:
 
                         if current_buffer.dtype == np.int16 and self.dtype == np.float32:
                             current_buffer = (current_buffer.astype(np.float32) / 32767.0).reshape(-1, self.channels)
+                        elif current_buffer.dtype == np.float32:
+                            current_buffer = current_buffer.reshape(-1, self.channels)
 
                     except queue.Empty:
                         outdata[frames_written:] = 0

--- a/tests/lib/test_local_audio_player.py
+++ b/tests/lib/test_local_audio_player.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, List, Union, AsyncGenerator
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from openai.helpers import local_audio_player
+
+
+class FakeCallbackStop(Exception):
+    """Stand-in for `sounddevice.CallbackStop`."""
+
+
+class FakeOutputStream:
+    """Minimal `sounddevice.OutputStream` replacement.
+
+    A real `sounddevice` stream invokes the user supplied `callback` from a
+    dedicated audio thread while the event loop is free to run. We mirror that
+    here so the code under test exercises its real control flow without needing
+    an audio device.
+    """
+
+    def __init__(self, *, samplerate: int, callback: Any, dtype: Any, channels: int) -> None:
+        self.samplerate = samplerate
+        self.callback = callback
+        self.dtype = dtype
+        self.channels = channels
+        self.written: List[Any] = []
+        self.error: BaseException | None = None
+        self._thread: threading.Thread | None = None
+        self._frame_count = 2
+
+    def _run(self) -> None:
+        while True:
+            outdata = np.zeros((self._frame_count, self.channels), dtype=self.dtype)
+            try:
+                self.callback(outdata, self._frame_count, None, None)
+            except FakeCallbackStop:
+                break
+            except BaseException as exc:  # pragma: no cover - only hit by the bug being fixed
+                self.error = exc
+                break
+            self.written.append(outdata.copy())
+
+    def __enter__(self) -> "FakeOutputStream":
+        self._thread = threading.Thread(target=self._run)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        if self._thread is not None:
+            self._thread.join()
+
+
+class FakeSD:
+    CallbackStop = FakeCallbackStop
+
+    def __init__(self) -> None:
+        self.streams: List[FakeOutputStream] = []
+
+    def OutputStream(self, **kwargs: Any) -> FakeOutputStream:
+        stream = FakeOutputStream(**kwargs)
+        self.streams.append(stream)
+        return stream
+
+
+@pytest.fixture()
+def fake_sd(monkeypatch: pytest.MonkeyPatch) -> FakeSD:
+    sd = FakeSD()
+    monkeypatch.setattr(local_audio_player, "sd", sd)
+    return sd
+
+
+async def test_play_accepts_one_dimensional_float32(fake_sd: FakeSD) -> None:
+    # A 1-D float32 array (e.g. a mono waveform from soundfile / librosa) is a
+    # valid input per the `play()` type signature. Before the fix this raised
+    # `IndexError: tuple index out of range` because float32 input was not
+    # reshaped to `(frames, channels)` like int16 input is.
+    samples = np.array([0.1, 0.2, 0.3, -0.4, -0.5, 0.6], dtype=np.float32)
+
+    await asyncio.wait_for(local_audio_player.LocalAudioPlayer().play(samples), timeout=5)
+
+    assert len(fake_sd.streams) == 1
+    stream = fake_sd.streams[0]
+    assert stream.error is None
+    assert stream.channels == 1
+
+    played = np.concatenate(stream.written)[: len(samples)]
+    assert played.shape == (len(samples), 1)
+    assert np.allclose(played[:, 0], samples)
+
+
+async def test_play_accepts_one_dimensional_int16(fake_sd: FakeSD) -> None:
+    # Regression guard: the pre-existing int16 path must keep working.
+    samples = np.array([1000, -2000, 3000, -4000], dtype=np.int16)
+
+    await asyncio.wait_for(local_audio_player.LocalAudioPlayer().play(samples), timeout=5)
+
+    stream = fake_sd.streams[0]
+    assert stream.error is None
+    played = np.concatenate(stream.written)[: len(samples)]
+    assert played.shape == (len(samples), 1)
+    assert np.allclose(played[:, 0], samples.astype(np.float32) / 32767.0)
+
+
+async def test_play_stream_accepts_one_dimensional_float32(fake_sd: FakeSD) -> None:
+    # `play_stream` has the same root cause: float32 buffers were not reshaped
+    # to `(frames, channels)`, so the callback raised a broadcasting error.
+    samples = np.array([0.1, 0.2, 0.3, -0.4, -0.5, 0.6], dtype=np.float32)
+
+    async def buffer_stream() -> AsyncGenerator[Union[Any, None], None]:
+        yield samples
+        yield None
+
+    await asyncio.wait_for(local_audio_player.LocalAudioPlayer().play_stream(buffer_stream()), timeout=5)
+
+    stream = fake_sd.streams[0]
+    assert stream.error is None
+
+    played = np.concatenate(stream.written)
+    # drop any leading zero-fill frames emitted before the producer delivered data
+    nonzero = played[played[:, 0] != 0]
+    assert np.allclose(nonzero[:, 0], samples)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`LocalAudioPlayer` (in `src/openai/helpers/local_audio_player.py`) mishandles **1-D `float32`** NumPy arrays.

Both `play()` and `play_stream()` reshape `int16` input to `(-1, channels)`, but pass `float32` input through **without** reshaping. A 1-D `float32` array — e.g. a mono waveform loaded via `soundfile`/`librosa`, and an explicitly declared input type of `play()` (`npt.NDArray[np.float32]`) — then breaks:

- **`play()`** raises `IndexError: tuple index out of range`, because the still-1-D array is used as `channels=audio_content.shape[1]` when constructing the `sounddevice.OutputStream`.
- **`play_stream()`** raises a broadcasting error inside the audio callback when assigning a 1-D slice into the 2-D `outdata` buffer.

`int16` input already works because it is reshaped; only the `float32` branch was missing the reshape.

### Repro (`play()`)

```python
import asyncio
import numpy as np
from openai.helpers import LocalAudioPlayer

# a mono float32 waveform, e.g. from soundfile / librosa
samples = np.array([0.1, 0.2, 0.3, -0.4, -0.5], dtype=np.float32)
asyncio.run(LocalAudioPlayer().play(samples))
# IndexError: tuple index out of range   (at channels=audio_content.shape[1])
```

### Fix

Reshape `float32` input to `(-1, self.channels)` in both code paths, mirroring the existing `int16` handling. Already-2-D input (e.g. the `(-1, 1)` buffer produced from a streamed TTS response) is unaffected — the reshape is a no-op.

```diff
             elif input.dtype == np.float32:
-                audio_content = cast("npt.NDArray[np.float32]", input)
+                audio_content = cast("npt.NDArray[np.float32]", input).reshape(-1, self.channels)
```
```diff
                         if current_buffer.dtype == np.int16 and self.dtype == np.float32:
                             current_buffer = (current_buffer.astype(np.float32) / 32767.0).reshape(-1, self.channels)
+                        elif current_buffer.dtype == np.float32:
+                            current_buffer = current_buffer.reshape(-1, self.channels)
```

### Why this is a hand-maintained file (not generated)

`src/openai/helpers/local_audio_player.py` has no `File generated from our OpenAPI spec by Stainless` header and is not part of the OpenAPI surface — it is one of the hand-written helpers under `helpers/`. The change is a self-contained correctness fix in that helper; it touches no generated code.

### Tests

Added `tests/lib/test_local_audio_player.py` with a lightweight, hardware-free fake for `sounddevice.OutputStream` that drives the real callback flow from a background thread:

- `test_play_accepts_one_dimensional_float32` — reproduces the `IndexError` (fails before the fix) and asserts the played frames match the input.
- `test_play_accepts_one_dimensional_int16` — regression guard for the existing `int16` path.
- `test_play_stream_accepts_one_dimensional_float32` — covers the streaming path.

Each test fails on `main` for the exact reason described above and passes with the fix. No network, no API key, no audio device.

### Validation (run locally)

- `pytest tests/lib/test_local_audio_player.py` — 3 passed (and confirmed red on `main`: `IndexError` for `play`, broadcast/hang for `play_stream`).
- `pytest tests/lib/` — 259 passed.
- `ruff format --check` / `ruff check .` — clean.
- `scripts/run-pyright -p pyproject.toml` — 0 errors.
- `mypy .` — Success: no issues.

## Additional context & links

- Compatibility: no public API change; only fixes a previously-crashing input shape. `int16` and already-2-D `float32` behavior is unchanged.
- `local_audio_player.py` carries `# mypy: ignore-errors`, so mypy does not type-check it; the change is pyright-clean.
