### PR TITLE
feat(types): define and export ServiceTier string literal (fix #3556)

### DIFF
--- a/src/openai/types/__init__.py
+++ b/src/openai/types/__init__.py
@@ -26,6 +26,7 @@ from .shared import (
     ResponseFormatJSONSchema as ResponseFormatJSONSchema,
     ResponseFormatTextPython as ResponseFormatTextPython,
     ResponseFormatTextGrammar as ResponseFormatTextGrammar,
+    ServiceTier as ServiceTier,
 )
 from .upload import Upload as Upload
 from .embedding import Embedding as Embedding

--- a/src/openai/types/shared/__init__.py
+++ b/src/openai/types/shared/__init__.py
@@ -18,3 +18,4 @@ from .response_format_json_object import ResponseFormatJSONObject as ResponseFor
 from .response_format_json_schema import ResponseFormatJSONSchema as ResponseFormatJSONSchema
 from .response_format_text_python import ResponseFormatTextPython as ResponseFormatTextPython
 from .response_format_text_grammar import ResponseFormatTextGrammar as ResponseFormatTextGrammar
+from .service_tier import ServiceTier as ServiceTier

--- a/src/openai/types/shared/service_tier.py
+++ b/src/openai/types/shared/service_tier.py
@@ -1,0 +1,7 @@
+# File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+from typing_extensions import Literal, TypeAlias
+
+__all__ = ["ServiceTier"]
+
+ServiceTier: TypeAlias = Literal["auto", "default", "flex", "scale", "priority", "fast"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,6 +24,15 @@ from openai._utils import asyncify
 from openai._models import BaseModel, FinalRequestOptions
 from openai._streaming import Stream, AsyncStream
 from openai._exceptions import APIStatusError, APITimeoutError, APIResponseValidationError
+from openai.types import ServiceTier
+
+
+def test_service_tier_export() -> None:
+    tier: ServiceTier = "auto"
+    assert tier == "auto"
+    assert "priority" in ServiceTier.__args__  # type: ignore
+
+
 from openai._base_client import (
     DEFAULT_TIMEOUT,
     HTTPX_DEFAULT_TIMEOUT,


### PR DESCRIPTION
Fixes #3556

## Summary
Define and export `ServiceTier` as a string literal type (`Literal["auto", "default", "flex", "scale", "priority", "fast"]`) under `openai.types` and `openai.types.shared`.

This allows SDK consumers to import `from openai.types import ServiceTier` without hardcoding custom string literal unions that break across SDK updates.

## How was this tested?
- Added unit test in `tests/test_client.py` verifying `ServiceTier` export and type literal values.
