### PR TITLE
feat(api): add WebSocket stream IDs

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 625cc75a-e869-4197-b1a1-0ab0f2dd58bf
-openapi_spec_hash: 9b793011794d783fd6a2d71d8a6f6972
-openapi_transformed_spec_hash: 89ade65e8a3170ca977f145feda2a689
+generation_id: 53946e0b-ca32-4724-9f42-4155beea8a67
+openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
+openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: 25f5de7c38e1809ac8576f80aba10db4a6c01df0
+codegen_sha: c8ff09541f193ac6671e2b55556913971a35d54c

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54665,20 +54665,36 @@ components:
             description: |
               The type of the client event. Always `response.create`.
             x-stainless-const: true
+          stream_id:
+            type: string
+            minLength: 1
+            maxLength: 256
+            pattern: ^[A-Za-z0-9_.-]+$
+            description: |
+              The WebSocket lane for this response. Requests with the same
+              `stream_id` are processed FIFO, and events for the response echo the
+              same `stream_id`.
+
+              `stream_id` controls routing; `previous_response_id` controls
+              conversation lineage, so a new lane can fork from a response created
+              on another lane.
         required:
         - type
       - $ref: '#/components/schemas/CreateResponse'
       description: |
         Client event for creating a response over a persistent WebSocket connection.
-        This payload uses the same top-level fields as `POST /v1/responses`.
+        This payload uses the same top-level fields as `POST /v1/responses`, plus
+        WebSocket-only envelope metadata.
 
         Notes:
         - `stream` is implicit over WebSocket and should not be sent.
         - `background` is not supported over WebSocket.
+        - `stream_id` is WebSocket-only and is not part of `POST /v1/responses`.
       x-oaiMeta:
         example: |
           {
             "type": "response.create",
+            "stream_id": "agent_1",
             "model": "gpt-5.5",
             "input": "Say hello."
           }
@@ -54688,7 +54704,672 @@ components:
       description: |
         Server events emitted by the Responses WebSocket server.
       anyOf:
+      - title: ResponseAudioWsDelta
+        description: Emitted when there is a partial audio response.
+        allOf:
+        - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseAudioWsDone
+        description: Emitted when the audio response is complete.
+        allOf:
+        - $ref: '#/components/schemas/ResponseAudioDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseAudioTranscriptWsDelta
+        description: Emitted when there is a partial transcript of audio.
+        allOf:
+        - $ref: '#/components/schemas/ResponseAudioTranscriptDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseAudioTranscriptWsDone
+        description: Emitted when the full audio transcript is completed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseAudioTranscriptDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCodeInterpreterCallCodeWsDelta
+        description: Emitted when a partial code snippet is streamed by the code interpreter.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCodeInterpreterCallCodeDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCodeInterpreterCallCodeWsDone
+        description: Emitted when the code snippet is finalized by the code interpreter.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCodeInterpreterCallCodeDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCodeInterpreterCallWsCompleted
+        description: Emitted when the code interpreter call is completed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCodeInterpreterCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCodeInterpreterCallInWsProgress
+        description: Emitted when a code interpreter call is in progress.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCodeInterpreterCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCodeInterpreterCallWsInterpreting
+        description: Emitted when the code interpreter is actively interpreting the code snippet.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCodeInterpreterCallInterpretingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWsCompleted
+        description: Emitted when the model response is complete.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseContentPartWsAdded
+        description: Emitted when a new content part is added.
+        allOf:
+        - $ref: '#/components/schemas/ResponseContentPartAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseContentPartWsDone
+        description: Emitted when a content part is done.
+        allOf:
+        - $ref: '#/components/schemas/ResponseContentPartDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWsCreated
+        description: |
+          An event that is emitted when a response is created.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCreatedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWsError
+        description: Emitted when an error occurs.
+        allOf:
+        - $ref: '#/components/schemas/ResponseErrorEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseFileSearchCallWsCompleted
+        description: Emitted when a file search call is completed (results found).
+        allOf:
+        - $ref: '#/components/schemas/ResponseFileSearchCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseFileSearchCallInWsProgress
+        description: Emitted when a file search call is initiated.
+        allOf:
+        - $ref: '#/components/schemas/ResponseFileSearchCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseFileSearchCallWsSearching
+        description: Emitted when a file search is currently searching.
+        allOf:
+        - $ref: '#/components/schemas/ResponseFileSearchCallSearchingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseFunctionCallArgumentsWsDelta
+        description: Emitted when there is a partial function-call arguments delta.
+        allOf:
+        - $ref: '#/components/schemas/ResponseFunctionCallArgumentsDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseFunctionCallArgumentsWsDone
+        description: Emitted when function-call arguments are finalized.
+        allOf:
+        - $ref: '#/components/schemas/ResponseFunctionCallArgumentsDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseInWsProgress
+        description: Emitted when the response is in progress.
+        allOf:
+        - $ref: '#/components/schemas/ResponseInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWsFailed
+        description: |
+          An event that is emitted when a response fails.
+        allOf:
+        - $ref: '#/components/schemas/ResponseFailedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWsIncomplete
+        description: |
+          An event that is emitted when a response finishes as incomplete.
+        allOf:
+        - $ref: '#/components/schemas/ResponseIncompleteEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseOutputItemWsAdded
+        description: Emitted when a new output item is added.
+        allOf:
+        - $ref: '#/components/schemas/ResponseOutputItemAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseOutputItemWsDone
+        description: Emitted when an output item is marked done.
+        allOf:
+        - $ref: '#/components/schemas/ResponseOutputItemDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseReasoningSummaryPartWsAdded
+        description: Emitted when a new reasoning summary part is added.
+        allOf:
+        - $ref: '#/components/schemas/ResponseReasoningSummaryPartAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseReasoningSummaryPartWsDone
+        description: Emitted when a reasoning summary part is completed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseReasoningSummaryPartDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseReasoningSummaryTextWsDelta
+        description: Emitted when a delta is added to a reasoning summary text.
+        allOf:
+        - $ref: '#/components/schemas/ResponseReasoningSummaryTextDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseReasoningSummaryTextWsDone
+        description: Emitted when a reasoning summary text is completed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseReasoningSummaryTextDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseReasoningTextWsDelta
+        description: Emitted when a delta is added to a reasoning text.
+        allOf:
+        - $ref: '#/components/schemas/ResponseReasoningTextDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseReasoningTextWsDone
+        description: Emitted when a reasoning text is completed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseReasoningTextDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseRefusalWsDelta
+        description: Emitted when there is a partial refusal text.
+        allOf:
+        - $ref: '#/components/schemas/ResponseRefusalDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseRefusalWsDone
+        description: Emitted when refusal text is finalized.
+        allOf:
+        - $ref: '#/components/schemas/ResponseRefusalDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseTextWsDelta
+        description: Emitted when there is an additional text delta.
+        allOf:
+        - $ref: '#/components/schemas/ResponseTextDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseTextWsDone
+        description: Emitted when text content is finalized.
+        allOf:
+        - $ref: '#/components/schemas/ResponseTextDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWebSearchCallWsCompleted
+        description: Emitted when a web search call is completed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseWebSearchCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWebSearchCallInWsProgress
+        description: Emitted when a web search call is initiated.
+        allOf:
+        - $ref: '#/components/schemas/ResponseWebSearchCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWebSearchCallWsSearching
+        description: Emitted when a web search call is executing.
+        allOf:
+        - $ref: '#/components/schemas/ResponseWebSearchCallSearchingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseImageGenCallWsCompleted
+        description: |
+          Emitted when an image generation tool call has completed and the final image is available.
+        allOf:
+        - $ref: '#/components/schemas/ResponseImageGenCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseImageGenCallWsGenerating
+        description: |
+          Emitted when an image generation tool call is actively generating an image (intermediate state).
+        allOf:
+        - $ref: '#/components/schemas/ResponseImageGenCallGeneratingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseImageGenCallInWsProgress
+        description: |
+          Emitted when an image generation tool call is in progress.
+        allOf:
+        - $ref: '#/components/schemas/ResponseImageGenCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseImageGenCallPartialWsImage
+        description: |
+          Emitted when a partial image is available during image generation streaming.
+        allOf:
+        - $ref: '#/components/schemas/ResponseImageGenCallPartialImageEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpCallArgumentsWsDelta
+        description: |
+          Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPCallArgumentsDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpCallArgumentsWsDone
+        description: |
+          Emitted when the arguments for an MCP tool call are finalized.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPCallArgumentsDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpCallWsCompleted
+        description: |
+          Emitted when an MCP  tool call has completed successfully.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpCallWsFailed
+        description: |
+          Emitted when an MCP  tool call has failed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPCallFailedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpCallInWsProgress
+        description: |
+          Emitted when an MCP  tool call is in progress.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpListToolsWsCompleted
+        description: |
+          Emitted when the list of available MCP tools has been successfully retrieved.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPListToolsCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpListToolsWsFailed
+        description: |
+          Emitted when the attempt to list available MCP tools has failed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPListToolsFailedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseMcpListToolsInWsProgress
+        description: |
+          Emitted when the system is in the process of retrieving the list of available MCP tools.
+        allOf:
+        - $ref: '#/components/schemas/ResponseMCPListToolsInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseOutputTextAnnotationWsAdded
+        description: |
+          Emitted when an annotation is added to output text content.
+        allOf:
+        - $ref: '#/components/schemas/ResponseOutputTextAnnotationAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseWsQueued
+        description: |
+          Emitted when a response is queued and waiting to be processed.
+        allOf:
+        - $ref: '#/components/schemas/ResponseQueuedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCustomToolCallInputWsDelta
+        description: |
+          Event representing a delta (partial update) to the input of a custom tool call.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCustomToolCallInputDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: ResponseCustomToolCallInputWsDone
+        description: |
+          Event indicating that input for a custom tool call is complete.
+        allOf:
+        - $ref: '#/components/schemas/ResponseCustomToolCallInputDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+    ResponsesWebSocketStreamEvent:
+      allOf:
       - $ref: '#/components/schemas/ResponseStreamEvent'
