### PR TITLE
fix(parse): run the request transform once in parse()

### DIFF
--- a/src/openai/resources/chat/completions/completions.py
+++ b/src/openai/resources/chat/completions/completions.py
@@ -232,7 +232,7 @@ class Completions(SyncAPIResource):
                     "verbosity": verbosity,
                     "web_search_options": web_search_options,
                 },
-                completion_create_params.CompletionCreateParams,
+                completion_create_params.CompletionCreateParamsNonStreaming,
             ),
             options=make_request_options(
                 extra_headers=extra_headers,
@@ -1843,7 +1843,7 @@ class AsyncCompletions(AsyncAPIResource):
                     "verbosity": verbosity,
                     "web_search_options": web_search_options,
                 },
-                completion_create_params.CompletionCreateParams,
+                completion_create_params.CompletionCreateParamsNonStreaming,
             ),
             options=make_request_options(
                 extra_headers=extra_headers,

--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -1385,7 +1385,9 @@ class Responses(SyncAPIResource):
                     "user": user,
                     "verbosity": verbosity,
                 },
-                response_create_params.ResponseCreateParams,
+                response_create_params.ResponseCreateParamsStreaming
+                if stream
+                else response_create_params.ResponseCreateParamsNonStreaming,
             ),
             options=make_request_options(
                 extra_headers=extra_headers,
@@ -3237,7 +3239,9 @@ class AsyncResponses(AsyncAPIResource):
                     "user": user,
                     "verbosity": verbosity,
                 },
-                response_create_params.ResponseCreateParams,
+                response_create_params.ResponseCreateParamsStreaming
+                if stream
+                else response_create_params.ResponseCreateParamsNonStreaming,
             ),
             options=make_request_options(
                 extra_headers=extra_headers,


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

For concurrent usage with large payloads, systems can use a disproportionately long time just in the `_transform_recursive()` method. A more optimal implementation (compile the per-type transform plan once, execute without runtime typing introspection) could speed up performance of transform up to 370x. You would probably want to do that yourself, however, and it might conflict with the migration to Castiron.

There is a tiny, trivial 2x improvement to be had, however:

The hand-written `parse()` helpers pass the `CreateParams` union to the request transform, while the generated `create()` methods dispatch to the concrete `Streaming`/`NonStreaming` type. For union annotations, `_transform_recursive` walks the body once per union member, so `parse()` requests pay exactly 2x the transform cost of `create()` requests (measured 1.99-2.01x).

Pass the concrete params type instead, mirroring `create().`

The transformed body is unchanged, we only skip an unnecessary second walk in `_transform_recursive()`. Output is verified by differential comparison on large bodies for both APIs.

This is the same fix `anthropic-sdk-python` shipped for `Messages.stream()` in v0.122.0 ([12c744c8](https://github.com/anthropics/anthropic-sdk-python/commit/12c744c8), "run the request transform once in messages.stream()").

## Additional context & links
