### PR TITLE
fix: coerce exception code to string or None

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -71,7 +71,8 @@ class APIError(OpenAIError):
         self.body = body
 
         if is_dict(body):
-            self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
+            code_val = body.get("code")
+            self.code = str(code_val) if code_val is not None else None
             self.param = cast(Any, construct_type(type_=Optional[str], value=body.get("param")))
             self.type = cast(Any, construct_type(type_=str, value=body.get("type")))
         else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2950,3 +2950,22 @@ class TestAsyncWorkloadIdentity401Retry:
             assert len(calls) == 2
 
             assert provider_call_count == 1
+
+
+def test_api_error_code_coercion() -> None:
+    from openai._exceptions import APIError
+
+    request = httpx.Request("GET", "http://localhost")
+
+    # Test integer code coercion
+    err = APIError("message", request, body={"code": 400, "param": "some_param", "type": "some_type"})
+    assert err.code == "400"
+
+    # Test string code coercion
+    err = APIError("message", request, body={"code": "invalid_api_key"})
+    assert err.code == "invalid_api_key"
+
+    # Test None code
+    err = APIError("message", request, body={"code": None})
+    assert err.code is None
+


### PR DESCRIPTION
Coerce error code inside APIError body to str | None to prevent validation errors with construct_type when the API returns integer codes (e.g. 400). Added unit test in tests/test_client.py.