+      - type: object
+        properties:
+          stream_id:
+            type: string
+            description: |
+              The WebSocket lane that emitted this event. This field is present
+              when the originating `response.create` event supplied a
+              `stream_id`.
     Role:
       type: object
       description: Details about a role that can be assigned through the public Roles API.
@@ -75691,7 +76372,661 @@ components:
       description: |
         Server events emitted by the Responses WebSocket server.
       anyOf:
-      - $ref: '#/components/schemas/BetaResponseStreamEvent'
+      - title: BetaResponseAudioWsDelta
+        description: Emitted when there is a partial audio response.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseAudioWsDone
+        description: Emitted when the audio response is complete.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseAudioTranscriptWsDelta
+        description: Emitted when there is a partial transcript of audio.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseAudioTranscriptDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseAudioTranscriptWsDone
+        description: Emitted when the full audio transcript is completed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseAudioTranscriptDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCodeInterpreterCallCodeWsDelta
+        description: Emitted when a partial code snippet is streamed by the code interpreter.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCodeInterpreterCallCodeDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCodeInterpreterCallCodeWsDone
+        description: Emitted when the code snippet is finalized by the code interpreter.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCodeInterpreterCallCodeDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCodeInterpreterCallWsCompleted
+        description: Emitted when the code interpreter call is completed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCodeInterpreterCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCodeInterpreterCallInWsProgress
+        description: Emitted when a code interpreter call is in progress.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCodeInterpreterCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCodeInterpreterCallWsInterpreting
+        description: Emitted when the code interpreter is actively interpreting the code snippet.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCodeInterpreterCallInterpretingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWsCompleted
+        description: Emitted when the model response is complete.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseContentPartWsAdded
+        description: Emitted when a new content part is added.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseContentPartAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseContentPartWsDone
+        description: Emitted when a content part is done.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseContentPartDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWsCreated
+        description: |
+          An event that is emitted when a response is created.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCreatedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWsError
+        description: Emitted when an error occurs.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseErrorEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseFileSearchCallWsCompleted
+        description: Emitted when a file search call is completed (results found).
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseFileSearchCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseFileSearchCallInWsProgress
+        description: Emitted when a file search call is initiated.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseFileSearchCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseFileSearchCallWsSearching
+        description: Emitted when a file search is currently searching.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseFileSearchCallSearchingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseFunctionCallArgumentsWsDelta
+        description: Emitted when there is a partial function-call arguments delta.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseFunctionCallArgumentsDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseFunctionCallArgumentsWsDone
+        description: Emitted when function-call arguments are finalized.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseFunctionCallArgumentsDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseInWsProgress
+        description: Emitted when the response is in progress.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWsFailed
+        description: |
+          An event that is emitted when a response fails.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseFailedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWsIncomplete
+        description: |
+          An event that is emitted when a response finishes as incomplete.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseIncompleteEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseOutputItemWsAdded
+        description: Emitted when a new output item is added.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseOutputItemAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseOutputItemWsDone
+        description: Emitted when an output item is marked done.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseOutputItemDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseReasoningSummaryPartWsAdded
+        description: Emitted when a new reasoning summary part is added.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseReasoningSummaryPartAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseReasoningSummaryPartWsDone
+        description: Emitted when a reasoning summary part is completed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseReasoningSummaryPartDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseReasoningSummaryTextWsDelta
+        description: Emitted when a delta is added to a reasoning summary text.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseReasoningSummaryTextDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseReasoningSummaryTextWsDone
+        description: Emitted when a reasoning summary text is completed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseReasoningSummaryTextDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseReasoningTextWsDelta
+        description: Emitted when a delta is added to a reasoning text.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseReasoningTextDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseReasoningTextWsDone
+        description: Emitted when a reasoning text is completed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseReasoningTextDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseRefusalWsDelta
+        description: Emitted when there is a partial refusal text.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseRefusalDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseRefusalWsDone
+        description: Emitted when refusal text is finalized.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseRefusalDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseTextWsDelta
+        description: Emitted when there is an additional text delta.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseTextDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseTextWsDone
+        description: Emitted when text content is finalized.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseTextDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWebSearchCallWsCompleted
+        description: Emitted when a web search call is completed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseWebSearchCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWebSearchCallInWsProgress
+        description: Emitted when a web search call is initiated.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseWebSearchCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWebSearchCallWsSearching
+        description: Emitted when a web search call is executing.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseWebSearchCallSearchingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseImageGenCallWsCompleted
+        description: |
+          Emitted when an image generation tool call has completed and the final image is available.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseImageGenCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseImageGenCallWsGenerating
+        description: |
+          Emitted when an image generation tool call is actively generating an image (intermediate state).
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseImageGenCallGeneratingEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseImageGenCallInWsProgress
+        description: |
+          Emitted when an image generation tool call is in progress.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseImageGenCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseImageGenCallPartialWsImage
+        description: |
+          Emitted when a partial image is available during image generation streaming.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseImageGenCallPartialImageEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpCallArgumentsWsDelta
+        description: |
+          Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPCallArgumentsDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpCallArgumentsWsDone
+        description: |
+          Emitted when the arguments for an MCP tool call are finalized.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPCallArgumentsDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpCallWsCompleted
+        description: |
+          Emitted when an MCP  tool call has completed successfully.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPCallCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpCallWsFailed
+        description: |
+          Emitted when an MCP  tool call has failed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPCallFailedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpCallInWsProgress
+        description: |
+          Emitted when an MCP  tool call is in progress.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPCallInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpListToolsWsCompleted
+        description: |
+          Emitted when the list of available MCP tools has been successfully retrieved.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPListToolsCompletedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpListToolsWsFailed
+        description: |
+          Emitted when the attempt to list available MCP tools has failed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPListToolsFailedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseMcpListToolsInWsProgress
+        description: |
+          Emitted when the system is in the process of retrieving the list of available MCP tools.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseMCPListToolsInProgressEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseOutputTextAnnotationWsAdded
+        description: |
+          Emitted when an annotation is added to output text content.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseOutputTextAnnotationAddedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseWsQueued
+        description: |
+          Emitted when a response is queued and waiting to be processed.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseQueuedEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCustomToolCallInputWsDelta
+        description: |
+          Event representing a delta (partial update) to the input of a custom tool call.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCustomToolCallInputDeltaEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
+      - title: BetaResponseCustomToolCallInputWsDone
+        description: |
+          Event indicating that input for a custom tool call is complete.
+        allOf:
+        - $ref: '#/components/schemas/BetaResponseCustomToolCallInputDoneEvent'
+        - type: object
+          properties:
+            stream_id:
+              type: string
+              description: |
+                The WebSocket lane that emitted this event. This field is present
+                when the originating `response.create` event supplied a
+                `stream_id`.
       - $ref: '#/components/schemas/BetaResponseInjectCreatedEvent'
       - $ref: '#/components/schemas/BetaResponseInjectFailedEvent'
     BetaResponseInjectFailedEvent:
