### PR TITLE
ci: fix CodeQL permissions for private repositories

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 


### PR DESCRIPTION
## Summary

- Grant the CodeQL workflow `actions: read` alongside its existing `contents: read` and `security-events: write` permissions.
- Allow the shared SDK workflow to read workflow-run metadata when it runs in the mirrored private repository.

## Why

The public workflow currently succeeds because public Actions workflow-run metadata can be read without an explicit Actions permission. The identical workflow fails in the private mirror with `Resource not accessible by integration` while preparing to upload CodeQL results.

## Validation

- Parsed the workflow as YAML and verified the complete least-privilege permission set.
- Confirmed the PR changes only one line in `.github/workflows/codeql.yml`.
- Verified the exact commit passed internal CodeQL: https://github.com/openai/openai-python-internal/actions/runs/31671272628