### PR TITLE
docs(api): describe response stream event unions

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 53946e0b-ca32-4724-9f42-4155beea8a67
-openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
-openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
+generation_id: 140ec82b-7058-463f-b12e-530abaf08731
+openapi_spec_hash: 143aa2ed6323d61a1834c74044e29d30
+openapi_transformed_spec_hash: 5af6fa4fd590fcc79ba2fdd69b9f7b82
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: c8ff09541f193ac6671e2b55556913971a35d54c
+codegen_sha: 5a71441f897efa316644a794e608af0c4fed7e18

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54296,6 +54296,7 @@ components:
             "sequence_number": 1
           }
     ResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/ResponseAudioDoneEvent'
@@ -77148,6 +77149,7 @@ components:
               when the originating `response.create` event supplied a
               `stream_id`.
     BetaResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'


### PR DESCRIPTION
## Summary
- Document ResponseStreamEvent and BetaResponseStreamEvent as events emitted while a response is streamed.
- Refresh the generated transformed OpenAPI reference and Castiron generation metadata.
- Source: https://github.com/openai/openai/pull/1277036
- OpenAPI commit: bc61c5299f7f6fdd6061ccad0ac7e4ec0f659098

## Validation
- Castiron local dry run; public promotion matches the generated candidate patch exactly.
- git diff --check and transformed-reference MD5 verified.