@@ -75801,6 +77136,17 @@ components:
             "response_id": "resp_123",
             "sequence_number": 8
           }
+    BetaResponsesWebSocketStreamEvent:
+      allOf:
+      - $ref: '#/components/schemas/BetaResponseStreamEvent'
+      - type: object
+        properties:
+          stream_id:
+            type: string
+            description: |
+              The WebSocket lane that emitted this event. This field is present
+              when the originating `response.create` event supplied a
+              `stream_id`.
     BetaResponseStreamEvent:
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
@@ -75918,20 +77264,36 @@ components:
             description: |
               The type of the client event. Always `response.create`.
             x-stainless-const: true
+          stream_id:
+            type: string
+            minLength: 1
+            maxLength: 256
+            pattern: ^[A-Za-z0-9_.-]+$
+            description: |
+              The WebSocket lane for this response. Requests with the same
+              `stream_id` are processed FIFO, and events for the response echo the
+              same `stream_id`.
+
+              `stream_id` controls routing; `previous_response_id` controls
+              conversation lineage, so a new lane can fork from a response created
+              on another lane.
         required:
         - type
       - $ref: '#/components/schemas/BetaCreateResponse'
       description: |
         Client event for creating a response over a persistent WebSocket connection.
-        This payload uses the same top-level fields as `POST /v1/responses`.
+        This payload uses the same top-level fields as `POST /v1/responses`, plus
+        WebSocket-only envelope metadata.
 
         Notes:
         - `stream` is implicit over WebSocket and should not be sent.
         - `background` is not supported over WebSocket.
+        - `stream_id` is WebSocket-only and is not part of `POST /v1/responses`.
       x-oaiMeta:
         example: |
           {
             "type": "response.create",
+            "stream_id": "agent_1",
             "model": "gpt-5.5",
             "input": "Say hello."
           }

--- a/src/openai/resources/beta/responses/responses.py
+++ b/src/openai/resources/beta/responses/responses.py
@@ -4259,11 +4259,11 @@ class AsyncResponsesConnection:
 
         Can be used as a method (returns ``self`` for chaining)::
 
-            connection.on("response.audio.delta", my_handler)
+            connection.on("response.inject.created", my_handler)
 
         Or as a decorator::
 
-            @connection.on("response.audio.delta")
+            @connection.on("response.inject.created")
             async def my_handler(event): ...
         """
         if handler is not None:
@@ -4710,11 +4710,11 @@ class ResponsesConnection:
 
         Can be used as a method (returns ``self`` for chaining)::
 
-            connection.on("response.audio.delta", my_handler)
+            connection.on("response.inject.created", my_handler)
 
         Or as a decorator::
 
-            @connection.on("response.audio.delta")
+            @connection.on("response.inject.created")
             def my_handler(event): ...
         """
         if handler is not None:
@@ -5094,6 +5094,7 @@ class ResponsesResponseResource(BaseResponsesConnectionResource):
         service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority", "fast"]] | Omit = omit,
         store: Optional[bool] | Omit = omit,
         stream: Optional[bool] | Omit = omit,
+        stream_id: str | Omit = omit,
         stream_options: Optional[beta_responses_client_event_param.ResponseCreateStreamOptions] | Omit = omit,
         temperature: Optional[float] | Omit = omit,
         text: BetaResponseTextConfigParam | Omit = omit,
