### PR TITLE
fix(azure): preserve deployment routing across copy/with_options

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -310,7 +310,7 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
         if not isinstance(provider, NotGiven):
             raise OpenAIError("Configure `provider` on `OpenAI`, not on `AzureOpenAI.with_options()`.")
 
-        return super().copy(
+        copied = super().copy(
             api_key=api_key,
             admin_api_key=admin_api_key,
             workload_identity=workload_identity,
@@ -334,6 +334,14 @@ class AzureOpenAI(BaseAzureClient[httpx.Client, Stream[Any]], OpenAI):
                 **_extra_kwargs,
             },
         )
+        # `super().copy()` reconstructs the client from `base_url`, which does not carry the
+        # Azure endpoint/deployment context that `_prepare_url` relies on to route
+        # non-deployment endpoints (e.g. `/models`). Preserve it unless the caller overrides
+        # the base URL.
+        if base_url is None:
+            copied._azure_endpoint = self._azure_endpoint
+            copied._azure_deployment = self._azure_deployment
+        return copied
 
     with_options = copy
 
@@ -634,7 +642,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
         if not isinstance(provider, NotGiven):
             raise OpenAIError("Configure `provider` on `AsyncOpenAI`, not on `AsyncAzureOpenAI.with_options()`.")
 
-        return super().copy(
+        copied = super().copy(
             api_key=api_key,
             admin_api_key=admin_api_key,
             workload_identity=workload_identity,
@@ -658,6 +666,14 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx.AsyncClient, AsyncStream[Any]], Asy
                 **_extra_kwargs,
             },
         )
+        # `super().copy()` reconstructs the client from `base_url`, which does not carry the
+        # Azure endpoint/deployment context that `_prepare_url` relies on to route
+        # non-deployment endpoints (e.g. `/models`). Preserve it unless the caller overrides
+        # the base URL.
+        if base_url is None:
+            copied._azure_endpoint = self._azure_endpoint
+            copied._azure_deployment = self._azure_deployment
+        return copied
 
     with_options = copy
 

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -79,6 +79,41 @@ def test_client_copying_override_options(client: Client) -> None:
     assert copied._custom_query == {"api-version": "2022-05-01"}
 
 
+@pytest.mark.parametrize(
+    "client",
+    [
+        AzureOpenAI(
+            api_version="2024-02-01",
+            api_key="example API key",
+            azure_endpoint="https://example-resource.azure.openai.com",
+            azure_deployment="deployment-client",
+        ),
+        AsyncAzureOpenAI(
+            api_version="2024-02-01",
+            api_key="example API key",
+            azure_endpoint="https://example-resource.azure.openai.com",
+            azure_deployment="deployment-client",
+        ),
+    ],
+)
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+def test_copy_preserves_deployment_routing(client: Client, method: Literal["copy", "with_options"]) -> None:
+    copied = client.copy() if method == "copy" else client.with_options()
+
+    # a non-deployment endpoint must not be nested under `/deployments/<deployment>/`
+    req = copied._build_request(FinalRequestOptions.construct(method="get", url="/models", json_data={}))
+    assert req.url == "https://example-resource.azure.openai.com/openai/models?api-version=2024-02-01"
+
+    # a deployment endpoint must keep the deployment path
+    req = copied._build_request(
+        FinalRequestOptions.construct(method="post", url="/chat/completions", json_data={"model": "ignored"})
+    )
+    assert req.url == (
+        "https://example-resource.azure.openai.com/openai/deployments/deployment-client"
+        "/chat/completions?api-version=2024-02-01"
+    )
+
+
 def test_enforce_credentials_false_sync() -> None:
     with update_env(AZURE_OPENAI_API_KEY=Omit(), AZURE_OPENAI_AD_TOKEN=Omit()):
         AzureOpenAI(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes a routing regression in `AzureOpenAI` / `AsyncAzureOpenAI` after `.copy()` / `.with_options()`.

This change is in **hand-maintained** code — `src/openai/lib/azure.py` has no `File generated from our OpenAPI spec by Stainless` header, and `copy()`/`with_options()` there is custom Azure logic, so it is not affected by codegen.

### Problem

`AzureOpenAI.copy()` (aliased as `with_options()`) delegates to the base `OpenAI.copy()`, which reconstructs the client from `base_url` and does **not** pass `azure_endpoint` / `azure_deployment` back to `AzureOpenAI.__init__`. Because `_azure_endpoint` and `_azure_deployment` are only set from those constructor arguments, they get reset to `None` on the copied client.

`_prepare_url()` uses those attributes to bypass the deployment path for **non-deployment** endpoints:

```python
if self._azure_deployment and self._azure_endpoint and url not in _deployments_endpoints:
    # -> {endpoint}/openai/{url}   (no /deployments/<name>/)
```

Once they are `None`, that bypass no longer runs, so a client configured with `azure_deployment` starts routing non-deployment endpoints (e.g. `/models`) under the deployment path, which 404s.

### Reproduction (no network / key required)

```python
from openai import AzureOpenAI

c = AzureOpenAI(
    azure_endpoint="https://example.openai.azure.com",
    azure_deployment="my-deploy",
    api_version="2024-06-01",
    azure_ad_token="fake-token",
)
print(c._prepare_url("/models"))
# https://example.openai.azure.com/openai/models        ✅

c2 = c.with_options(timeout=30)
print(c2._azure_endpoint, c2._azure_deployment)          # None None
print(c2._prepare_url("/models"))
# https://example.openai.azure.com/openai/deployments/my-deploy/models   ❌ (404)
```

### Fix

Preserve `_azure_endpoint` / `_azure_deployment` on the copied client, unless the caller overrides `base_url` in the copy (in which case the old endpoint context is intentionally not carried over). Applied symmetrically to the sync and async clients.

### Why minimal

- Only `copy()` in each of the two Azure clients changes; two guarded lines each.
- Public API, credential handling, and the mutually-exclusive `base_url` / `azure_endpoint` constructor contract are untouched (the fix deliberately avoids passing `azure_endpoint` alongside `base_url`).
- Deployment endpoints (e.g. `/chat/completions`) are unaffected — `base_url` already encodes the deployment and `_build_request` continues to guard on `"/deployments" in base_url.path`.

### Tests

Added `test_copy_preserves_deployment_routing` in `tests/lib/test_azure.py` (sync + async × `copy` / `with_options`), asserting that after a copy:
- `/models` → `{endpoint}/openai/models` (not nested under `/deployments/<name>/`), and
- `/chat/completions` still keeps the deployment path.

Fails on `main` (wrong `/models` URL), passes with this change.

### Validation

- `rye run pytest tests/lib/test_azure.py` → 63 passed
- `rye run pytest tests/lib/` → all pass except a pre-existing, unrelated failure (`test_bedrock_auth_conformance.py::test_retry_signing_fixture`, which fails identically on clean `main` in this environment)
- `ruff check` / `ruff format` clean on both files
- `pyright` and `mypy` clean on `src/openai/lib/azure.py`

### Compatibility

No public API change; behavior only changes for the previously-broken post-copy case. Copies that override `base_url` keep their current behavior.

## Additional context & links

Discovered by auditing sibling copy/state-preservation logic; no existing issue or PR covers this. `.with_options()` is a common pattern (per-request timeouts/headers), so Azure users combining it with `azure_deployment` are likely to hit this.