@@ -5106,11 +5107,13 @@ class ResponsesResponseResource(BaseResponsesConnectionResource):
     ) -> None:
         """
         Client event for creating a response over a persistent WebSocket connection.
-        This payload uses the same top-level fields as `POST /v1/responses`.
+        This payload uses the same top-level fields as `POST /v1/responses`, plus
+        WebSocket-only envelope metadata.
 
         Notes:
         - `stream` is implicit over WebSocket and should not be sent.
         - `background` is not supported over WebSocket.
+        - `stream_id` is WebSocket-only and is not part of `POST /v1/responses`.
         """
         self._connection.send(
             cast(
@@ -5141,6 +5144,7 @@ class ResponsesResponseResource(BaseResponsesConnectionResource):
                         "service_tier": service_tier,
                         "store": store,
                         "stream": stream,
+                        "stream_id": stream_id,
                         "stream_options": stream_options,
                         "temperature": temperature,
                         "text": text,
@@ -5301,6 +5305,7 @@ class AsyncResponsesResponseResource(BaseAsyncResponsesConnectionResource):
         service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority", "fast"]] | Omit = omit,
         store: Optional[bool] | Omit = omit,
         stream: Optional[bool] | Omit = omit,
+        stream_id: str | Omit = omit,
         stream_options: Optional[beta_responses_client_event_param.ResponseCreateStreamOptions] | Omit = omit,
         temperature: Optional[float] | Omit = omit,
         text: BetaResponseTextConfigParam | Omit = omit,
@@ -5313,11 +5318,13 @@ class AsyncResponsesResponseResource(BaseAsyncResponsesConnectionResource):
     ) -> None:
         """
         Client event for creating a response over a persistent WebSocket connection.
-        This payload uses the same top-level fields as `POST /v1/responses`.
+        This payload uses the same top-level fields as `POST /v1/responses`, plus
+        WebSocket-only envelope metadata.
 
         Notes:
         - `stream` is implicit over WebSocket and should not be sent.
         - `background` is not supported over WebSocket.
+        - `stream_id` is WebSocket-only and is not part of `POST /v1/responses`.
         """
         await self._connection.send(
             cast(
@@ -5348,6 +5355,7 @@ class AsyncResponsesResponseResource(BaseAsyncResponsesConnectionResource):
                         "service_tier": service_tier,
                         "store": store,
                         "stream": stream,
+                        "stream_id": stream_id,
                         "stream_options": stream_options,
                         "temperature": temperature,
                         "text": text,

--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -4178,11 +4178,11 @@ class AsyncResponsesConnection:
 
         Can be used as a method (returns ``self`` for chaining)::
 
-            connection.on("response.audio.delta", my_handler)
+            connection.on("error", my_handler)
 
         Or as a decorator::
 
-            @connection.on("response.audio.delta")
+            @connection.on("error")
             async def my_handler(event): ...
         """
         if handler is not None:
@@ -4629,11 +4629,11 @@ class ResponsesConnection:
 
         Can be used as a method (returns ``self`` for chaining)::
 
-            connection.on("response.audio.delta", my_handler)
+            connection.on("error", my_handler)
 
         Or as a decorator::
 
-            @connection.on("response.audio.delta")
+            @connection.on("error")
             def my_handler(event): ...
         """
         if handler is not None:
@@ -4899,6 +4899,7 @@ class ResponsesResponseResource(BaseResponsesConnectionResource):
         service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority", "fast"]] | Omit = omit,
         store: Optional[bool] | Omit = omit,
         stream: Optional[bool] | Omit = omit,
+        stream_id: str | Omit = omit,
         stream_options: Optional[responses_client_event_param.StreamOptions] | Omit = omit,
         temperature: Optional[float] | Omit = omit,
         text: ResponseTextConfigParam | Omit = omit,
@@ -4937,6 +4938,7 @@ class ResponsesResponseResource(BaseResponsesConnectionResource):
                         "service_tier": service_tier,
                         "store": store,
                         "stream": stream,
+                        "stream_id": stream_id,
                         "stream_options": stream_options,
                         "temperature": temperature,
                         "text": text,
@@ -4983,6 +4985,7 @@ class AsyncResponsesResponseResource(BaseAsyncResponsesConnectionResource):
         service_tier: Optional[Literal["auto", "default", "flex", "scale", "priority", "fast"]] | Omit = omit,
         store: Optional[bool] | Omit = omit,
         stream: Optional[bool] | Omit = omit,
+        stream_id: str | Omit = omit,
         stream_options: Optional[responses_client_event_param.StreamOptions] | Omit = omit,
         temperature: Optional[float] | Omit = omit,
         text: ResponseTextConfigParam | Omit = omit,
@@ -5021,6 +5024,7 @@ class AsyncResponsesResponseResource(BaseAsyncResponsesConnectionResource):
                         "service_tier": service_tier,
                         "store": store,
                         "stream": stream,
+                        "stream_id": stream_id,
                         "stream_options": stream_options,
                         "temperature": temperature,
                         "text": text,

--- a/src/openai/types/beta/beta_responses_client_event.py
+++ b/src/openai/types/beta/beta_responses_client_event.py
@@ -215,11 +215,13 @@ ResponseCreateToolChoice: TypeAlias = Union[
 class ResponseCreate(BaseModel):
     """
     Client event for creating a response over a persistent WebSocket connection.
-    This payload uses the same top-level fields as `POST /v1/responses`.
+    This payload uses the same top-level fields as `POST /v1/responses`, plus
+    WebSocket-only envelope metadata.
 
     Notes:
     - `stream` is implicit over WebSocket and should not be sent.
     - `background` is not supported over WebSocket.
+    - `stream_id` is WebSocket-only and is not part of `POST /v1/responses`.
     """
 
     type: Literal["response.create"]
@@ -537,6 +539,16 @@ class ResponseCreate(BaseModel):
     See the
     [Streaming section below](https://platform.openai.com/docs/api-reference/responses-streaming)
     for more information.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane for this response.
+
+    Requests with the same `stream_id` are processed FIFO, and events for the
+    response echo the same `stream_id`.
+
+    `stream_id` controls routing; `previous_response_id` controls conversation
+    lineage, so a new lane can fork from a response created on another lane.
     """
 
     stream_options: Optional[ResponseCreateStreamOptions] = None

--- a/src/openai/types/beta/beta_responses_client_event_param.py
+++ b/src/openai/types/beta/beta_responses_client_event_param.py
@@ -215,11 +215,13 @@ ResponseCreateToolChoice: TypeAlias = Union[
 class ResponseCreate(TypedDict, total=False):
     """
     Client event for creating a response over a persistent WebSocket connection.
-    This payload uses the same top-level fields as `POST /v1/responses`.
+    This payload uses the same top-level fields as `POST /v1/responses`, plus
+    WebSocket-only envelope metadata.
 
     Notes:
     - `stream` is implicit over WebSocket and should not be sent.
     - `background` is not supported over WebSocket.
+    - `stream_id` is WebSocket-only and is not part of `POST /v1/responses`.
     """
 
     type: Required[Literal["response.create"]]
@@ -536,6 +538,16 @@ class ResponseCreate(TypedDict, total=False):
     See the
     [Streaming section below](https://platform.openai.com/docs/api-reference/responses-streaming)
     for more information.
+    """
+
+    stream_id: str
+    """The WebSocket lane for this response.
+
+    Requests with the same `stream_id` are processed FIFO, and events for the
+    response echo the same `stream_id`.
+
+    `stream_id` controls routing; `previous_response_id` controls conversation
+    lineage, so a new lane can fork from a response created on another lane.
     """
 
     stream_options: Optional[ResponseCreateStreamOptions]

--- a/src/openai/types/beta/beta_responses_server_event.py
+++ b/src/openai/types/beta/beta_responses_server_event.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
 
-from typing import Union
+from typing import Union, Optional
 from typing_extensions import Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -60,63 +60,710 @@ from .beta_response_code_interpreter_call_code_delta_event import BetaResponseCo
 from .beta_response_code_interpreter_call_in_progress_event import BetaResponseCodeInterpreterCallInProgressEvent
 from .beta_response_code_interpreter_call_interpreting_event import BetaResponseCodeInterpreterCallInterpretingEvent
 
-__all__ = ["BetaResponsesServerEvent"]
+__all__ = [
+    "BetaResponsesServerEvent",
+    "BetaResponseAudioWsDelta",
+    "BetaResponseAudioWsDone",
+    "BetaResponseAudioTranscriptWsDelta",
+    "BetaResponseAudioTranscriptWsDone",
+    "BetaResponseCodeInterpreterCallCodeWsDelta",
+    "BetaResponseCodeInterpreterCallCodeWsDone",
+    "BetaResponseCodeInterpreterCallWsCompleted",
+    "BetaResponseCodeInterpreterCallInWsProgress",
+    "BetaResponseCodeInterpreterCallWsInterpreting",
+    "BetaResponseWsCompleted",
+    "BetaResponseContentPartWsAdded",
+    "BetaResponseContentPartWsDone",
+    "BetaResponseWsCreated",
+    "BetaResponseWsError",
+    "BetaResponseFileSearchCallWsCompleted",
+    "BetaResponseFileSearchCallInWsProgress",
+    "BetaResponseFileSearchCallWsSearching",
+    "BetaResponseFunctionCallArgumentsWsDelta",
+    "BetaResponseFunctionCallArgumentsWsDone",
+    "BetaResponseInWsProgress",
+    "BetaResponseWsFailed",
+    "BetaResponseWsIncomplete",
+    "BetaResponseOutputItemWsAdded",
+    "BetaResponseOutputItemWsDone",
+    "BetaResponseReasoningSummaryPartWsAdded",
+    "BetaResponseReasoningSummaryPartWsDone",
+    "BetaResponseReasoningSummaryTextWsDelta",
+    "BetaResponseReasoningSummaryTextWsDone",
+    "BetaResponseReasoningTextWsDelta",
+    "BetaResponseReasoningTextWsDone",
+    "BetaResponseRefusalWsDelta",
+    "BetaResponseRefusalWsDone",
+    "BetaResponseTextWsDelta",
+    "BetaResponseTextWsDone",
+    "BetaResponseWebSearchCallWsCompleted",
+    "BetaResponseWebSearchCallInWsProgress",
+    "BetaResponseWebSearchCallWsSearching",
+    "BetaResponseImageGenCallWsCompleted",
+    "BetaResponseImageGenCallWsGenerating",
+    "BetaResponseImageGenCallInWsProgress",
+    "BetaResponseImageGenCallPartialWsImage",
+    "BetaResponseMcpCallArgumentsWsDelta",
+    "BetaResponseMcpCallArgumentsWsDone",
+    "BetaResponseMcpCallWsCompleted",
+    "BetaResponseMcpCallWsFailed",
+    "BetaResponseMcpCallInWsProgress",
+    "BetaResponseMcpListToolsWsCompleted",
+    "BetaResponseMcpListToolsWsFailed",
+    "BetaResponseMcpListToolsInWsProgress",
+    "BetaResponseOutputTextAnnotationWsAdded",
+    "BetaResponseWsQueued",
+    "BetaResponseCustomToolCallInputWsDelta",
+    "BetaResponseCustomToolCallInputWsDone",
+]
+
+
+class BetaResponseAudioWsDelta(BetaResponseAudioDeltaEvent):
+    """Emitted when there is a partial audio response."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseAudioWsDone(BetaResponseAudioDoneEvent):
+    """Emitted when the audio response is complete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseAudioTranscriptWsDelta(BetaResponseAudioTranscriptDeltaEvent):
+    """Emitted when there is a partial transcript of audio."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseAudioTranscriptWsDone(BetaResponseAudioTranscriptDoneEvent):
+    """Emitted when the full audio transcript is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCodeInterpreterCallCodeWsDelta(BetaResponseCodeInterpreterCallCodeDeltaEvent):
+    """Emitted when a partial code snippet is streamed by the code interpreter."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCodeInterpreterCallCodeWsDone(BetaResponseCodeInterpreterCallCodeDoneEvent):
+    """Emitted when the code snippet is finalized by the code interpreter."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCodeInterpreterCallWsCompleted(BetaResponseCodeInterpreterCallCompletedEvent):
+    """Emitted when the code interpreter call is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCodeInterpreterCallInWsProgress(BetaResponseCodeInterpreterCallInProgressEvent):
+    """Emitted when a code interpreter call is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCodeInterpreterCallWsInterpreting(BetaResponseCodeInterpreterCallInterpretingEvent):
+    """Emitted when the code interpreter is actively interpreting the code snippet."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWsCompleted(BetaResponseCompletedEvent):
+    """Emitted when the model response is complete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseContentPartWsAdded(BetaResponseContentPartAddedEvent):
+    """Emitted when a new content part is added."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseContentPartWsDone(BetaResponseContentPartDoneEvent):
+    """Emitted when a content part is done."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWsCreated(BetaResponseCreatedEvent):
+    """An event that is emitted when a response is created."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWsError(BetaResponseErrorEvent):
+    """Emitted when an error occurs."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseFileSearchCallWsCompleted(BetaResponseFileSearchCallCompletedEvent):
+    """Emitted when a file search call is completed (results found)."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseFileSearchCallInWsProgress(BetaResponseFileSearchCallInProgressEvent):
+    """Emitted when a file search call is initiated."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseFileSearchCallWsSearching(BetaResponseFileSearchCallSearchingEvent):
+    """Emitted when a file search is currently searching."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseFunctionCallArgumentsWsDelta(BetaResponseFunctionCallArgumentsDeltaEvent):
+    """Emitted when there is a partial function-call arguments delta."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseFunctionCallArgumentsWsDone(BetaResponseFunctionCallArgumentsDoneEvent):
+    """Emitted when function-call arguments are finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseInWsProgress(BetaResponseInProgressEvent):
+    """Emitted when the response is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWsFailed(BetaResponseFailedEvent):
+    """An event that is emitted when a response fails."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWsIncomplete(BetaResponseIncompleteEvent):
+    """An event that is emitted when a response finishes as incomplete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseOutputItemWsAdded(BetaResponseOutputItemAddedEvent):
+    """Emitted when a new output item is added."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseOutputItemWsDone(BetaResponseOutputItemDoneEvent):
+    """Emitted when an output item is marked done."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseReasoningSummaryPartWsAdded(BetaResponseReasoningSummaryPartAddedEvent):
+    """Emitted when a new reasoning summary part is added."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseReasoningSummaryPartWsDone(BetaResponseReasoningSummaryPartDoneEvent):
+    """Emitted when a reasoning summary part is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseReasoningSummaryTextWsDelta(BetaResponseReasoningSummaryTextDeltaEvent):
+    """Emitted when a delta is added to a reasoning summary text."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseReasoningSummaryTextWsDone(BetaResponseReasoningSummaryTextDoneEvent):
+    """Emitted when a reasoning summary text is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseReasoningTextWsDelta(BetaResponseReasoningTextDeltaEvent):
+    """Emitted when a delta is added to a reasoning text."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseReasoningTextWsDone(BetaResponseReasoningTextDoneEvent):
+    """Emitted when a reasoning text is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseRefusalWsDelta(BetaResponseRefusalDeltaEvent):
+    """Emitted when there is a partial refusal text."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseRefusalWsDone(BetaResponseRefusalDoneEvent):
+    """Emitted when refusal text is finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseTextWsDelta(BetaResponseTextDeltaEvent):
+    """Emitted when there is an additional text delta."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseTextWsDone(BetaResponseTextDoneEvent):
+    """Emitted when text content is finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWebSearchCallWsCompleted(BetaResponseWebSearchCallCompletedEvent):
+    """Emitted when a web search call is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWebSearchCallInWsProgress(BetaResponseWebSearchCallInProgressEvent):
+    """Emitted when a web search call is initiated."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWebSearchCallWsSearching(BetaResponseWebSearchCallSearchingEvent):
+    """Emitted when a web search call is executing."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseImageGenCallWsCompleted(BetaResponseImageGenCallCompletedEvent):
+    """
+    Emitted when an image generation tool call has completed and the final image is available.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseImageGenCallWsGenerating(BetaResponseImageGenCallGeneratingEvent):
+    """
+    Emitted when an image generation tool call is actively generating an image (intermediate state).
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseImageGenCallInWsProgress(BetaResponseImageGenCallInProgressEvent):
+    """Emitted when an image generation tool call is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseImageGenCallPartialWsImage(BetaResponseImageGenCallPartialImageEvent):
+    """Emitted when a partial image is available during image generation streaming."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpCallArgumentsWsDelta(BetaResponseMcpCallArgumentsDeltaEvent):
+    """
+    Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpCallArgumentsWsDone(BetaResponseMcpCallArgumentsDoneEvent):
+    """Emitted when the arguments for an MCP tool call are finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpCallWsCompleted(BetaResponseMcpCallCompletedEvent):
+    """Emitted when an MCP  tool call has completed successfully."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpCallWsFailed(BetaResponseMcpCallFailedEvent):
+    """Emitted when an MCP  tool call has failed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpCallInWsProgress(BetaResponseMcpCallInProgressEvent):
+    """Emitted when an MCP  tool call is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpListToolsWsCompleted(BetaResponseMcpListToolsCompletedEvent):
+    """Emitted when the list of available MCP tools has been successfully retrieved."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpListToolsWsFailed(BetaResponseMcpListToolsFailedEvent):
+    """Emitted when the attempt to list available MCP tools has failed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseMcpListToolsInWsProgress(BetaResponseMcpListToolsInProgressEvent):
+    """
+    Emitted when the system is in the process of retrieving the list of available MCP tools.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseOutputTextAnnotationWsAdded(BetaResponseOutputTextAnnotationAddedEvent):
+    """Emitted when an annotation is added to output text content."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseWsQueued(BetaResponseQueuedEvent):
+    """Emitted when a response is queued and waiting to be processed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCustomToolCallInputWsDelta(BetaResponseCustomToolCallInputDeltaEvent):
+    """Event representing a delta (partial update) to the input of a custom tool call."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class BetaResponseCustomToolCallInputWsDone(BetaResponseCustomToolCallInputDoneEvent):
+    """Event indicating that input for a custom tool call is complete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
 
 BetaResponsesServerEvent: TypeAlias = Annotated[
     Union[
-        BetaResponseAudioDeltaEvent,
-        BetaResponseAudioDoneEvent,
-        BetaResponseAudioTranscriptDeltaEvent,
-        BetaResponseAudioTranscriptDoneEvent,
-        BetaResponseCodeInterpreterCallCodeDeltaEvent,
-        BetaResponseCodeInterpreterCallCodeDoneEvent,
-        BetaResponseCodeInterpreterCallCompletedEvent,
-        BetaResponseCodeInterpreterCallInProgressEvent,
-        BetaResponseCodeInterpreterCallInterpretingEvent,
-        BetaResponseCompletedEvent,
-        BetaResponseContentPartAddedEvent,
-        BetaResponseContentPartDoneEvent,
-        BetaResponseCreatedEvent,
-        BetaResponseErrorEvent,
-        BetaResponseFileSearchCallCompletedEvent,
-        BetaResponseFileSearchCallInProgressEvent,
-        BetaResponseFileSearchCallSearchingEvent,
-        BetaResponseFunctionCallArgumentsDeltaEvent,
-        BetaResponseFunctionCallArgumentsDoneEvent,
-        BetaResponseInProgressEvent,
-        BetaResponseFailedEvent,
-        BetaResponseIncompleteEvent,
-        BetaResponseOutputItemAddedEvent,
-        BetaResponseOutputItemDoneEvent,
-        BetaResponseReasoningSummaryPartAddedEvent,
-        BetaResponseReasoningSummaryPartDoneEvent,
-        BetaResponseReasoningSummaryTextDeltaEvent,
-        BetaResponseReasoningSummaryTextDoneEvent,
-        BetaResponseReasoningTextDeltaEvent,
-        BetaResponseReasoningTextDoneEvent,
-        BetaResponseRefusalDeltaEvent,
-        BetaResponseRefusalDoneEvent,
-        BetaResponseTextDeltaEvent,
-        BetaResponseTextDoneEvent,
-        BetaResponseWebSearchCallCompletedEvent,
-        BetaResponseWebSearchCallInProgressEvent,
-        BetaResponseWebSearchCallSearchingEvent,
-        BetaResponseImageGenCallCompletedEvent,
-        BetaResponseImageGenCallGeneratingEvent,
-        BetaResponseImageGenCallInProgressEvent,
-        BetaResponseImageGenCallPartialImageEvent,
-        BetaResponseMcpCallArgumentsDeltaEvent,
-        BetaResponseMcpCallArgumentsDoneEvent,
-        BetaResponseMcpCallCompletedEvent,
-        BetaResponseMcpCallFailedEvent,
-        BetaResponseMcpCallInProgressEvent,
-        BetaResponseMcpListToolsCompletedEvent,
-        BetaResponseMcpListToolsFailedEvent,
-        BetaResponseMcpListToolsInProgressEvent,
-        BetaResponseOutputTextAnnotationAddedEvent,
-        BetaResponseQueuedEvent,
-        BetaResponseCustomToolCallInputDeltaEvent,
-        BetaResponseCustomToolCallInputDoneEvent,
+        BetaResponseAudioWsDelta,
+        BetaResponseAudioWsDone,
+        BetaResponseAudioTranscriptWsDelta,
+        BetaResponseAudioTranscriptWsDone,
+        BetaResponseCodeInterpreterCallCodeWsDelta,
+        BetaResponseCodeInterpreterCallCodeWsDone,
+        BetaResponseCodeInterpreterCallWsCompleted,
+        BetaResponseCodeInterpreterCallInWsProgress,
+        BetaResponseCodeInterpreterCallWsInterpreting,
+        BetaResponseWsCompleted,
+        BetaResponseContentPartWsAdded,
+        BetaResponseContentPartWsDone,
+        BetaResponseWsCreated,
+        BetaResponseWsError,
+        BetaResponseFileSearchCallWsCompleted,
+        BetaResponseFileSearchCallInWsProgress,
+        BetaResponseFileSearchCallWsSearching,
+        BetaResponseFunctionCallArgumentsWsDelta,
+        BetaResponseFunctionCallArgumentsWsDone,
+        BetaResponseInWsProgress,
+        BetaResponseWsFailed,
+        BetaResponseWsIncomplete,
+        BetaResponseOutputItemWsAdded,
+        BetaResponseOutputItemWsDone,
+        BetaResponseReasoningSummaryPartWsAdded,
+        BetaResponseReasoningSummaryPartWsDone,
+        BetaResponseReasoningSummaryTextWsDelta,
+        BetaResponseReasoningSummaryTextWsDone,
+        BetaResponseReasoningTextWsDelta,
+        BetaResponseReasoningTextWsDone,
+        BetaResponseRefusalWsDelta,
+        BetaResponseRefusalWsDone,
+        BetaResponseTextWsDelta,
+        BetaResponseTextWsDone,
+        BetaResponseWebSearchCallWsCompleted,
+        BetaResponseWebSearchCallInWsProgress,
+        BetaResponseWebSearchCallWsSearching,
+        BetaResponseImageGenCallWsCompleted,
+        BetaResponseImageGenCallWsGenerating,
+        BetaResponseImageGenCallInWsProgress,
+        BetaResponseImageGenCallPartialWsImage,
+        BetaResponseMcpCallArgumentsWsDelta,
+        BetaResponseMcpCallArgumentsWsDone,
+        BetaResponseMcpCallWsCompleted,
+        BetaResponseMcpCallWsFailed,
+        BetaResponseMcpCallInWsProgress,
+        BetaResponseMcpListToolsWsCompleted,
+        BetaResponseMcpListToolsWsFailed,
+        BetaResponseMcpListToolsInWsProgress,
+        BetaResponseOutputTextAnnotationWsAdded,
+        BetaResponseWsQueued,
+        BetaResponseCustomToolCallInputWsDelta,
+        BetaResponseCustomToolCallInputWsDone,
         BetaResponseInjectCreatedEvent,
         BetaResponseInjectFailedEvent,
     ],

--- a/src/openai/types/responses/responses_client_event.py
+++ b/src/openai/types/responses/responses_client_event.py
@@ -351,6 +351,16 @@ class ResponsesClientEvent(BaseModel):
     for more information.
     """
 
+    stream_id: Optional[str] = None
+    """The WebSocket lane for this response.
+
+    Requests with the same `stream_id` are processed FIFO, and events for the
+    response echo the same `stream_id`.
+
+    `stream_id` controls routing; `previous_response_id` controls conversation
+    lineage, so a new lane can fork from a response created on another lane.
+    """
+
     stream_options: Optional[StreamOptions] = None
     """Options for streaming responses. Only set this when you set `stream: true`."""
 

--- a/src/openai/types/responses/responses_client_event_param.py
+++ b/src/openai/types/responses/responses_client_event_param.py
@@ -352,6 +352,16 @@ class ResponsesClientEventParam(TypedDict, total=False):
     for more information.
     """
 
+    stream_id: str
+    """The WebSocket lane for this response.
+
+    Requests with the same `stream_id` are processed FIFO, and events for the
+    response echo the same `stream_id`.
+
+    `stream_id` controls routing; `previous_response_id` controls conversation
+    lineage, so a new lane can fork from a response created on another lane.
+    """
+
     stream_options: Optional[StreamOptions]
     """Options for streaming responses. Only set this when you set `stream: true`."""
 

--- a/src/openai/types/responses/responses_server_event.py
+++ b/src/openai/types/responses/responses_server_event.py
@@ -1,6 +1,6 @@
 # File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
 
-from typing import Union
+from typing import Union, Optional
 from typing_extensions import Annotated, TypeAlias
 
 from ..._utils import PropertyInfo
@@ -58,63 +58,710 @@ from .response_code_interpreter_call_code_delta_event import ResponseCodeInterpr
 from .response_code_interpreter_call_in_progress_event import ResponseCodeInterpreterCallInProgressEvent
 from .response_code_interpreter_call_interpreting_event import ResponseCodeInterpreterCallInterpretingEvent
 
-__all__ = ["ResponsesServerEvent"]
+__all__ = [
+    "ResponsesServerEvent",
+    "ResponseAudioWsDelta",
+    "ResponseAudioWsDone",
+    "ResponseAudioTranscriptWsDelta",
+    "ResponseAudioTranscriptWsDone",
+    "ResponseCodeInterpreterCallCodeWsDelta",
+    "ResponseCodeInterpreterCallCodeWsDone",
+    "ResponseCodeInterpreterCallWsCompleted",
+    "ResponseCodeInterpreterCallInWsProgress",
+    "ResponseCodeInterpreterCallWsInterpreting",
+    "ResponseWsCompleted",
+    "ResponseContentPartWsAdded",
+    "ResponseContentPartWsDone",
+    "ResponseWsCreated",
+    "ResponseWsError",
+    "ResponseFileSearchCallWsCompleted",
+    "ResponseFileSearchCallInWsProgress",
+    "ResponseFileSearchCallWsSearching",
+    "ResponseFunctionCallArgumentsWsDelta",
+    "ResponseFunctionCallArgumentsWsDone",
+    "ResponseInWsProgress",
+    "ResponseWsFailed",
+    "ResponseWsIncomplete",
+    "ResponseOutputItemWsAdded",
+    "ResponseOutputItemWsDone",
+    "ResponseReasoningSummaryPartWsAdded",
+    "ResponseReasoningSummaryPartWsDone",
+    "ResponseReasoningSummaryTextWsDelta",
+    "ResponseReasoningSummaryTextWsDone",
+    "ResponseReasoningTextWsDelta",
+    "ResponseReasoningTextWsDone",
+    "ResponseRefusalWsDelta",
+    "ResponseRefusalWsDone",
+    "ResponseTextWsDelta",
+    "ResponseTextWsDone",
+    "ResponseWebSearchCallWsCompleted",
+    "ResponseWebSearchCallInWsProgress",
+    "ResponseWebSearchCallWsSearching",
+    "ResponseImageGenCallWsCompleted",
+    "ResponseImageGenCallWsGenerating",
+    "ResponseImageGenCallInWsProgress",
+    "ResponseImageGenCallPartialWsImage",
+    "ResponseMcpCallArgumentsWsDelta",
+    "ResponseMcpCallArgumentsWsDone",
+    "ResponseMcpCallWsCompleted",
+    "ResponseMcpCallWsFailed",
+    "ResponseMcpCallInWsProgress",
+    "ResponseMcpListToolsWsCompleted",
+    "ResponseMcpListToolsWsFailed",
+    "ResponseMcpListToolsInWsProgress",
+    "ResponseOutputTextAnnotationWsAdded",
+    "ResponseWsQueued",
+    "ResponseCustomToolCallInputWsDelta",
+    "ResponseCustomToolCallInputWsDone",
+]
+
+
+class ResponseAudioWsDelta(ResponseAudioDeltaEvent):
+    """Emitted when there is a partial audio response."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseAudioWsDone(ResponseAudioDoneEvent):
+    """Emitted when the audio response is complete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseAudioTranscriptWsDelta(ResponseAudioTranscriptDeltaEvent):
+    """Emitted when there is a partial transcript of audio."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseAudioTranscriptWsDone(ResponseAudioTranscriptDoneEvent):
+    """Emitted when the full audio transcript is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCodeInterpreterCallCodeWsDelta(ResponseCodeInterpreterCallCodeDeltaEvent):
+    """Emitted when a partial code snippet is streamed by the code interpreter."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCodeInterpreterCallCodeWsDone(ResponseCodeInterpreterCallCodeDoneEvent):
+    """Emitted when the code snippet is finalized by the code interpreter."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCodeInterpreterCallWsCompleted(ResponseCodeInterpreterCallCompletedEvent):
+    """Emitted when the code interpreter call is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCodeInterpreterCallInWsProgress(ResponseCodeInterpreterCallInProgressEvent):
+    """Emitted when a code interpreter call is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCodeInterpreterCallWsInterpreting(ResponseCodeInterpreterCallInterpretingEvent):
+    """Emitted when the code interpreter is actively interpreting the code snippet."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWsCompleted(ResponseCompletedEvent):
+    """Emitted when the model response is complete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseContentPartWsAdded(ResponseContentPartAddedEvent):
+    """Emitted when a new content part is added."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseContentPartWsDone(ResponseContentPartDoneEvent):
+    """Emitted when a content part is done."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWsCreated(ResponseCreatedEvent):
+    """An event that is emitted when a response is created."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWsError(ResponseErrorEvent):
+    """Emitted when an error occurs."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseFileSearchCallWsCompleted(ResponseFileSearchCallCompletedEvent):
+    """Emitted when a file search call is completed (results found)."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseFileSearchCallInWsProgress(ResponseFileSearchCallInProgressEvent):
+    """Emitted when a file search call is initiated."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseFileSearchCallWsSearching(ResponseFileSearchCallSearchingEvent):
+    """Emitted when a file search is currently searching."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseFunctionCallArgumentsWsDelta(ResponseFunctionCallArgumentsDeltaEvent):
+    """Emitted when there is a partial function-call arguments delta."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseFunctionCallArgumentsWsDone(ResponseFunctionCallArgumentsDoneEvent):
+    """Emitted when function-call arguments are finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseInWsProgress(ResponseInProgressEvent):
+    """Emitted when the response is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWsFailed(ResponseFailedEvent):
+    """An event that is emitted when a response fails."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWsIncomplete(ResponseIncompleteEvent):
+    """An event that is emitted when a response finishes as incomplete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseOutputItemWsAdded(ResponseOutputItemAddedEvent):
+    """Emitted when a new output item is added."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseOutputItemWsDone(ResponseOutputItemDoneEvent):
+    """Emitted when an output item is marked done."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseReasoningSummaryPartWsAdded(ResponseReasoningSummaryPartAddedEvent):
+    """Emitted when a new reasoning summary part is added."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseReasoningSummaryPartWsDone(ResponseReasoningSummaryPartDoneEvent):
+    """Emitted when a reasoning summary part is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseReasoningSummaryTextWsDelta(ResponseReasoningSummaryTextDeltaEvent):
+    """Emitted when a delta is added to a reasoning summary text."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseReasoningSummaryTextWsDone(ResponseReasoningSummaryTextDoneEvent):
+    """Emitted when a reasoning summary text is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseReasoningTextWsDelta(ResponseReasoningTextDeltaEvent):
+    """Emitted when a delta is added to a reasoning text."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseReasoningTextWsDone(ResponseReasoningTextDoneEvent):
+    """Emitted when a reasoning text is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseRefusalWsDelta(ResponseRefusalDeltaEvent):
+    """Emitted when there is a partial refusal text."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseRefusalWsDone(ResponseRefusalDoneEvent):
+    """Emitted when refusal text is finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseTextWsDelta(ResponseTextDeltaEvent):
+    """Emitted when there is an additional text delta."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseTextWsDone(ResponseTextDoneEvent):
+    """Emitted when text content is finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWebSearchCallWsCompleted(ResponseWebSearchCallCompletedEvent):
+    """Emitted when a web search call is completed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWebSearchCallInWsProgress(ResponseWebSearchCallInProgressEvent):
+    """Emitted when a web search call is initiated."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWebSearchCallWsSearching(ResponseWebSearchCallSearchingEvent):
+    """Emitted when a web search call is executing."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseImageGenCallWsCompleted(ResponseImageGenCallCompletedEvent):
+    """
+    Emitted when an image generation tool call has completed and the final image is available.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseImageGenCallWsGenerating(ResponseImageGenCallGeneratingEvent):
+    """
+    Emitted when an image generation tool call is actively generating an image (intermediate state).
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseImageGenCallInWsProgress(ResponseImageGenCallInProgressEvent):
+    """Emitted when an image generation tool call is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseImageGenCallPartialWsImage(ResponseImageGenCallPartialImageEvent):
+    """Emitted when a partial image is available during image generation streaming."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpCallArgumentsWsDelta(ResponseMcpCallArgumentsDeltaEvent):
+    """
+    Emitted when there is a delta (partial update) to the arguments of an MCP tool call.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpCallArgumentsWsDone(ResponseMcpCallArgumentsDoneEvent):
+    """Emitted when the arguments for an MCP tool call are finalized."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpCallWsCompleted(ResponseMcpCallCompletedEvent):
+    """Emitted when an MCP  tool call has completed successfully."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpCallWsFailed(ResponseMcpCallFailedEvent):
+    """Emitted when an MCP  tool call has failed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpCallInWsProgress(ResponseMcpCallInProgressEvent):
+    """Emitted when an MCP  tool call is in progress."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpListToolsWsCompleted(ResponseMcpListToolsCompletedEvent):
+    """Emitted when the list of available MCP tools has been successfully retrieved."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpListToolsWsFailed(ResponseMcpListToolsFailedEvent):
+    """Emitted when the attempt to list available MCP tools has failed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseMcpListToolsInWsProgress(ResponseMcpListToolsInProgressEvent):
+    """
+    Emitted when the system is in the process of retrieving the list of available MCP tools.
+    """
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseOutputTextAnnotationWsAdded(ResponseOutputTextAnnotationAddedEvent):
+    """Emitted when an annotation is added to output text content."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseWsQueued(ResponseQueuedEvent):
+    """Emitted when a response is queued and waiting to be processed."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCustomToolCallInputWsDelta(ResponseCustomToolCallInputDeltaEvent):
+    """Event representing a delta (partial update) to the input of a custom tool call."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
+
+class ResponseCustomToolCallInputWsDone(ResponseCustomToolCallInputDoneEvent):
+    """Event indicating that input for a custom tool call is complete."""
+
+    stream_id: Optional[str] = None
+    """The WebSocket lane that emitted this event.
+
+    This field is present when the originating `response.create` event supplied a
+    `stream_id`.
+    """
+
 
 ResponsesServerEvent: TypeAlias = Annotated[
     Union[
-        ResponseAudioDeltaEvent,
-        ResponseAudioDoneEvent,
-        ResponseAudioTranscriptDeltaEvent,
-        ResponseAudioTranscriptDoneEvent,
-        ResponseCodeInterpreterCallCodeDeltaEvent,
-        ResponseCodeInterpreterCallCodeDoneEvent,
-        ResponseCodeInterpreterCallCompletedEvent,
-        ResponseCodeInterpreterCallInProgressEvent,
-        ResponseCodeInterpreterCallInterpretingEvent,
-        ResponseCompletedEvent,
-        ResponseContentPartAddedEvent,
-        ResponseContentPartDoneEvent,
-        ResponseCreatedEvent,
-        ResponseErrorEvent,
-        ResponseFileSearchCallCompletedEvent,
-        ResponseFileSearchCallInProgressEvent,
-        ResponseFileSearchCallSearchingEvent,
-        ResponseFunctionCallArgumentsDeltaEvent,
-        ResponseFunctionCallArgumentsDoneEvent,
-        ResponseInProgressEvent,
-        ResponseFailedEvent,
-        ResponseIncompleteEvent,
-        ResponseOutputItemAddedEvent,
-        ResponseOutputItemDoneEvent,
-        ResponseReasoningSummaryPartAddedEvent,
-        ResponseReasoningSummaryPartDoneEvent,
-        ResponseReasoningSummaryTextDeltaEvent,
-        ResponseReasoningSummaryTextDoneEvent,
-        ResponseReasoningTextDeltaEvent,
-        ResponseReasoningTextDoneEvent,
-        ResponseRefusalDeltaEvent,
-        ResponseRefusalDoneEvent,
-        ResponseTextDeltaEvent,
-        ResponseTextDoneEvent,
-        ResponseWebSearchCallCompletedEvent,
-        ResponseWebSearchCallInProgressEvent,
-        ResponseWebSearchCallSearchingEvent,
-        ResponseImageGenCallCompletedEvent,
-        ResponseImageGenCallGeneratingEvent,
-        ResponseImageGenCallInProgressEvent,
-        ResponseImageGenCallPartialImageEvent,
-        ResponseMcpCallArgumentsDeltaEvent,
-        ResponseMcpCallArgumentsDoneEvent,
-        ResponseMcpCallCompletedEvent,
-        ResponseMcpCallFailedEvent,
-        ResponseMcpCallInProgressEvent,
-        ResponseMcpListToolsCompletedEvent,
-        ResponseMcpListToolsFailedEvent,
-        ResponseMcpListToolsInProgressEvent,
-        ResponseOutputTextAnnotationAddedEvent,
-        ResponseQueuedEvent,
-        ResponseCustomToolCallInputDeltaEvent,
-        ResponseCustomToolCallInputDoneEvent,
+        ResponseAudioWsDelta,
+        ResponseAudioWsDone,
+        ResponseAudioTranscriptWsDelta,
+        ResponseAudioTranscriptWsDone,
+        ResponseCodeInterpreterCallCodeWsDelta,
+        ResponseCodeInterpreterCallCodeWsDone,
+        ResponseCodeInterpreterCallWsCompleted,
+        ResponseCodeInterpreterCallInWsProgress,
+        ResponseCodeInterpreterCallWsInterpreting,
+        ResponseWsCompleted,
+        ResponseContentPartWsAdded,
+        ResponseContentPartWsDone,
+        ResponseWsCreated,
+        ResponseWsError,
+        ResponseFileSearchCallWsCompleted,
+        ResponseFileSearchCallInWsProgress,
+        ResponseFileSearchCallWsSearching,
+        ResponseFunctionCallArgumentsWsDelta,
+        ResponseFunctionCallArgumentsWsDone,
+        ResponseInWsProgress,
+        ResponseWsFailed,
+        ResponseWsIncomplete,
+        ResponseOutputItemWsAdded,
+        ResponseOutputItemWsDone,
+        ResponseReasoningSummaryPartWsAdded,
+        ResponseReasoningSummaryPartWsDone,
+        ResponseReasoningSummaryTextWsDelta,
+        ResponseReasoningSummaryTextWsDone,
+        ResponseReasoningTextWsDelta,
+        ResponseReasoningTextWsDone,
+        ResponseRefusalWsDelta,
+        ResponseRefusalWsDone,
+        ResponseTextWsDelta,
+        ResponseTextWsDone,
+        ResponseWebSearchCallWsCompleted,
+        ResponseWebSearchCallInWsProgress,
+        ResponseWebSearchCallWsSearching,
+        ResponseImageGenCallWsCompleted,
+        ResponseImageGenCallWsGenerating,
+        ResponseImageGenCallInWsProgress,
+        ResponseImageGenCallPartialWsImage,
+        ResponseMcpCallArgumentsWsDelta,
+        ResponseMcpCallArgumentsWsDone,
+        ResponseMcpCallWsCompleted,
+        ResponseMcpCallWsFailed,
+        ResponseMcpCallInWsProgress,
+        ResponseMcpListToolsWsCompleted,
+        ResponseMcpListToolsWsFailed,
+        ResponseMcpListToolsInWsProgress,
+        ResponseOutputTextAnnotationWsAdded,
+        ResponseWsQueued,
+        ResponseCustomToolCallInputWsDelta,
+        ResponseCustomToolCallInputWsDone,
     ],
     PropertyInfo(discriminator="type"),
 ]


### PR DESCRIPTION
## Summary

Adds optional WebSocket-only stream_id routing metadata to Responses client events and all server response events. Events sharing a stream ID are processed FIFO and response events echo that identifier.

Source: https://github.com/openai/openai/pull/1282468
OpenAPI commit: 1e5b3b1f1d21b51c5a37d6122c2b3b2d70ef5a1a

## Validation

- Castiron public-baseline generation and formatter completed
- Python source compilation passed
- Strict generated-diff quality review passed
- No private inputs, workflow files, or internal-repository changes are included