### PR TITLE
feat(auth): add X.509 workload identity federation for HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,56 @@ client = OpenAI(
 )
 ```
 
+#### X.509 workload identity (mutual TLS)
+
+For X.509 workload identity federation, configure the client certificate and
+server trust on an HTTPX2 client, then pass only the identity-provider and
+service-account IDs to the SDK:
+
+```python
+import os
+import ssl
+
+from openai import OpenAI, DefaultHttpx2Client
+from openai.auth import x509_workload_identity
+
+tls_context = ssl.create_default_context(
+    cafile=os.getenv("OPENAI_MTLS_CA_BUNDLE"),
+)
+tls_context.load_cert_chain(
+    certfile=os.environ["OPENAI_MTLS_CERTIFICATE_CHAIN"],
+    keyfile=os.environ["OPENAI_MTLS_PRIVATE_KEY"],
+    password=os.getenv("OPENAI_MTLS_PRIVATE_KEY_PASSWORD"),
+)
+
+client = OpenAI(
+    workload_identity=x509_workload_identity(
+        identity_provider_id=os.environ["OPENAI_IDENTITY_PROVIDER_ID"],
+        service_account_id=os.environ["OPENAI_SERVICE_ACCOUNT_ID"],
+        # refresh_buffer_seconds=120.0,
+    ),
+    http_client=DefaultHttpx2Client(
+        verify=tls_context,
+        follow_redirects=False,
+    ),
+)
+```
+
+X.509 mode defaults to `https://mtls.api.openai.com/v1` when neither `base_url`
+nor `OPENAI_BASE_URL` is set. The same configured HTTP client presents its
+certificate to the fixed mTLS token-exchange endpoint and to the API. Tokens
+are exchanged lazily, cached, and refreshed automatically. Certificate files,
+private keys, passwords, server trust, proxies, and rotation remain application
+and transport concerns.
+
+For asynchronous requests, use `AsyncOpenAI` with
+`DefaultAsyncHttpx2Client`. See the complete [sync rollout-toggle
+example](examples/x509_workload_identity.py) and [async rollout-toggle
+example](examples/x509_workload_identity_async.py), which select API-key or
+X.509 authentication with the application-owned `OPENAI_AUTH_MODE`
+environment variable. X.509 workload identity currently supports HTTP APIs;
+Realtime and WebSockets are not included.
+
 ### Vision
 
 With an image URL:
@@ -950,9 +1000,11 @@ client = AsyncOpenAI(
 See the complete [sync HTTPX2](examples/mtls_httpx2.py) and
 [async HTTPX2](examples/mtls_httpx2_async.py) examples.
 
-The certificate-bearing HTTP client is transport-wide. Dedicate it to the
-selected mTLS origin; do not reuse it for other services or pass it through
-`with_options()` with a different `base_url`. If redirects are required, add an
+The certificate-bearing HTTP client is transport-wide. For API-key mTLS,
+dedicate it to the selected API origin; X.509 workload identity also uses the
+fixed OpenAI mTLS token-exchange origin. Do not reuse the client for unrelated
+services or pass it through `with_options()` with a different `base_url`.
+If redirects are required for API-key mTLS, add an
 HTTPX2 request hook that rejects requests whose scheme, host, or port differs
 from the configured mTLS origin before enabling `follow_redirects`.
 
@@ -969,9 +1021,9 @@ For certificate rotation, build a new `SSLContext`, HTTP client, and `OpenAI` or
 client after its in-flight requests finish. Do not assume existing TLS
 connections will renegotiate.
 
-This recipe applies to ordinary API-key HTTP traffic. It does not implement
-certificate-only X.509 workload identity, token exchange, or Realtime WebSocket
-mTLS.
+This recipe applies to ordinary API-key HTTP traffic. For certificate-backed
+token exchange, use the X.509 workload identity configuration described above.
+Realtime WebSocket mTLS is not included.
 
 ### Managing HTTP resources
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ private keys, passwords, server trust, proxies, and rotation remain application
 and transport concerns.
 
 X.509 API requests require HTTPS and must stay on the configured API origin.
+The effective HTTP Host authority must match that origin.
+Provider API-key and proxy-only headers cannot be sent to the API alongside
+X.509 authentication.
 Token exchanges do not inherit API request hooks, authentication, or cookies.
 Identity settings are captured when the client is constructed; create a new
 client to change the identity. Azure clients do not support X.509 workload

--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ are exchanged lazily, cached, and refreshed automatically. Certificate files,
 private keys, passwords, server trust, proxies, and rotation remain application
 and transport concerns.
 
+X.509 API requests require HTTPS and must stay on the configured API origin.
+Token exchanges do not inherit API request hooks, authentication, or cookies.
+Identity settings are captured when the client is constructed; create a new
+client to change the identity. Azure clients do not support X.509 workload
+identity.
+
 For asynchronous requests, use `AsyncOpenAI` with
 `DefaultAsyncHttpx2Client`. See the complete [sync rollout-toggle
 example](examples/x509_workload_identity.py) and [async rollout-toggle

--- a/examples/x509_workload_identity.py
+++ b/examples/x509_workload_identity.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+import ssl
+
+from openai import OpenAI, DefaultHttpx2Client
+from openai.auth import x509_workload_identity
+
+
+def create_client() -> OpenAI:
+    mode = os.getenv("OPENAI_AUTH_MODE", "api_key")
+    if mode == "api_key":
+        return OpenAI()
+    if mode != "x509":
+        raise ValueError("OPENAI_AUTH_MODE must be 'api_key' or 'x509'")
+
+    tls_context = ssl.create_default_context(cafile=os.getenv("OPENAI_MTLS_CA_BUNDLE"))
+    tls_context.load_cert_chain(
+        certfile=os.environ["OPENAI_MTLS_CERTIFICATE_CHAIN"],
+        keyfile=os.environ["OPENAI_MTLS_PRIVATE_KEY"],
+        password=os.getenv("OPENAI_MTLS_PRIVATE_KEY_PASSWORD"),
+    )
+
+    return OpenAI(
+        workload_identity=x509_workload_identity(
+            identity_provider_id=os.environ["OPENAI_IDENTITY_PROVIDER_ID"],
+            service_account_id=os.environ["OPENAI_SERVICE_ACCOUNT_ID"],
+        ),
+        base_url=os.getenv("OPENAI_BASE_URL"),
+        http_client=DefaultHttpx2Client(verify=tls_context, follow_redirects=False),
+    )
+
+
+def main() -> None:
+    with create_client() as client:
+        response = client.responses.create(model="gpt-5.5", input="Hello!")
+        print(response.output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/x509_workload_identity_async.py
+++ b/examples/x509_workload_identity_async.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+import ssl
+import asyncio
+
+from openai import AsyncOpenAI, DefaultAsyncHttpx2Client
+from openai.auth import x509_workload_identity
+
+
+def create_client() -> AsyncOpenAI:
+    mode = os.getenv("OPENAI_AUTH_MODE", "api_key")
+    if mode == "api_key":
+        return AsyncOpenAI()
+    if mode != "x509":
+        raise ValueError("OPENAI_AUTH_MODE must be 'api_key' or 'x509'")
+
+    tls_context = ssl.create_default_context(cafile=os.getenv("OPENAI_MTLS_CA_BUNDLE"))
+    tls_context.load_cert_chain(
+        certfile=os.environ["OPENAI_MTLS_CERTIFICATE_CHAIN"],
+        keyfile=os.environ["OPENAI_MTLS_PRIVATE_KEY"],
+        password=os.getenv("OPENAI_MTLS_PRIVATE_KEY_PASSWORD"),
+    )
+
+    return AsyncOpenAI(
+        workload_identity=x509_workload_identity(
+            identity_provider_id=os.environ["OPENAI_IDENTITY_PROVIDER_ID"],
+            service_account_id=os.environ["OPENAI_SERVICE_ACCOUNT_ID"],
+        ),
+        base_url=os.getenv("OPENAI_BASE_URL"),
+        http_client=DefaultAsyncHttpx2Client(verify=tls_context, follow_redirects=False),
+    )
+
+
+async def main() -> None:
+    async with create_client() as client:
+        response = await client.responses.create(model="gpt-5.5", input="Hello!")
+        print(response.output_text)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -29,7 +29,7 @@ from ._utils import (
     get_async_library,
 )
 from ._compat import cached_property
-from ._httpx2 import is_httpx2_sync_client, is_httpx2_async_client
+from ._httpx2 import normalize_httpx_url, is_httpx2_sync_client, is_httpx2_async_client
 from ._models import SecurityOptions, FinalRequestOptions
 from ._version import __version__
 from ._provider import _Provider, _provider_name, _ProviderRuntime, _configure_provider
@@ -131,6 +131,16 @@ class OpenAI(SyncAPIClient):
     'http://' or 'https://' scheme. For example: 'http://example.com' becomes
     'wss://example.com'
     """
+
+    @property
+    @override
+    def base_url(self) -> httpx2.URL:
+        return self._base_url
+
+    @base_url.setter
+    def base_url(self, url: httpx2.URL | str) -> None:
+        self._base_url = self._enforce_trailing_slash(normalize_httpx_url(url))
+        self._base_url_was_default = False
 
     def __init__(
         self,
@@ -771,6 +781,16 @@ class AsyncOpenAI(AsyncAPIClient):
     'http://' or 'https://' scheme. For example: 'http://example.com' becomes
     'wss://example.com'
     """
+
+    @property
+    @override
+    def base_url(self) -> httpx2.URL:
+        return self._base_url
+
+    @base_url.setter
+    def base_url(self, url: httpx2.URL | str) -> None:
+        self._base_url = self._enforce_trailing_slash(normalize_httpx_url(url))
+        self._base_url_was_default = False
 
     def __init__(
         self,

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -122,6 +122,7 @@ class OpenAI(SyncAPIClient):
     _workload_identity_auth: WorkloadIdentityAuth | SyncX509WorkloadIdentityAuth | None
     _provider: _Provider | None
     _provider_runtime: _ProviderRuntime | None
+    _base_url_was_default: bool
 
     websocket_base_url: str | httpx2.URL | None
     """Base URL for WebSocket connections.
@@ -267,6 +268,7 @@ class OpenAI(SyncAPIClient):
             base_url = provider_runtime.base_url
         elif base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
+        self._base_url_was_default = provider_runtime is None and base_url is None
         if base_url is None:
             base_url = MTLS_API_BASE_URL if x509_identity is not None else "https://api.openai.com/v1"
 
@@ -657,6 +659,7 @@ class OpenAI(SyncAPIClient):
         http_client = http_client or self._client
 
         next_provider = self._provider if isinstance(provider, NotGiven) else provider
+        preserve_default_base_url = False
         auth_options: dict[str, Any]
         if next_provider is not None:
             auth_options = {
@@ -679,10 +682,9 @@ class OpenAI(SyncAPIClient):
                 next_workload_identity = None
             current_x509 = is_x509_workload_identity(self.workload_identity)
             next_x509 = is_x509_workload_identity(next_workload_identity)
-            current_default_base_url = f"{MTLS_API_BASE_URL}/" if current_x509 else "https://api.openai.com/v1/"
-            inherited_base_url = (
-                None if current_x509 != next_x509 and str(self.base_url) == current_default_base_url else self.base_url
-            )
+            mode_changed = current_x509 != next_x509
+            inherited_base_url = None if mode_changed and self._base_url_was_default else self.base_url
+            preserve_default_base_url = base_url is None and not mode_changed and self._base_url_was_default
             auth_options = {
                 "api_key": api_key
                 if workload_identity is not None
@@ -692,7 +694,7 @@ class OpenAI(SyncAPIClient):
                 "base_url": base_url or inherited_base_url,
             }
 
-        return self.__class__(
+        copied = self.__class__(
             organization=organization or inherited_organization,
             project=project or inherited_project,
             webhook_secret=webhook_secret or self.webhook_secret,
@@ -706,6 +708,9 @@ class OpenAI(SyncAPIClient):
             **auth_options,
             **_extra_kwargs,
         )
+        if preserve_default_base_url:
+            copied._base_url_was_default = True
+        return copied
 
     # Alias for `copy` for nicer inline usage, e.g.
     # client.with_options(timeout=10).foo.create(...)
@@ -757,6 +762,7 @@ class AsyncOpenAI(AsyncAPIClient):
     _workload_identity_auth: WorkloadIdentityAuth | AsyncX509WorkloadIdentityAuth | None
     _provider: _Provider | None
     _provider_runtime: _ProviderRuntime | None
+    _base_url_was_default: bool
 
     websocket_base_url: str | httpx2.URL | None
     """Base URL for WebSocket connections.
@@ -902,6 +908,7 @@ class AsyncOpenAI(AsyncAPIClient):
             base_url = provider_runtime.base_url
         elif base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
+        self._base_url_was_default = provider_runtime is None and base_url is None
         if base_url is None:
             base_url = MTLS_API_BASE_URL if x509_identity is not None else "https://api.openai.com/v1"
 
@@ -1304,6 +1311,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         http_client = http_client or self._client
         next_provider = self._provider if isinstance(provider, NotGiven) else provider
+        preserve_default_base_url = False
         auth_options: dict[str, Any]
         if next_provider is not None:
             auth_options = {
@@ -1326,10 +1334,9 @@ class AsyncOpenAI(AsyncAPIClient):
                 next_workload_identity = None
             current_x509 = is_x509_workload_identity(self.workload_identity)
             next_x509 = is_x509_workload_identity(next_workload_identity)
-            current_default_base_url = f"{MTLS_API_BASE_URL}/" if current_x509 else "https://api.openai.com/v1/"
-            inherited_base_url = (
-                None if current_x509 != next_x509 and str(self.base_url) == current_default_base_url else self.base_url
-            )
+            mode_changed = current_x509 != next_x509
+            inherited_base_url = None if mode_changed and self._base_url_was_default else self.base_url
+            preserve_default_base_url = base_url is None and not mode_changed and self._base_url_was_default
             auth_options = {
                 "api_key": api_key
                 if workload_identity is not None
@@ -1339,7 +1346,7 @@ class AsyncOpenAI(AsyncAPIClient):
                 "base_url": base_url or inherited_base_url,
             }
 
-        return self.__class__(
+        copied = self.__class__(
             organization=organization or inherited_organization,
             project=project or inherited_project,
             webhook_secret=webhook_secret or self.webhook_secret,
@@ -1353,6 +1360,9 @@ class AsyncOpenAI(AsyncAPIClient):
             **auth_options,
             **_extra_kwargs,
         )
+        if preserve_default_base_url:
+            copied._base_url_was_default = True
+        return copied
 
     # Alias for `copy` for nicer inline usage, e.g.
     # client.with_options(timeout=10).foo.create(...)

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -38,6 +38,7 @@ from .auth._x509 import (
     MTLS_API_BASE_URL,
     SyncX509WorkloadIdentityAuth,
     AsyncX509WorkloadIdentityAuth,
+    validate_x509_api_url,
     is_x509_workload_identity,
 )
 from ._exceptions import OpenAIError, APIStatusError
@@ -139,7 +140,10 @@ class OpenAI(SyncAPIClient):
 
     @base_url.setter
     def base_url(self, url: httpx2.URL | str) -> None:
-        self._base_url = self._enforce_trailing_slash(normalize_httpx_url(url))
+        normalized_url = normalize_httpx_url(url)
+        if is_x509_workload_identity(self.workload_identity):
+            validate_x509_api_url(normalized_url)
+        self._base_url = self._enforce_trailing_slash(normalized_url)
         self._base_url_was_default = False
 
     def __init__(
@@ -212,6 +216,8 @@ class OpenAI(SyncAPIClient):
         if api_key is not None and api_key != WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER and workload_identity is not None:
             raise OpenAIError("The `api_key` and `workload_identity` arguments are mutually exclusive")
 
+        if is_x509_workload_identity(workload_identity):
+            workload_identity = workload_identity.copy()
         self.workload_identity = workload_identity if provider_runtime is None else None
 
         if provider_runtime is not None:
@@ -281,6 +287,8 @@ class OpenAI(SyncAPIClient):
         self._base_url_was_default = provider_runtime is None and base_url is None
         if base_url is None:
             base_url = MTLS_API_BASE_URL if x509_identity is not None else "https://api.openai.com/v1"
+        if x509_identity is not None:
+            validate_x509_api_url(base_url)
 
         custom_headers_env = os.environ.get("OPENAI_CUSTOM_HEADERS") if provider_runtime is None else None
         if custom_headers_env is not None:
@@ -304,7 +312,7 @@ class OpenAI(SyncAPIClient):
 
         if x509_identity is not None:
             self._workload_identity_auth = SyncX509WorkloadIdentityAuth(
-                workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
+                workload_identity=x509_identity.copy(), http_client=self._client, max_retries=max_retries
             )
         elif subject_token_identity is not None:
             self._workload_identity_auth = WorkloadIdentityAuth(
@@ -493,17 +501,31 @@ class OpenAI(SyncAPIClient):
     ) -> httpx2.Response:
         used_access_token: str | None = None
         request_is_replayable = False
+        x509_auth = self._workload_identity_auth
 
-        if self._workload_identity_auth is not None:
-            if self._workload_identity_auth._follow_redirects is not None:
-                kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
+        if x509_auth is not None:
+            if isinstance(x509_auth, SyncX509WorkloadIdentityAuth):
+                if x509_auth.workload_identity != self.workload_identity:
+                    raise OpenAIError("X.509 workload identity cannot be changed after client construction")
+                validate_x509_api_url(request.url, expected_origin=self.base_url)
+            if x509_auth._follow_redirects is not None:
+                kwargs["follow_redirects"] = x509_auth._follow_redirects
             authorization = request.headers.get("Authorization")
             if authorization == f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}":
-                used_access_token = self._workload_identity_auth.get_token()
+                used_access_token = x509_auth.get_token()
                 request.headers["Authorization"] = f"Bearer {used_access_token}"
-                request_is_replayable = self._workload_identity_auth._can_retry_request(request)
+                request_is_replayable = x509_auth._can_retry_request(request)
 
-        response = super()._send_request(request, stream=stream, **kwargs)
+        if isinstance(x509_auth, SyncX509WorkloadIdentityAuth):
+            response = x509_auth.send_api_request(
+                request,
+                expected_origin=self.base_url,
+                expected_authorization=f"Bearer {used_access_token}" if used_access_token is not None else None,
+                stream=stream,
+                **kwargs,
+            )
+        else:
+            response = super()._send_request(request, stream=stream, **kwargs)
         if response.status_code != 401 or self._workload_identity_auth is None or used_access_token is None:
             return response
 
@@ -789,7 +811,10 @@ class AsyncOpenAI(AsyncAPIClient):
 
     @base_url.setter
     def base_url(self, url: httpx2.URL | str) -> None:
-        self._base_url = self._enforce_trailing_slash(normalize_httpx_url(url))
+        normalized_url = normalize_httpx_url(url)
+        if is_x509_workload_identity(self.workload_identity):
+            validate_x509_api_url(normalized_url)
+        self._base_url = self._enforce_trailing_slash(normalized_url)
         self._base_url_was_default = False
 
     def __init__(
@@ -862,6 +887,8 @@ class AsyncOpenAI(AsyncAPIClient):
         if api_key is not None and api_key != WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER and workload_identity is not None:
             raise OpenAIError("The `api_key` and `workload_identity` arguments are mutually exclusive")
 
+        if is_x509_workload_identity(workload_identity):
+            workload_identity = workload_identity.copy()
         self.workload_identity = workload_identity if provider_runtime is None else None
 
         if provider_runtime is not None:
@@ -931,6 +958,8 @@ class AsyncOpenAI(AsyncAPIClient):
         self._base_url_was_default = provider_runtime is None and base_url is None
         if base_url is None:
             base_url = MTLS_API_BASE_URL if x509_identity is not None else "https://api.openai.com/v1"
+        if x509_identity is not None:
+            validate_x509_api_url(base_url)
 
         custom_headers_env = os.environ.get("OPENAI_CUSTOM_HEADERS") if provider_runtime is None else None
         if custom_headers_env is not None:
@@ -954,7 +983,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         if x509_identity is not None:
             self._workload_identity_auth = AsyncX509WorkloadIdentityAuth(
-                workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
+                workload_identity=x509_identity.copy(), http_client=self._client, max_retries=max_retries
             )
         elif subject_token_identity is not None:
             self._workload_identity_auth = WorkloadIdentityAuth(
@@ -1143,17 +1172,31 @@ class AsyncOpenAI(AsyncAPIClient):
     ) -> httpx2.Response:
         used_access_token: str | None = None
         request_is_replayable = False
+        x509_auth = self._workload_identity_auth
 
-        if self._workload_identity_auth is not None:
-            if self._workload_identity_auth._follow_redirects is not None:
-                kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
+        if x509_auth is not None:
+            if isinstance(x509_auth, AsyncX509WorkloadIdentityAuth):
+                if x509_auth.workload_identity != self.workload_identity:
+                    raise OpenAIError("X.509 workload identity cannot be changed after client construction")
+                validate_x509_api_url(request.url, expected_origin=self.base_url)
+            if x509_auth._follow_redirects is not None:
+                kwargs["follow_redirects"] = x509_auth._follow_redirects
             authorization = request.headers.get("Authorization")
             if authorization == f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}":
-                used_access_token = await self._workload_identity_auth.get_token_async()
+                used_access_token = await x509_auth.get_token_async()
                 request.headers["Authorization"] = f"Bearer {used_access_token}"
-                request_is_replayable = self._workload_identity_auth._can_retry_request(request)
+                request_is_replayable = x509_auth._can_retry_request(request)
 
-        response = await super()._send_request(request, stream=stream, **kwargs)
+        if isinstance(x509_auth, AsyncX509WorkloadIdentityAuth):
+            response = await x509_auth.send_api_request(
+                request,
+                expected_origin=self.base_url,
+                expected_authorization=f"Bearer {used_access_token}" if used_access_token is not None else None,
+                stream=stream,
+                **kwargs,
+            )
+        else:
+            response = await super()._send_request(request, stream=stream, **kwargs)
         if response.status_code != 401 or self._workload_identity_auth is None or used_access_token is None:
             return response
 

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -674,17 +674,21 @@ class OpenAI(SyncAPIClient):
                 "base_url": base_url,
             }
         else:
+            next_workload_identity = workload_identity if workload_identity is not None else self.workload_identity
+            if api_key is not None and workload_identity is None:
+                next_workload_identity = None
+            current_x509 = is_x509_workload_identity(self.workload_identity)
+            next_x509 = is_x509_workload_identity(next_workload_identity)
+            current_default_base_url = f"{MTLS_API_BASE_URL}/" if current_x509 else "https://api.openai.com/v1/"
             inherited_base_url = (
-                None
-                if is_x509_workload_identity(workload_identity) and str(self.base_url) == "https://api.openai.com/v1/"
-                else self.base_url
+                None if current_x509 != next_x509 and str(self.base_url) == current_default_base_url else self.base_url
             )
             auth_options = {
                 "api_key": api_key
                 if workload_identity is not None
                 else api_key or self._api_key_provider or self.api_key,
                 "admin_api_key": admin_api_key or self.admin_api_key,
-                "workload_identity": workload_identity or self.workload_identity,
+                "workload_identity": next_workload_identity,
                 "base_url": base_url or inherited_base_url,
             }
 
@@ -1317,17 +1321,21 @@ class AsyncOpenAI(AsyncAPIClient):
                 "base_url": base_url,
             }
         else:
+            next_workload_identity = workload_identity if workload_identity is not None else self.workload_identity
+            if api_key is not None and workload_identity is None:
+                next_workload_identity = None
+            current_x509 = is_x509_workload_identity(self.workload_identity)
+            next_x509 = is_x509_workload_identity(next_workload_identity)
+            current_default_base_url = f"{MTLS_API_BASE_URL}/" if current_x509 else "https://api.openai.com/v1/"
             inherited_base_url = (
-                None
-                if is_x509_workload_identity(workload_identity) and str(self.base_url) == "https://api.openai.com/v1/"
-                else self.base_url
+                None if current_x509 != next_x509 and str(self.base_url) == current_default_base_url else self.base_url
             )
             auth_options = {
                 "api_key": api_key
                 if workload_identity is not None
                 else api_key or self._api_key_provider or self.api_key,
                 "admin_api_key": admin_api_key or self.admin_api_key,
-                "workload_identity": workload_identity or self.workload_identity,
+                "workload_identity": next_workload_identity,
                 "base_url": base_url or inherited_base_url,
             }
 

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -10,7 +10,7 @@ import httpx2
 
 from . import _exceptions
 from ._qs import Querystring
-from .auth import WorkloadIdentity, WorkloadIdentityAuth
+from .auth import WorkloadIdentity, WorkloadIdentityAuth, X509WorkloadIdentity
 from ._types import (
     Omit,
     Headers,
@@ -115,7 +115,7 @@ class OpenAI(SyncAPIClient):
     # client options
     api_key: str
     admin_api_key: str | None
-    workload_identity: WorkloadIdentity | None
+    workload_identity: WorkloadIdentity | X509WorkloadIdentity | None
     organization: str | None
     project: str | None
     webhook_secret: str | None
@@ -136,7 +136,7 @@ class OpenAI(SyncAPIClient):
         *,
         api_key: str | Callable[[], str] | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -252,7 +252,14 @@ class OpenAI(SyncAPIClient):
 
         self.websocket_base_url = websocket_base_url
 
-        x509_identity = workload_identity if is_x509_workload_identity(workload_identity) else None
+        if is_x509_workload_identity(workload_identity):
+            x509_identity = workload_identity
+            subject_token_identity = None
+        else:
+            x509_identity = None
+            subject_token_identity = (
+                workload_identity if workload_identity is not None and "provider" in workload_identity else None
+            )
         if provider_runtime is not None:
             base_url = provider_runtime.base_url
         elif base_url is None:
@@ -280,16 +287,15 @@ class OpenAI(SyncAPIClient):
             _strict_response_validation=_strict_response_validation,
         )
 
-        if workload_identity is not None:
-            if x509_identity is not None:
-                self._workload_identity_auth = SyncX509WorkloadIdentityAuth(
-                    workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
-                )
-            else:
-                self._workload_identity_auth = WorkloadIdentityAuth(
-                    workload_identity=workload_identity,
-                    _use_httpx2=is_httpx2_sync_client(self._client),
-                )
+        if x509_identity is not None:
+            self._workload_identity_auth = SyncX509WorkloadIdentityAuth(
+                workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
+            )
+        elif subject_token_identity is not None:
+            self._workload_identity_auth = WorkloadIdentityAuth(
+                workload_identity=subject_token_identity,
+                _use_httpx2=is_httpx2_sync_client(self._client),
+            )
 
         self._default_stream_cls = Stream
 
@@ -470,29 +476,29 @@ class OpenAI(SyncAPIClient):
         retried: bool = False,
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
-        used_workload_identity_auth = False
+        used_access_token: str | None = None
         request_is_replayable = False
 
         if self._workload_identity_auth is not None:
+            if self._workload_identity_auth._follow_redirects is not None:
+                kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
             authorization = request.headers.get("Authorization")
             if authorization == f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}":
-                request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
-                used_workload_identity_auth = True
+                used_access_token = self._workload_identity_auth.get_token()
+                request.headers["Authorization"] = f"Bearer {used_access_token}"
                 request_is_replayable = self._workload_identity_auth._can_retry_request(request)
-                if self._workload_identity_auth._follow_redirects is not None:
-                    kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
 
         response = super()._send_request(request, stream=stream, **kwargs)
         if (
             response.status_code == 401
             and self._workload_identity_auth is not None
-            and used_workload_identity_auth
+            and used_access_token is not None
             and not retried
             and request_is_replayable
         ):
             response.close()
             self._workload_identity_auth._prepare_retry_request(request)
-            self._workload_identity_auth.invalidate_token()
+            self._workload_identity_auth.invalidate_token(used_access_token)
             request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
             return self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
 
@@ -733,7 +739,7 @@ class AsyncOpenAI(AsyncAPIClient):
     # client options
     api_key: str
     admin_api_key: str | None
-    workload_identity: WorkloadIdentity | None
+    workload_identity: WorkloadIdentity | X509WorkloadIdentity | None
     organization: str | None
     project: str | None
     webhook_secret: str | None
@@ -754,7 +760,7 @@ class AsyncOpenAI(AsyncAPIClient):
         *,
         api_key: str | Callable[[], Awaitable[str]] | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         organization: str | None = None,
         project: str | None = None,
         webhook_secret: str | None = None,
@@ -870,7 +876,14 @@ class AsyncOpenAI(AsyncAPIClient):
 
         self.websocket_base_url = websocket_base_url
 
-        x509_identity = workload_identity if is_x509_workload_identity(workload_identity) else None
+        if is_x509_workload_identity(workload_identity):
+            x509_identity = workload_identity
+            subject_token_identity = None
+        else:
+            x509_identity = None
+            subject_token_identity = (
+                workload_identity if workload_identity is not None and "provider" in workload_identity else None
+            )
         if provider_runtime is not None:
             base_url = provider_runtime.base_url
         elif base_url is None:
@@ -898,16 +911,15 @@ class AsyncOpenAI(AsyncAPIClient):
             _strict_response_validation=_strict_response_validation,
         )
 
-        if workload_identity is not None:
-            if x509_identity is not None:
-                self._workload_identity_auth = AsyncX509WorkloadIdentityAuth(
-                    workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
-                )
-            else:
-                self._workload_identity_auth = WorkloadIdentityAuth(
-                    workload_identity=workload_identity,
-                    _use_httpx2=is_httpx2_async_client(self._client),
-                )
+        if x509_identity is not None:
+            self._workload_identity_auth = AsyncX509WorkloadIdentityAuth(
+                workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
+            )
+        elif subject_token_identity is not None:
+            self._workload_identity_auth = WorkloadIdentityAuth(
+                workload_identity=subject_token_identity,
+                _use_httpx2=is_httpx2_async_client(self._client),
+            )
 
         self._default_stream_cls = AsyncStream
 
@@ -1088,29 +1100,29 @@ class AsyncOpenAI(AsyncAPIClient):
         retried: bool = False,
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
-        used_workload_identity_auth = False
+        used_access_token: str | None = None
         request_is_replayable = False
 
         if self._workload_identity_auth is not None:
+            if self._workload_identity_auth._follow_redirects is not None:
+                kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
             authorization = request.headers.get("Authorization")
             if authorization == f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}":
-                request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
-                used_workload_identity_auth = True
+                used_access_token = await self._workload_identity_auth.get_token_async()
+                request.headers["Authorization"] = f"Bearer {used_access_token}"
                 request_is_replayable = self._workload_identity_auth._can_retry_request(request)
-                if self._workload_identity_auth._follow_redirects is not None:
-                    kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
 
         response = await super()._send_request(request, stream=stream, **kwargs)
         if (
             response.status_code == 401
             and self._workload_identity_auth is not None
-            and used_workload_identity_auth
+            and used_access_token is not None
             and not retried
             and request_is_replayable
         ):
             await response.aclose()
             self._workload_identity_auth._prepare_retry_request(request)
-            self._workload_identity_auth.invalidate_token()
+            self._workload_identity_auth.invalidate_token(used_access_token)
             request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
             return await self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
 

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -255,11 +255,14 @@ class OpenAI(SyncAPIClient):
         if is_x509_workload_identity(workload_identity):
             x509_identity = workload_identity
             subject_token_identity = None
-        else:
+        elif workload_identity is None:
             x509_identity = None
-            subject_token_identity = (
-                workload_identity if workload_identity is not None and "provider" in workload_identity else None
-            )
+            subject_token_identity = None
+        elif "provider" in workload_identity:
+            x509_identity = None
+            subject_token_identity = workload_identity
+        else:
+            raise OpenAIError("Invalid `workload_identity` configuration: expected an X.509 or subject-token identity")
         if provider_runtime is not None:
             base_url = provider_runtime.base_url
         elif base_url is None:
@@ -498,7 +501,7 @@ class OpenAI(SyncAPIClient):
 
         response.close()
         self._workload_identity_auth._prepare_retry_request(request)
-        request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
+        request.headers["Authorization"] = f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}"
         return self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
 
     @override
@@ -876,11 +879,14 @@ class AsyncOpenAI(AsyncAPIClient):
         if is_x509_workload_identity(workload_identity):
             x509_identity = workload_identity
             subject_token_identity = None
-        else:
+        elif workload_identity is None:
             x509_identity = None
-            subject_token_identity = (
-                workload_identity if workload_identity is not None and "provider" in workload_identity else None
-            )
+            subject_token_identity = None
+        elif "provider" in workload_identity:
+            x509_identity = None
+            subject_token_identity = workload_identity
+        else:
+            raise OpenAIError("Invalid `workload_identity` configuration: expected an X.509 or subject-token identity")
         if provider_runtime is not None:
             base_url = provider_runtime.base_url
         elif base_url is None:
@@ -1119,7 +1125,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         await response.aclose()
         self._workload_identity_auth._prepare_retry_request(request)
-        request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
+        request.headers["Authorization"] = f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}"
         return await self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
 
     @override

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -40,6 +40,8 @@ from .auth._x509 import (
     AsyncX509WorkloadIdentityAuth,
     validate_x509_api_url,
     is_x509_workload_identity,
+    validate_x509_api_credentials,
+    validate_x509_request_authority,
 )
 from ._exceptions import OpenAIError, APIStatusError
 from ._base_client import (
@@ -508,6 +510,8 @@ class OpenAI(SyncAPIClient):
                 if x509_auth.workload_identity != self.workload_identity:
                     raise OpenAIError("X.509 workload identity cannot be changed after client construction")
                 validate_x509_api_url(request.url, expected_origin=self.base_url)
+                validate_x509_request_authority(request)
+                validate_x509_api_credentials(request)
             if x509_auth._follow_redirects is not None:
                 kwargs["follow_redirects"] = x509_auth._follow_redirects
             authorization = request.headers.get("Authorization")
@@ -520,7 +524,7 @@ class OpenAI(SyncAPIClient):
             response = x509_auth.send_api_request(
                 request,
                 expected_origin=self.base_url,
-                expected_authorization=f"Bearer {used_access_token}" if used_access_token is not None else None,
+                expected_authorization=request.headers.get("Authorization"),
                 stream=stream,
                 **kwargs,
             )
@@ -1179,6 +1183,8 @@ class AsyncOpenAI(AsyncAPIClient):
                 if x509_auth.workload_identity != self.workload_identity:
                     raise OpenAIError("X.509 workload identity cannot be changed after client construction")
                 validate_x509_api_url(request.url, expected_origin=self.base_url)
+                validate_x509_request_authority(request)
+                validate_x509_api_credentials(request)
             if x509_auth._follow_redirects is not None:
                 kwargs["follow_redirects"] = x509_auth._follow_redirects
             authorization = request.headers.get("Authorization")
@@ -1191,7 +1197,7 @@ class AsyncOpenAI(AsyncAPIClient):
             response = await x509_auth.send_api_request(
                 request,
                 expected_origin=self.base_url,
-                expected_authorization=f"Bearer {used_access_token}" if used_access_token is not None else None,
+                expected_authorization=request.headers.get("Authorization"),
                 stream=stream,
                 **kwargs,
             )

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -596,7 +596,7 @@ class OpenAI(SyncAPIClient):
 
     @override
     def _custom_auth(self, security: SecurityOptions) -> httpx2.Auth | None:
-        if self._provider_runtime is not None:
+        if self._provider_runtime is not None or isinstance(self._workload_identity_auth, SyncX509WorkloadIdentityAuth):
             return httpx2.Auth()
 
         return super()._custom_auth(security)
@@ -674,11 +674,18 @@ class OpenAI(SyncAPIClient):
                 "base_url": base_url,
             }
         else:
+            inherited_base_url = (
+                None
+                if is_x509_workload_identity(workload_identity) and str(self.base_url) == "https://api.openai.com/v1/"
+                else self.base_url
+            )
             auth_options = {
-                "api_key": api_key or self._api_key_provider or self.api_key,
+                "api_key": api_key
+                if workload_identity is not None
+                else api_key or self._api_key_provider or self.api_key,
                 "admin_api_key": admin_api_key or self.admin_api_key,
                 "workload_identity": workload_identity or self.workload_identity,
-                "base_url": base_url or self.base_url,
+                "base_url": base_url or inherited_base_url,
             }
 
         return self.__class__(
@@ -1231,7 +1238,9 @@ class AsyncOpenAI(AsyncAPIClient):
     @property
     @override
     def custom_auth(self) -> httpx2.Auth | None:
-        if self._provider_runtime is not None:
+        if self._provider_runtime is not None or isinstance(
+            self._workload_identity_auth, AsyncX509WorkloadIdentityAuth
+        ):
             return httpx2.Auth()
 
         return super().custom_auth
@@ -1308,11 +1317,18 @@ class AsyncOpenAI(AsyncAPIClient):
                 "base_url": base_url,
             }
         else:
+            inherited_base_url = (
+                None
+                if is_x509_workload_identity(workload_identity) and str(self.base_url) == "https://api.openai.com/v1/"
+                else self.base_url
+            )
             auth_options = {
-                "api_key": api_key or self._api_key_provider or self.api_key,
+                "api_key": api_key
+                if workload_identity is not None
+                else api_key or self._api_key_provider or self.api_key,
                 "admin_api_key": admin_api_key or self.admin_api_key,
                 "workload_identity": workload_identity or self.workload_identity,
-                "base_url": base_url or self.base_url,
+                "base_url": base_url or inherited_base_url,
             }
 
         return self.__class__(

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -34,6 +34,12 @@ from ._models import SecurityOptions, FinalRequestOptions
 from ._version import __version__
 from ._provider import _Provider, _provider_name, _ProviderRuntime, _configure_provider
 from ._streaming import Stream as Stream, AsyncStream as AsyncStream
+from .auth._x509 import (
+    MTLS_API_BASE_URL,
+    SyncX509WorkloadIdentityAuth,
+    AsyncX509WorkloadIdentityAuth,
+    is_x509_workload_identity,
+)
 from ._exceptions import OpenAIError, APIStatusError
 from ._base_client import (
     DEFAULT_MAX_RETRIES,
@@ -246,12 +252,13 @@ class OpenAI(SyncAPIClient):
 
         self.websocket_base_url = websocket_base_url
 
+        x509_identity = workload_identity if is_x509_workload_identity(workload_identity) else None
         if provider_runtime is not None:
             base_url = provider_runtime.base_url
         elif base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
         if base_url is None:
-            base_url = f"https://api.openai.com/v1"
+            base_url = MTLS_API_BASE_URL if x509_identity is not None else "https://api.openai.com/v1"
 
         custom_headers_env = os.environ.get("OPENAI_CUSTOM_HEADERS") if provider_runtime is None else None
         if custom_headers_env is not None:
@@ -274,10 +281,15 @@ class OpenAI(SyncAPIClient):
         )
 
         if workload_identity is not None:
-            self._workload_identity_auth = WorkloadIdentityAuth(
-                workload_identity=workload_identity,
-                _use_httpx2=is_httpx2_sync_client(self._client),
-            )
+            if x509_identity is not None:
+                self._workload_identity_auth = SyncX509WorkloadIdentityAuth(
+                    workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
+                )
+            else:
+                self._workload_identity_auth = WorkloadIdentityAuth(
+                    workload_identity=workload_identity,
+                    _use_httpx2=is_httpx2_sync_client(self._client),
+                )
 
         self._default_stream_cls = Stream
 
@@ -459,12 +471,16 @@ class OpenAI(SyncAPIClient):
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
         used_workload_identity_auth = False
+        request_is_replayable = False
 
         if self._workload_identity_auth is not None:
             authorization = request.headers.get("Authorization")
             if authorization == f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}":
                 request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
                 used_workload_identity_auth = True
+                request_is_replayable = self._workload_identity_auth._can_retry_request(request)
+                if self._workload_identity_auth._follow_redirects is not None:
+                    kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
 
         response = super()._send_request(request, stream=stream, **kwargs)
         if (
@@ -472,8 +488,10 @@ class OpenAI(SyncAPIClient):
             and self._workload_identity_auth is not None
             and used_workload_identity_auth
             and not retried
+            and request_is_replayable
         ):
             response.close()
+            self._workload_identity_auth._prepare_retry_request(request)
             self._workload_identity_auth.invalidate_token()
             request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
             return self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
@@ -852,12 +870,13 @@ class AsyncOpenAI(AsyncAPIClient):
 
         self.websocket_base_url = websocket_base_url
 
+        x509_identity = workload_identity if is_x509_workload_identity(workload_identity) else None
         if provider_runtime is not None:
             base_url = provider_runtime.base_url
         elif base_url is None:
             base_url = os.environ.get("OPENAI_BASE_URL")
         if base_url is None:
-            base_url = f"https://api.openai.com/v1"
+            base_url = MTLS_API_BASE_URL if x509_identity is not None else "https://api.openai.com/v1"
 
         custom_headers_env = os.environ.get("OPENAI_CUSTOM_HEADERS") if provider_runtime is None else None
         if custom_headers_env is not None:
@@ -880,10 +899,15 @@ class AsyncOpenAI(AsyncAPIClient):
         )
 
         if workload_identity is not None:
-            self._workload_identity_auth = WorkloadIdentityAuth(
-                workload_identity=workload_identity,
-                _use_httpx2=is_httpx2_async_client(self._client),
-            )
+            if x509_identity is not None:
+                self._workload_identity_auth = AsyncX509WorkloadIdentityAuth(
+                    workload_identity=x509_identity, http_client=self._client, max_retries=max_retries
+                )
+            else:
+                self._workload_identity_auth = WorkloadIdentityAuth(
+                    workload_identity=workload_identity,
+                    _use_httpx2=is_httpx2_async_client(self._client),
+                )
 
         self._default_stream_cls = AsyncStream
 
@@ -1065,12 +1089,16 @@ class AsyncOpenAI(AsyncAPIClient):
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
         used_workload_identity_auth = False
+        request_is_replayable = False
 
         if self._workload_identity_auth is not None:
             authorization = request.headers.get("Authorization")
             if authorization == f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}":
                 request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
                 used_workload_identity_auth = True
+                request_is_replayable = self._workload_identity_auth._can_retry_request(request)
+                if self._workload_identity_auth._follow_redirects is not None:
+                    kwargs["follow_redirects"] = self._workload_identity_auth._follow_redirects
 
         response = await super()._send_request(request, stream=stream, **kwargs)
         if (
@@ -1078,8 +1106,10 @@ class AsyncOpenAI(AsyncAPIClient):
             and self._workload_identity_auth is not None
             and used_workload_identity_auth
             and not retried
+            and request_is_replayable
         ):
             await response.aclose()
+            self._workload_identity_auth._prepare_retry_request(request)
             self._workload_identity_auth.invalidate_token()
             request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
             return await self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -489,20 +489,17 @@ class OpenAI(SyncAPIClient):
                 request_is_replayable = self._workload_identity_auth._can_retry_request(request)
 
         response = super()._send_request(request, stream=stream, **kwargs)
-        if (
-            response.status_code == 401
-            and self._workload_identity_auth is not None
-            and used_access_token is not None
-            and not retried
-            and request_is_replayable
-        ):
-            response.close()
-            self._workload_identity_auth._prepare_retry_request(request)
-            self._workload_identity_auth.invalidate_token(used_access_token)
-            request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
-            return self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
+        if response.status_code != 401 or self._workload_identity_auth is None or used_access_token is None:
+            return response
 
-        return response
+        self._workload_identity_auth.invalidate_token(used_access_token)
+        if retried or not request_is_replayable:
+            return response
+
+        response.close()
+        self._workload_identity_auth._prepare_retry_request(request)
+        request.headers["Authorization"] = f"Bearer {self._workload_identity_auth.get_token()}"
+        return self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
 
     @override
     def _send_request(
@@ -612,7 +609,7 @@ class OpenAI(SyncAPIClient):
         *,
         api_key: str | Callable[[], str] | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         provider: _Provider | None | NotGiven = not_given,
         organization: str | None = None,
         project: str | None = None,
@@ -1113,20 +1110,17 @@ class AsyncOpenAI(AsyncAPIClient):
                 request_is_replayable = self._workload_identity_auth._can_retry_request(request)
 
         response = await super()._send_request(request, stream=stream, **kwargs)
-        if (
-            response.status_code == 401
-            and self._workload_identity_auth is not None
-            and used_access_token is not None
-            and not retried
-            and request_is_replayable
-        ):
-            await response.aclose()
-            self._workload_identity_auth._prepare_retry_request(request)
-            self._workload_identity_auth.invalidate_token(used_access_token)
-            request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
-            return await self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
+        if response.status_code != 401 or self._workload_identity_auth is None or used_access_token is None:
+            return response
 
-        return response
+        self._workload_identity_auth.invalidate_token(used_access_token)
+        if retried or not request_is_replayable:
+            return response
+
+        await response.aclose()
+        self._workload_identity_auth._prepare_retry_request(request)
+        request.headers["Authorization"] = f"Bearer {await self._workload_identity_auth.get_token_async()}"
+        return await self._send_with_auth_retry(request, stream=stream, retried=True, **kwargs)
 
     @override
     async def _send_request(
@@ -1247,7 +1241,7 @@ class AsyncOpenAI(AsyncAPIClient):
         *,
         api_key: str | Callable[[], Awaitable[str]] | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         provider: _Provider | None | NotGiven = not_given,
         organization: str | None = None,
         project: str | None = None,

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -119,7 +119,7 @@ class OpenAI(SyncAPIClient):
     organization: str | None
     project: str | None
     webhook_secret: str | None
-    _workload_identity_auth: WorkloadIdentityAuth | None
+    _workload_identity_auth: WorkloadIdentityAuth | SyncX509WorkloadIdentityAuth | None
     _provider: _Provider | None
     _provider_runtime: _ProviderRuntime | None
 
@@ -743,7 +743,7 @@ class AsyncOpenAI(AsyncAPIClient):
     organization: str | None
     project: str | None
     webhook_secret: str | None
-    _workload_identity_auth: WorkloadIdentityAuth | None
+    _workload_identity_auth: WorkloadIdentityAuth | AsyncX509WorkloadIdentityAuth | None
     _provider: _Provider | None
     _provider_runtime: _ProviderRuntime | None
 

--- a/src/openai/auth/__init__.py
+++ b/src/openai/auth/__init__.py
@@ -4,7 +4,10 @@ from ._workload import (
     WorkloadIdentity as WorkloadIdentity,
     SubjectTokenProvider as SubjectTokenProvider,
     WorkloadIdentityAuth as WorkloadIdentityAuth,
+    X509WorkloadIdentity as X509WorkloadIdentity,
+    SubjectTokenWorkloadIdentity as SubjectTokenWorkloadIdentity,
     gcp_id_token_provider as gcp_id_token_provider,
+    x509_workload_identity as x509_workload_identity,
     k8s_service_account_token_provider as k8s_service_account_token_provider,
     azure_managed_identity_token_provider as azure_managed_identity_token_provider,
 )
@@ -12,7 +15,10 @@ from ._workload import (
 __all__ = [
     "SubjectTokenProvider",
     "WorkloadIdentity",
+    "SubjectTokenWorkloadIdentity",
+    "X509WorkloadIdentity",
     "WorkloadIdentityAuth",
+    "x509_workload_identity",
     "k8s_service_account_token_provider",
     "azure_managed_identity_token_provider",
     "gcp_id_token_provider",

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -8,6 +8,7 @@ from typing_extensions import Literal, TypeAlias, NotRequired
 
 import httpx2
 
+from .._utils import is_dict
 from .._httpx2 import DefaultHttpx2Client, _loaded_legacy_httpx
 from .._exceptions import OAuthError, OpenAIError, SubjectTokenProviderError
 from .._utils._sync import to_thread
@@ -27,7 +28,7 @@ class SubjectTokenProvider(TypedDict):
     get_token: Callable[[], str]
 
 
-class SubjectTokenWorkloadIdentity(TypedDict):
+class WorkloadIdentity(TypedDict):
     """Identity provider resource id in WIFAPI."""
 
     identity_provider_id: str
@@ -42,6 +43,9 @@ class SubjectTokenWorkloadIdentity(TypedDict):
     refresh_buffer_seconds: NotRequired[float]
 
 
+SubjectTokenWorkloadIdentity: TypeAlias = WorkloadIdentity
+
+
 class X509WorkloadIdentity(TypedDict):
     """Authenticate with the client certificate configured on the HTTP transport."""
 
@@ -49,9 +53,6 @@ class X509WorkloadIdentity(TypedDict):
     identity_provider_id: str
     service_account_id: str
     refresh_buffer_seconds: NotRequired[float]
-
-
-WorkloadIdentity: TypeAlias = SubjectTokenWorkloadIdentity | X509WorkloadIdentity
 
 
 def x509_workload_identity(
@@ -208,9 +209,22 @@ class WorkloadIdentityAuth:
         token_exchange_url: str = DEFAULT_TOKEN_EXCHANGE_URL,
         _use_httpx2: bool = True,
     ):
+        self._initialize_token_cache(
+            workload_identity=workload_identity,
+            token_exchange_url=token_exchange_url,
+            use_httpx2=_use_httpx2,
+        )
+
+    def _initialize_token_cache(
+        self,
+        *,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity,
+        token_exchange_url: str,
+        use_httpx2: bool = True,
+    ) -> None:
         self.workload_identity = workload_identity
         self.token_exchange_url = token_exchange_url
-        self._use_httpx2 = _use_httpx2
+        self._use_httpx2 = use_httpx2
         self._follow_redirects: bool | None = None
 
         self._cached_token: str | None = None
@@ -252,8 +266,10 @@ class WorkloadIdentityAuth:
     async def get_token_async(self) -> str:
         return await to_thread(self.get_token)
 
-    def invalidate_token(self) -> None:
+    def invalidate_token(self, token: str | None = None) -> None:
         with self._lock:
+            if token is not None and self._cached_token != token:
+                return
             self._cached_token = None
             self._cached_token_expires_at_monotonic = None
             self._cached_token_refresh_at_monotonic = None
@@ -312,6 +328,8 @@ class WorkloadIdentityAuth:
         if response.is_success:
             if body is None:
                 raise OpenAIError("Token exchange succeeded but response body was empty")
+            if not is_dict(body):
+                raise OpenAIError("Token exchange succeeded but response body was not a JSON object")
             access_token = body.get("access_token")
             expires_in = body.get("expires_in")
             if not isinstance(access_token, str) or not access_token:

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -4,7 +4,7 @@ import time
 import threading
 from typing import Any, Callable, TypedDict, cast
 from pathlib import Path
-from typing_extensions import Literal, NotRequired
+from typing_extensions import Literal, TypeAlias, NotRequired
 
 import httpx2
 
@@ -27,7 +27,7 @@ class SubjectTokenProvider(TypedDict):
     get_token: Callable[[], str]
 
 
-class WorkloadIdentity(TypedDict):
+class SubjectTokenWorkloadIdentity(TypedDict):
     """Identity provider resource id in WIFAPI."""
 
     identity_provider_id: str
@@ -40,6 +40,35 @@ class WorkloadIdentity(TypedDict):
 
     """Optional buffer time in seconds to refresh the OpenAI token before it expires. Defaults to 1200 seconds (20 minutes)."""
     refresh_buffer_seconds: NotRequired[float]
+
+
+class X509WorkloadIdentity(TypedDict):
+    """Authenticate with the client certificate configured on the HTTP transport."""
+
+    type: Literal["x509"]
+    identity_provider_id: str
+    service_account_id: str
+    refresh_buffer_seconds: NotRequired[float]
+
+
+WorkloadIdentity: TypeAlias = SubjectTokenWorkloadIdentity | X509WorkloadIdentity
+
+
+def x509_workload_identity(
+    *,
+    identity_provider_id: str,
+    service_account_id: str,
+    refresh_buffer_seconds: float | None = None,
+) -> X509WorkloadIdentity:
+    """Configure X.509 workload identity without handling certificate material."""
+    identity: X509WorkloadIdentity = {
+        "type": "x509",
+        "identity_provider_id": identity_provider_id,
+        "service_account_id": service_account_id,
+    }
+    if refresh_buffer_seconds is not None:
+        identity["refresh_buffer_seconds"] = refresh_buffer_seconds
+    return identity
 
 
 def k8s_service_account_token_provider(
@@ -182,6 +211,7 @@ class WorkloadIdentityAuth:
         self.workload_identity = workload_identity
         self.token_exchange_url = token_exchange_url
         self._use_httpx2 = _use_httpx2
+        self._follow_redirects: bool | None = None
 
         self._cached_token: str | None = None
         self._cached_token_expires_at_monotonic: float | None = None
@@ -230,6 +260,9 @@ class WorkloadIdentityAuth:
 
     def _perform_refresh(self) -> None:
         token_data = self._fetch_token_from_exchange()
+        self._store_token(token_data)
+
+    def _store_token(self, token_data: dict[str, Any]) -> None:
         now = time.monotonic()
         expires_in = token_data["expires_in"]
 
@@ -241,7 +274,8 @@ class WorkloadIdentityAuth:
     def _fetch_token_from_exchange(self) -> dict[str, Any]:
         subject_token = self._get_subject_token()
 
-        token_type = self.workload_identity["provider"]["token_type"]
+        identity = cast(SubjectTokenWorkloadIdentity, self.workload_identity)
+        token_type = identity["provider"]["token_type"]
         subject_token_type = SUBJECT_TOKEN_TYPES.get(token_type)
         if subject_token_type is None:
             raise OpenAIError(
@@ -282,16 +316,19 @@ class WorkloadIdentityAuth:
             expires_in = body.get("expires_in")
             if not isinstance(access_token, str) or not access_token:
                 raise OpenAIError("Token exchange response did not include a valid access_token")
-            if not isinstance(expires_in, (int, float)):
-                raise OpenAIError("Token exchange response did not include a valid expires_in")
-            return {"access_token": access_token, "expires_in": float(expires_in)}
+            return {"access_token": access_token, "expires_in": self._validate_expires_in(expires_in)}
 
         raise OpenAIError(
             f"Token exchange failed with status {response.status_code}",
         )
 
+    def _validate_expires_in(self, expires_in: object) -> float:
+        if not isinstance(expires_in, (int, float)):
+            raise OpenAIError("Token exchange response did not include a valid expires_in")
+        return float(expires_in)
+
     def _get_subject_token(self) -> str:
-        provider = self.workload_identity["provider"]
+        provider = cast(SubjectTokenWorkloadIdentity, self.workload_identity)["provider"]
         subject_token = provider["get_token"]()
         if not subject_token:
             raise OpenAIError("The workload identity provider returned an empty subject token")
@@ -314,3 +351,12 @@ class WorkloadIdentityAuth:
         configured_buffer = self.workload_identity.get("refresh_buffer_seconds", DEFAULT_REFRESH_BUFFER_SECONDS)
         effective_buffer = min(configured_buffer, expires_in / 2)
         return max(expires_in - effective_buffer, 0.0)
+
+    def _can_retry_request(self, request: httpx2.Request) -> bool:
+        """Preserve the established subject-token request retry behavior."""
+        del request
+        return True
+
+    def _prepare_retry_request(self, request: httpx2.Request) -> None:
+        """Preserve the established subject-token request retry behavior."""
+        del request

--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import time
 import threading
-from typing import Any, Callable, TypedDict, cast
+from typing import Any, Generic, TypeVar, Callable, TypedDict, cast
 from pathlib import Path
-from typing_extensions import Literal, TypeAlias, NotRequired
+from typing_extensions import Literal, TypeAlias, NotRequired, override
 
 import httpx2
 
@@ -53,6 +53,9 @@ class X509WorkloadIdentity(TypedDict):
     identity_provider_id: str
     service_account_id: str
     refresh_buffer_seconds: NotRequired[float]
+
+
+_WorkloadIdentityT = TypeVar("_WorkloadIdentityT", WorkloadIdentity, X509WorkloadIdentity)
 
 
 def x509_workload_identity(
@@ -201,30 +204,17 @@ def gcp_id_token_provider(
     return {"token_type": "id", "get_token": get_token}
 
 
-class WorkloadIdentityAuth:
+class _WorkloadIdentityAuth(Generic[_WorkloadIdentityT]):
     def __init__(
         self,
         *,
-        workload_identity: WorkloadIdentity,
+        workload_identity: _WorkloadIdentityT,
         token_exchange_url: str = DEFAULT_TOKEN_EXCHANGE_URL,
         _use_httpx2: bool = True,
-    ):
-        self._initialize_token_cache(
-            workload_identity=workload_identity,
-            token_exchange_url=token_exchange_url,
-            use_httpx2=_use_httpx2,
-        )
-
-    def _initialize_token_cache(
-        self,
-        *,
-        workload_identity: WorkloadIdentity | X509WorkloadIdentity,
-        token_exchange_url: str,
-        use_httpx2: bool = True,
     ) -> None:
-        self.workload_identity = workload_identity
+        self.workload_identity: _WorkloadIdentityT = workload_identity
         self.token_exchange_url = token_exchange_url
-        self._use_httpx2 = use_httpx2
+        self._use_httpx2 = _use_httpx2
         self._follow_redirects: bool | None = None
 
         self._cached_token: str | None = None
@@ -288,33 +278,7 @@ class WorkloadIdentityAuth:
             self._cached_token_refresh_at_monotonic = now + self._refresh_delay_seconds(expires_in)
 
     def _fetch_token_from_exchange(self) -> dict[str, Any]:
-        subject_token = self._get_subject_token()
-
-        identity = cast(SubjectTokenWorkloadIdentity, self.workload_identity)
-        token_type = identity["provider"]["token_type"]
-        subject_token_type = SUBJECT_TOKEN_TYPES.get(token_type)
-        if subject_token_type is None:
-            raise OpenAIError(
-                f"Unsupported token type: {token_type!r}. Supported types: {', '.join(SUBJECT_TOKEN_TYPES.keys())}"
-            )
-
-        legacy_httpx = _loaded_legacy_httpx() if not self._use_httpx2 else None
-        exchange_client = (
-            legacy_httpx.Client() if legacy_httpx is not None else DefaultHttpx2Client(follow_redirects=False)
-        )
-        with exchange_client as client:
-            response = client.post(
-                self.token_exchange_url,
-                json={
-                    "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
-                    "subject_token": subject_token,
-                    "subject_token_type": subject_token_type,
-                    "identity_provider_id": self.workload_identity["identity_provider_id"],
-                    "service_account_id": self.workload_identity["service_account_id"],
-                },
-                timeout=10.0,
-            )
-            return self._handle_token_response(response)
+        raise NotImplementedError("Workload identity authentication must implement token exchange")
 
     def _handle_token_response(self, response: httpx2.Response) -> dict[str, Any]:
         try:
@@ -345,13 +309,6 @@ class WorkloadIdentityAuth:
             raise OpenAIError("Token exchange response did not include a valid expires_in")
         return float(expires_in)
 
-    def _get_subject_token(self) -> str:
-        provider = cast(SubjectTokenWorkloadIdentity, self.workload_identity)["provider"]
-        subject_token = provider["get_token"]()
-        if not subject_token:
-            raise OpenAIError("The workload identity provider returned an empty subject token")
-        return subject_token
-
     def _token_unusable(self) -> bool:
         return self._cached_token is None or self._token_expired()
 
@@ -378,3 +335,53 @@ class WorkloadIdentityAuth:
     def _prepare_retry_request(self, request: httpx2.Request) -> None:
         """Preserve the established subject-token request retry behavior."""
         del request
+
+
+class WorkloadIdentityAuth(_WorkloadIdentityAuth[WorkloadIdentity]):
+    def __init__(
+        self,
+        *,
+        workload_identity: WorkloadIdentity,
+        token_exchange_url: str = DEFAULT_TOKEN_EXCHANGE_URL,
+        _use_httpx2: bool = True,
+    ) -> None:
+        super().__init__(
+            workload_identity=workload_identity,
+            token_exchange_url=token_exchange_url,
+            _use_httpx2=_use_httpx2,
+        )
+
+    @override
+    def _fetch_token_from_exchange(self) -> dict[str, Any]:
+        subject_token = self._get_subject_token()
+        token_type = self.workload_identity["provider"]["token_type"]
+        subject_token_type = SUBJECT_TOKEN_TYPES.get(token_type)
+        if subject_token_type is None:
+            raise OpenAIError(
+                f"Unsupported token type: {token_type!r}. Supported types: {', '.join(SUBJECT_TOKEN_TYPES.keys())}"
+            )
+
+        legacy_httpx = _loaded_legacy_httpx() if not self._use_httpx2 else None
+        exchange_client = (
+            legacy_httpx.Client() if legacy_httpx is not None else DefaultHttpx2Client(follow_redirects=False)
+        )
+        with exchange_client as client:
+            response = client.post(
+                self.token_exchange_url,
+                json={
+                    "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
+                    "subject_token": subject_token,
+                    "subject_token_type": subject_token_type,
+                    "identity_provider_id": self.workload_identity["identity_provider_id"],
+                    "service_account_id": self.workload_identity["service_account_id"],
+                },
+                timeout=10.0,
+            )
+            return self._handle_token_response(response)
+
+    def _get_subject_token(self) -> str:
+        provider = self.workload_identity["provider"]
+        subject_token = provider["get_token"]()
+        if not subject_token:
+            raise OpenAIError("The workload identity provider returned an empty subject token")
+        return subject_token

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -14,8 +14,8 @@ from .._httpx2 import timeout_exceptions, _loaded_legacy_httpx
 from ._workload import (
     TOKEN_EXCHANGE_GRANT_TYPE,
     WorkloadIdentity,
-    WorkloadIdentityAuth,
     X509WorkloadIdentity,
+    _WorkloadIdentityAuth,
 )
 from .._constants import MAX_RETRY_DELAY, INITIAL_RETRY_DELAY, MAX_RETRY_AFTER_DELAY
 from .._exceptions import OAuthError, OpenAIError, APITimeoutError, APIConnectionError
@@ -130,10 +130,10 @@ def _raise_transport_error(error: Exception) -> NoReturn:
     raise APIConnectionError(request=request) from error
 
 
-class _X509WorkloadIdentityAuth(WorkloadIdentityAuth):
+class _X509WorkloadIdentityAuth(_WorkloadIdentityAuth[X509WorkloadIdentity]):
     def __init__(self, *, workload_identity: X509WorkloadIdentity, max_retries: int) -> None:
         _validate_identity(workload_identity)
-        self._initialize_token_cache(workload_identity=workload_identity, token_exchange_url=_X509_TOKEN_EXCHANGE_URL)
+        super().__init__(workload_identity=workload_identity, token_exchange_url=_X509_TOKEN_EXCHANGE_URL)
         self._max_exchange_retries = min(max(max_retries, 0), _MAX_EXCHANGE_RETRIES)
         self._follow_redirects = False
 
@@ -183,12 +183,11 @@ class SyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
 
     @override
     def _fetch_token_from_exchange(self) -> dict[str, Any]:
-        identity = cast(X509WorkloadIdentity, self.workload_identity)
         for attempt in range(self._max_exchange_retries + 1):
             try:
                 response = self._http_client.post(
                     _X509_TOKEN_EXCHANGE_URL,
-                    json=_exchange_payload(identity),
+                    json=_exchange_payload(self.workload_identity),
                     timeout=10.0,
                     follow_redirects=False,
                 )
@@ -228,12 +227,11 @@ class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
                 return cast(str, self._cached_token)
 
     async def _fetch_token_from_exchange_async(self) -> dict[str, Any]:
-        identity = cast(X509WorkloadIdentity, self.workload_identity)
         for attempt in range(self._max_exchange_retries + 1):
             try:
                 response = await self._http_client.post(
                     _X509_TOKEN_EXCHANGE_URL,
-                    json=_exchange_payload(identity),
+                    json=_exchange_payload(self.workload_identity),
                     timeout=10.0,
                     follow_redirects=False,
                 )

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import math
 import time
 import email.utils
@@ -27,6 +28,7 @@ _MAX_EXCHANGE_RETRIES = 2
 _REPLAY_POSITION_EXTENSION = "openai_x509_replay_position"
 _REPLAY_FILE_POSITIONS_EXTENSION = "openai_x509_replay_file_positions"
 _ALLOWED_IDENTITY_FIELDS = {"type", "identity_provider_id", "service_account_id", "refresh_buffer_seconds"}
+_BEARER_ACCESS_TOKEN = re.compile(r"[A-Za-z0-9._~+/-]+=*")
 
 
 def validate_x509_api_url(url: httpx2.URL | str, *, expected_origin: httpx2.URL | None = None) -> None:
@@ -44,6 +46,39 @@ def validate_x509_api_url(url: httpx2.URL | str, *, expected_origin: httpx2.URL 
         raise OpenAIError("X.509 workload identity requests must use the configured API origin")
 
 
+def validate_x509_api_credentials(request: httpx2.Request) -> None:
+    if any(
+        header.lower().replace("_", "-") in ("api-key", "x-api-key", "proxy-authorization")
+        for header in request.headers
+    ):
+        raise OpenAIError("X.509 workload identity requests cannot include API-key or proxy credentials")
+
+
+def validate_x509_request_authority(request: httpx2.Request) -> None:
+    host_headers = request.headers.get_list("host")
+    if (
+        len(host_headers) != 1
+        or any(delimiter in host_headers[0] for delimiter in "/?#@\\")
+        or any(header.startswith(":") for header in request.headers)
+    ):
+        raise OpenAIError("X.509 workload identity requests require exactly one valid Host authority")
+
+    try:
+        host_url = httpx2.URL(f"https://{host_headers[0]}")
+    except httpx2.InvalidURL as error:
+        raise OpenAIError("X.509 workload identity requests require a valid Host authority") from error
+
+    if (
+        host_url.username
+        or host_url.password
+        or host_url.path != "/"
+        or host_url.query
+        or host_url.fragment
+        or (host_url.host, host_url.port) != (request.url.host, request.url.port)
+    ):
+        raise OpenAIError("X.509 workload identity Host authority must match the request URL")
+
+
 def _validate_transport_request(
     request: httpx2.Request,
     *,
@@ -52,17 +87,21 @@ def _validate_transport_request(
     token_exchange: bool,
 ) -> None:
     validate_x509_api_url(request.url, expected_origin=expected_origin)
+    validate_x509_request_authority(request)
 
     if token_exchange:
         if str(request.url) != _X509_TOKEN_EXCHANGE_URL:
             raise OpenAIError("X.509 token exchange requests must use the pinned authentication URL")
         if any(
-            header in request.headers
-            for header in ("authorization", "proxy-authorization", "cookie", "x-api-key", "api-key")
+            header.lower().replace("_", "-")
+            in ("authorization", "proxy-authorization", "cookie", "x-api-key", "api-key")
+            for header in request.headers
         ):
             raise OpenAIError("X.509 token exchange requests cannot include API credentials")
-    elif expected_authorization is not None and request.headers.get("Authorization") != expected_authorization:
-        raise OpenAIError("X.509 workload identity authorization cannot be changed by HTTP request hooks")
+    else:
+        validate_x509_api_credentials(request)
+        if request.headers.get("Authorization") != expected_authorization:
+            raise OpenAIError("X.509 workload identity authorization cannot be changed by HTTP request hooks")
 
 
 class _SyncX509ForwardingTransport(httpx2.BaseTransport):
@@ -330,7 +369,14 @@ class _X509WorkloadIdentityAuth(_WorkloadIdentityAuth[X509WorkloadIdentity]):
     @override
     def _handle_token_response(self, response: httpx2.Response) -> dict[str, Any]:
         if response.status_code not in (400, 401, 403):
-            return super()._handle_token_response(response)
+            token_data = super()._handle_token_response(response)
+            response_body = response.json()
+            token_type = response_body.get("token_type")
+            if "token_type" in response_body and (not isinstance(token_type, str) or token_type.lower() != "bearer"):
+                raise OpenAIError("X.509 token exchange response must use the Bearer token type")
+            if _BEARER_ACCESS_TOKEN.fullmatch(token_data["access_token"]) is None:
+                raise OpenAIError("X.509 token exchange response did not include a valid Bearer access_token")
+            return token_data
 
         try:
             response_body = response.json() if response.content else None

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -4,7 +4,7 @@ import math
 import time
 import email.utils
 from typing import Any, NoReturn, cast
-from typing_extensions import TypeGuard, override
+from typing_extensions import TypeIs, override
 
 import anyio
 import httpx2
@@ -28,7 +28,9 @@ _REPLAY_POSITION_EXTENSION = "openai_x509_replay_position"
 _ALLOWED_IDENTITY_FIELDS = {"type", "identity_provider_id", "service_account_id", "refresh_buffer_seconds"}
 
 
-def is_x509_workload_identity(identity: WorkloadIdentity | None) -> TypeGuard[X509WorkloadIdentity]:
+def is_x509_workload_identity(
+    identity: WorkloadIdentity | X509WorkloadIdentity | None,
+) -> TypeIs[X509WorkloadIdentity]:
     return identity is not None and identity.get("type") == "x509"
 
 
@@ -131,7 +133,7 @@ def _raise_transport_error(error: Exception) -> NoReturn:
 class _X509WorkloadIdentityAuth(WorkloadIdentityAuth):
     def __init__(self, *, workload_identity: X509WorkloadIdentity, max_retries: int) -> None:
         _validate_identity(workload_identity)
-        super().__init__(workload_identity=workload_identity, token_exchange_url=_X509_TOKEN_EXCHANGE_URL)
+        self._initialize_token_cache(workload_identity=workload_identity, token_exchange_url=_X509_TOKEN_EXCHANGE_URL)
         self._max_exchange_retries = min(max(max_retries, 0), _MAX_EXCHANGE_RETRIES)
         self._follow_redirects = False
 

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -29,6 +29,16 @@ _REPLAY_FILE_POSITIONS_EXTENSION = "openai_x509_replay_file_positions"
 _ALLOWED_IDENTITY_FIELDS = {"type", "identity_provider_id", "service_account_id", "refresh_buffer_seconds"}
 
 
+def _as_finite_float(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        value = float(value)
+    except OverflowError:
+        return None
+    return value if math.isfinite(value) else None
+
+
 def is_x509_workload_identity(
     identity: WorkloadIdentity | X509WorkloadIdentity | None,
 ) -> TypeIs[X509WorkloadIdentity]:
@@ -46,13 +56,10 @@ def _validate_identity(identity: X509WorkloadIdentity) -> None:
         raise OpenAIError("X.509 workload identity requires identity-provider and service-account IDs")
 
     refresh_buffer = cast(object, identity.get("refresh_buffer_seconds"))
-    if refresh_buffer is not None and (
-        isinstance(refresh_buffer, bool)
-        or not isinstance(refresh_buffer, (int, float))
-        or not math.isfinite(refresh_buffer)
-        or refresh_buffer < 0
-    ):
-        raise OpenAIError("X.509 workload identity requires a finite, non-negative refresh buffer")
+    if refresh_buffer is not None:
+        refresh_buffer_value = _as_finite_float(refresh_buffer)
+        if refresh_buffer_value is None or refresh_buffer_value < 0:
+            raise OpenAIError("X.509 workload identity requires a finite, non-negative refresh buffer")
 
 
 def _exchange_payload(identity: X509WorkloadIdentity) -> dict[str, str]:
@@ -167,11 +174,10 @@ class _X509WorkloadIdentityAuth(_WorkloadIdentityAuth[X509WorkloadIdentity]):
 
     @override
     def _validate_expires_in(self, expires_in: object) -> float:
-        if isinstance(expires_in, bool) or not isinstance(expires_in, (int, float)):
+        expires_in_value = _as_finite_float(expires_in)
+        if expires_in_value is None or expires_in_value <= 0:
             raise OpenAIError("X.509 token exchange response did not include a positive, finite expires_in")
-        if not math.isfinite(expires_in) or expires_in <= 0:
-            raise OpenAIError("X.509 token exchange response did not include a positive, finite expires_in")
-        return float(expires_in)
+        return expires_in_value
 
     @override
     def _can_retry_request(self, request: httpx2.Request) -> bool:

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import math
+import time
+import email.utils
+from typing import Any, NoReturn, cast
+from typing_extensions import TypeGuard, override
+
+import anyio
+import httpx2
+
+from .._utils import is_dict
+from .._httpx2 import timeout_exceptions, _loaded_legacy_httpx
+from ._workload import (
+    TOKEN_EXCHANGE_GRANT_TYPE,
+    WorkloadIdentity,
+    WorkloadIdentityAuth,
+    X509WorkloadIdentity,
+)
+from .._constants import MAX_RETRY_DELAY, INITIAL_RETRY_DELAY, MAX_RETRY_AFTER_DELAY
+from .._exceptions import OAuthError, OpenAIError, APITimeoutError, APIConnectionError
+
+MTLS_API_BASE_URL = "https://mtls.api.openai.com/v1"
+_X509_TOKEN_EXCHANGE_URL = "https://mtls.auth.openai.com/oauth/token"
+_X509_SUBJECT_TOKEN_TYPE = "urn:openai:params:oauth:token-type:x509"
+_MAX_EXCHANGE_RETRIES = 2
+_REPLAY_POSITION_EXTENSION = "openai_x509_replay_position"
+_ALLOWED_IDENTITY_FIELDS = {"type", "identity_provider_id", "service_account_id", "refresh_buffer_seconds"}
+
+
+def is_x509_workload_identity(identity: WorkloadIdentity | None) -> TypeGuard[X509WorkloadIdentity]:
+    return identity is not None and identity.get("type") == "x509"
+
+
+def _validate_identity(identity: X509WorkloadIdentity) -> None:
+    if "provider" in identity or "client_id" in identity:
+        raise OpenAIError("X.509 workload identity does not accept a subject-token provider or client ID")
+
+    if set(identity) - _ALLOWED_IDENTITY_FIELDS:
+        raise OpenAIError("X.509 workload identity accepts only identity IDs and an optional refresh buffer")
+
+    if not identity["identity_provider_id"] or not identity["service_account_id"]:
+        raise OpenAIError("X.509 workload identity requires identity-provider and service-account IDs")
+
+    refresh_buffer = cast(object, identity.get("refresh_buffer_seconds"))
+    if refresh_buffer is not None and (
+        isinstance(refresh_buffer, bool)
+        or not isinstance(refresh_buffer, (int, float))
+        or not math.isfinite(refresh_buffer)
+        or refresh_buffer < 0
+    ):
+        raise OpenAIError("X.509 workload identity requires a finite, non-negative refresh buffer")
+
+
+def _exchange_payload(identity: X509WorkloadIdentity) -> dict[str, str]:
+    return {
+        "grant_type": TOKEN_EXCHANGE_GRANT_TYPE,
+        "subject_token_type": _X509_SUBJECT_TOKEN_TYPE,
+        "identity_provider_id": identity["identity_provider_id"],
+        "service_account_id": identity["service_account_id"],
+    }
+
+
+def _retry_delay(response: httpx2.Response | None, attempt: int) -> float | None:
+    if response is not None:
+        if response.status_code not in (408, 409, 429) and response.status_code < 500:
+            return None
+
+        retry_after = response.headers.get("retry-after")
+        if retry_after is not None:
+            try:
+                delay = float(retry_after)
+            except ValueError:
+                try:
+                    parsed = email.utils.parsedate_tz(retry_after)
+                    delay = float(email.utils.mktime_tz(parsed) - time.time()) if parsed is not None else -1
+                except (OverflowError, OSError, ValueError):
+                    delay = -1
+
+            if math.isfinite(delay) and 0 <= delay <= MAX_RETRY_AFTER_DELAY:
+                return delay
+            if delay > MAX_RETRY_AFTER_DELAY:
+                return None
+
+    return float(min(INITIAL_RETRY_DELAY * 2**attempt, MAX_RETRY_DELAY))
+
+
+def _is_replayable_request(request: httpx2.Request) -> bool:
+    if isinstance(getattr(request, "_content", None), bytes):
+        return True
+
+    stream = request.stream
+    fields = getattr(stream, "fields", None)
+    if isinstance(fields, list):
+        for field in cast(list[object], fields):
+            file = getattr(field, "file", None)
+            if file is None or isinstance(file, (str, bytes)):
+                continue
+            seekable = getattr(file, "seekable", None)
+            if not callable(seekable) or not seekable():
+                return False
+        return True
+
+    source = getattr(stream, "_stream", stream)
+    seekable = getattr(source, "seekable", None)
+    seek = getattr(source, "seek", None)
+    tell = getattr(source, "tell", None)
+    if not callable(seekable) or not seekable() or not callable(seek) or not callable(tell):
+        return False
+    request.extensions[_REPLAY_POSITION_EXTENSION] = tell()
+    return True
+
+
+def _transport_errors() -> tuple[type[Exception], ...]:
+    legacy_httpx = _loaded_legacy_httpx()
+    if legacy_httpx is None:
+        return (httpx2.TransportError,)
+    legacy_transport_error = cast(type[Exception], getattr(legacy_httpx, "TransportError", httpx2.TransportError))
+    return (httpx2.TransportError, legacy_transport_error)
+
+
+def _raise_transport_error(error: Exception) -> NoReturn:
+    request = cast(httpx2.Request | None, getattr(error, "request", None))
+    if request is None:
+        raise OpenAIError("X.509 token exchange connection failed") from error
+    if isinstance(error, timeout_exceptions()):
+        raise APITimeoutError(request=request) from error
+    raise APIConnectionError(request=request) from error
+
+
+class _X509WorkloadIdentityAuth(WorkloadIdentityAuth):
+    def __init__(self, *, workload_identity: X509WorkloadIdentity, max_retries: int) -> None:
+        _validate_identity(workload_identity)
+        super().__init__(workload_identity=workload_identity, token_exchange_url=_X509_TOKEN_EXCHANGE_URL)
+        self._max_exchange_retries = min(max(max_retries, 0), _MAX_EXCHANGE_RETRIES)
+        self._follow_redirects = False
+
+    @override
+    def _handle_token_response(self, response: httpx2.Response) -> dict[str, Any]:
+        if response.status_code not in (400, 401, 403):
+            return super()._handle_token_response(response)
+
+        try:
+            response_body = response.json() if response.content else None
+        except ValueError:
+            response_body = None
+
+        oauth_error = response_body.get("error") if is_dict(response_body) else None
+        safe_body = {"error": oauth_error} if isinstance(oauth_error, str) else None
+        raise OAuthError(response=response, body=safe_body)
+
+    @override
+    def _validate_expires_in(self, expires_in: object) -> float:
+        if isinstance(expires_in, bool) or not isinstance(expires_in, (int, float)):
+            raise OpenAIError("X.509 token exchange response did not include a positive, finite expires_in")
+        if not math.isfinite(expires_in) or expires_in <= 0:
+            raise OpenAIError("X.509 token exchange response did not include a positive, finite expires_in")
+        return float(expires_in)
+
+    @override
+    def _can_retry_request(self, request: httpx2.Request) -> bool:
+        return _is_replayable_request(request)
+
+    @override
+    def _prepare_retry_request(self, request: httpx2.Request) -> None:
+        position = request.extensions.get(_REPLAY_POSITION_EXTENSION)
+        if not isinstance(position, int):
+            return
+        source = getattr(request.stream, "_stream", request.stream)
+        seek = getattr(source, "seek", None)
+        if callable(seek):
+            seek(position)
+
+
+class SyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
+    def __init__(
+        self, *, workload_identity: X509WorkloadIdentity, http_client: httpx2.Client, max_retries: int
+    ) -> None:
+        super().__init__(workload_identity=workload_identity, max_retries=max_retries)
+        self._http_client = http_client
+
+    @override
+    def _fetch_token_from_exchange(self) -> dict[str, Any]:
+        identity = cast(X509WorkloadIdentity, self.workload_identity)
+        for attempt in range(self._max_exchange_retries + 1):
+            try:
+                response = self._http_client.post(
+                    _X509_TOKEN_EXCHANGE_URL,
+                    json=_exchange_payload(identity),
+                    timeout=10.0,
+                    follow_redirects=False,
+                )
+            except _transport_errors() as error:
+                if attempt >= self._max_exchange_retries:
+                    _raise_transport_error(error)
+                delay = _retry_delay(None, attempt)
+            else:
+                delay = _retry_delay(response, attempt)
+                if attempt >= self._max_exchange_retries or delay is None:
+                    return self._handle_token_response(response)
+
+            if delay is not None:
+                time.sleep(delay)
+
+        raise AssertionError("X.509 token exchange retry loop exhausted unexpectedly")
+
+
+class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
+    def __init__(
+        self, *, workload_identity: X509WorkloadIdentity, http_client: httpx2.AsyncClient, max_retries: int
+    ) -> None:
+        super().__init__(workload_identity=workload_identity, max_retries=max_retries)
+        self._http_client = http_client
+        self._async_lock = anyio.Lock()
+
+    @override
+    async def get_token_async(self) -> str:
+        async with self._async_lock:
+            with self._lock:
+                if not self._token_unusable() and not self._needs_refresh():
+                    return cast(str, self._cached_token)
+
+            token_data = await self._fetch_token_from_exchange_async()
+            self._store_token(token_data)
+            with self._lock:
+                return cast(str, self._cached_token)
+
+    async def _fetch_token_from_exchange_async(self) -> dict[str, Any]:
+        identity = cast(X509WorkloadIdentity, self.workload_identity)
+        for attempt in range(self._max_exchange_retries + 1):
+            try:
+                response = await self._http_client.post(
+                    _X509_TOKEN_EXCHANGE_URL,
+                    json=_exchange_payload(identity),
+                    timeout=10.0,
+                    follow_redirects=False,
+                )
+            except _transport_errors() as error:
+                if attempt >= self._max_exchange_retries:
+                    _raise_transport_error(error)
+                delay = _retry_delay(None, attempt)
+            else:
+                delay = _retry_delay(response, attempt)
+                if attempt >= self._max_exchange_retries or delay is None:
+                    return self._handle_token_response(response)
+
+            if delay is not None:
+                await anyio.sleep(delay)
+
+        raise AssertionError("X.509 token exchange retry loop exhausted unexpectedly")

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -41,7 +41,7 @@ def _validate_identity(identity: X509WorkloadIdentity) -> None:
     if set(identity) - _ALLOWED_IDENTITY_FIELDS:
         raise OpenAIError("X.509 workload identity accepts only identity IDs and an optional refresh buffer")
 
-    if not identity["identity_provider_id"] or not identity["service_account_id"]:
+    if not identity.get("identity_provider_id") or not identity.get("service_account_id"):
         raise OpenAIError("X.509 workload identity requires identity-provider and service-account IDs")
 
     refresh_buffer = cast(object, identity.get("refresh_buffer_seconds"))
@@ -188,6 +188,7 @@ class SyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
                 response = self._http_client.post(
                     _X509_TOKEN_EXCHANGE_URL,
                     json=_exchange_payload(self.workload_identity),
+                    auth=lambda request: request,
                     timeout=10.0,
                     follow_redirects=False,
                 )
@@ -232,6 +233,7 @@ class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
                 response = await self._http_client.post(
                     _X509_TOKEN_EXCHANGE_URL,
                     json=_exchange_payload(self.workload_identity),
+                    auth=lambda request: request,
                     timeout=10.0,
                     follow_redirects=False,
                 )

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -64,6 +64,11 @@ def _exchange_payload(identity: X509WorkloadIdentity) -> dict[str, str]:
     }
 
 
+def _strip_authorization(request: httpx2.Request) -> httpx2.Request:
+    request.headers.pop("Authorization", None)
+    return request
+
+
 def _retry_delay(response: httpx2.Response | None, attempt: int) -> float | None:
     if response is not None:
         if response.status_code not in (408, 409, 429) and response.status_code < 500:
@@ -205,7 +210,7 @@ class SyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
                 response = self._http_client.post(
                     _X509_TOKEN_EXCHANGE_URL,
                     json=_exchange_payload(self.workload_identity),
-                    auth=lambda request: request,
+                    auth=_strip_authorization,
                     timeout=10.0,
                     follow_redirects=False,
                 )
@@ -250,7 +255,7 @@ class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
                 response = await self._http_client.post(
                     _X509_TOKEN_EXCHANGE_URL,
                     json=_exchange_payload(self.workload_identity),
-                    auth=lambda request: request,
+                    auth=_strip_authorization,
                     timeout=10.0,
                     follow_redirects=False,
                 )

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -71,9 +71,13 @@ def _exchange_payload(identity: X509WorkloadIdentity) -> dict[str, str]:
     }
 
 
-def _strip_authorization(request: httpx2.Request) -> httpx2.Request:
-    request.headers.pop("Authorization", None)
-    return request
+def _token_exchange_request(identity: X509WorkloadIdentity) -> httpx2.Request:
+    return httpx2.Request(
+        "POST",
+        _X509_TOKEN_EXCHANGE_URL,
+        json=_exchange_payload(identity),
+        extensions={"timeout": httpx2.Timeout(10.0).as_dict()},
+    )
 
 
 def _retry_delay(response: httpx2.Response | None, attempt: int) -> float | None:
@@ -213,11 +217,9 @@ class SyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
     def _fetch_token_from_exchange(self) -> dict[str, Any]:
         for attempt in range(self._max_exchange_retries + 1):
             try:
-                response = self._http_client.post(
-                    _X509_TOKEN_EXCHANGE_URL,
-                    json=_exchange_payload(self.workload_identity),
-                    auth=_strip_authorization,
-                    timeout=10.0,
+                response = self._http_client.send(
+                    _token_exchange_request(self.workload_identity),
+                    auth=None,
                     follow_redirects=False,
                 )
             except _transport_errors() as error:
@@ -258,11 +260,9 @@ class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
     async def _fetch_token_from_exchange_async(self) -> dict[str, Any]:
         for attempt in range(self._max_exchange_retries + 1):
             try:
-                response = await self._http_client.post(
-                    _X509_TOKEN_EXCHANGE_URL,
-                    json=_exchange_payload(self.workload_identity),
-                    auth=_strip_authorization,
-                    timeout=10.0,
+                response = await self._http_client.send(
+                    _token_exchange_request(self.workload_identity),
+                    auth=None,
                     follow_redirects=False,
                 )
             except _transport_errors() as error:

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -10,7 +10,7 @@ import anyio
 import httpx2
 
 from .._utils import is_dict
-from .._httpx2 import timeout_exceptions, _loaded_legacy_httpx
+from .._httpx2 import timeout_exceptions, normalize_httpx_url, _loaded_legacy_httpx
 from ._workload import (
     TOKEN_EXCHANGE_GRANT_TYPE,
     WorkloadIdentity,
@@ -27,6 +27,162 @@ _MAX_EXCHANGE_RETRIES = 2
 _REPLAY_POSITION_EXTENSION = "openai_x509_replay_position"
 _REPLAY_FILE_POSITIONS_EXTENSION = "openai_x509_replay_file_positions"
 _ALLOWED_IDENTITY_FIELDS = {"type", "identity_provider_id", "service_account_id", "refresh_buffer_seconds"}
+
+
+def validate_x509_api_url(url: httpx2.URL | str, *, expected_origin: httpx2.URL | None = None) -> None:
+    normalized_url = normalize_httpx_url(url)
+    if normalized_url.scheme != "https" or not normalized_url.host:
+        raise OpenAIError("X.509 workload identity requires an absolute HTTPS API URL")
+
+    if normalized_url.username or normalized_url.password:
+        raise OpenAIError("X.509 workload identity API URLs cannot contain user credentials")
+
+    if expected_origin is not None and (normalized_url.host, normalized_url.port) != (
+        expected_origin.host,
+        expected_origin.port,
+    ):
+        raise OpenAIError("X.509 workload identity requests must use the configured API origin")
+
+
+def _validate_transport_request(
+    request: httpx2.Request,
+    *,
+    expected_origin: httpx2.URL,
+    expected_authorization: str | None,
+    token_exchange: bool,
+) -> None:
+    validate_x509_api_url(request.url, expected_origin=expected_origin)
+
+    if token_exchange:
+        if str(request.url) != _X509_TOKEN_EXCHANGE_URL:
+            raise OpenAIError("X.509 token exchange requests must use the pinned authentication URL")
+        if any(
+            header in request.headers
+            for header in ("authorization", "proxy-authorization", "cookie", "x-api-key", "api-key")
+        ):
+            raise OpenAIError("X.509 token exchange requests cannot include API credentials")
+    elif expected_authorization is not None and request.headers.get("Authorization") != expected_authorization:
+        raise OpenAIError("X.509 workload identity authorization cannot be changed by HTTP request hooks")
+
+
+class _SyncX509ForwardingTransport(httpx2.BaseTransport):
+    def __init__(
+        self,
+        *,
+        http_client: httpx2.Client,
+        expected_origin: httpx2.URL,
+        expected_authorization: str | None,
+        token_exchange: bool,
+    ) -> None:
+        self._http_client = http_client
+        self._expected_origin = expected_origin
+        self._expected_authorization = expected_authorization
+        self._token_exchange = token_exchange
+
+    @override
+    def handle_request(self, request: httpx2.Request) -> httpx2.Response:
+        _validate_transport_request(
+            request,
+            expected_origin=self._expected_origin,
+            expected_authorization=self._expected_authorization,
+            token_exchange=self._token_exchange,
+        )
+        if self._http_client.is_closed:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+        return self._http_client._transport_for_url(request.url).handle_request(request)
+
+    @override
+    def close(self) -> None:
+        # The caller owns the selected connection pool and proxy transports.
+        return None
+
+
+class _AsyncX509ForwardingTransport(httpx2.AsyncBaseTransport):
+    def __init__(
+        self,
+        *,
+        http_client: httpx2.AsyncClient,
+        expected_origin: httpx2.URL,
+        expected_authorization: str | None,
+        token_exchange: bool,
+    ) -> None:
+        self._http_client = http_client
+        self._expected_origin = expected_origin
+        self._expected_authorization = expected_authorization
+        self._token_exchange = token_exchange
+
+    @override
+    async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+        _validate_transport_request(
+            request,
+            expected_origin=self._expected_origin,
+            expected_authorization=self._expected_authorization,
+            token_exchange=self._token_exchange,
+        )
+        if self._http_client.is_closed:
+            raise RuntimeError("Cannot send a request, as the client has been closed.")
+        return await self._http_client._transport_for_url(request.url).handle_async_request(request)
+
+    @override
+    async def aclose(self) -> None:
+        # The caller owns the selected connection pool and proxy transports.
+        return None
+
+
+def _scoped_sync_client(
+    http_client: httpx2.Client,
+    *,
+    expected_origin: httpx2.URL,
+    expected_authorization: str | None = None,
+    token_exchange: bool = False,
+) -> httpx2.Client:
+    transport = _SyncX509ForwardingTransport(
+        http_client=http_client,
+        expected_origin=expected_origin,
+        expected_authorization=expected_authorization,
+        token_exchange=token_exchange,
+    )
+    legacy_httpx = _loaded_legacy_httpx()
+    client_type = httpx2.Client
+    if legacy_httpx is not None and not isinstance(cast(object, http_client), httpx2.Client):
+        client_type = legacy_httpx.Client
+    scoped_client = client_type(
+        transport=transport,
+        timeout=http_client.timeout,
+        event_hooks=None if token_exchange else http_client.event_hooks,
+        trust_env=False,
+    )
+    if not token_exchange:
+        scoped_client._cookies = http_client.cookies
+    return scoped_client
+
+
+def _scoped_async_client(
+    http_client: httpx2.AsyncClient,
+    *,
+    expected_origin: httpx2.URL,
+    expected_authorization: str | None = None,
+    token_exchange: bool = False,
+) -> httpx2.AsyncClient:
+    transport = _AsyncX509ForwardingTransport(
+        http_client=http_client,
+        expected_origin=expected_origin,
+        expected_authorization=expected_authorization,
+        token_exchange=token_exchange,
+    )
+    legacy_httpx = _loaded_legacy_httpx()
+    client_type = httpx2.AsyncClient
+    if legacy_httpx is not None and not isinstance(cast(object, http_client), httpx2.AsyncClient):
+        client_type = legacy_httpx.AsyncClient
+    scoped_client = client_type(
+        transport=transport,
+        timeout=http_client.timeout,
+        event_hooks=None if token_exchange else http_client.event_hooks,
+        trust_env=False,
+    )
+    if not token_exchange:
+        scoped_client._cookies = http_client.cookies
+    return scoped_client
 
 
 def _as_finite_float(value: object) -> float | None:
@@ -71,8 +227,17 @@ def _exchange_payload(identity: X509WorkloadIdentity) -> dict[str, str]:
     }
 
 
-def _token_exchange_request(identity: X509WorkloadIdentity) -> httpx2.Request:
-    return httpx2.Request(
+def _token_exchange_request(
+    identity: X509WorkloadIdentity,
+    *,
+    http_client: httpx2.Client | httpx2.AsyncClient,
+) -> httpx2.Request:
+    request_type = httpx2.Request
+    legacy_httpx = _loaded_legacy_httpx()
+    if legacy_httpx is not None and not isinstance(cast(object, http_client), (httpx2.Client, httpx2.AsyncClient)):
+        request_type = cast(type[httpx2.Request], cast(Any, legacy_httpx).Request)
+
+    return request_type(
         "POST",
         _X509_TOKEN_EXCHANGE_URL,
         json=_exchange_payload(identity),
@@ -213,15 +378,36 @@ class SyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
         super().__init__(workload_identity=workload_identity, max_retries=max_retries)
         self._http_client = http_client
 
+    def send_api_request(
+        self,
+        request: httpx2.Request,
+        *,
+        expected_origin: httpx2.URL,
+        expected_authorization: str | None,
+        stream: bool,
+        **kwargs: Any,
+    ) -> httpx2.Response:
+        with _scoped_sync_client(
+            self._http_client,
+            expected_origin=expected_origin,
+            expected_authorization=expected_authorization,
+        ) as scoped_client:
+            return scoped_client.send(request, stream=stream, **kwargs)
+
     @override
     def _fetch_token_from_exchange(self) -> dict[str, Any]:
         for attempt in range(self._max_exchange_retries + 1):
             try:
-                response = self._http_client.send(
-                    _token_exchange_request(self.workload_identity),
-                    auth=None,
-                    follow_redirects=False,
-                )
+                with _scoped_sync_client(
+                    self._http_client,
+                    expected_origin=httpx2.URL(_X509_TOKEN_EXCHANGE_URL),
+                    token_exchange=True,
+                ) as scoped_client:
+                    response = scoped_client.send(
+                        _token_exchange_request(self.workload_identity, http_client=self._http_client),
+                        auth=None,
+                        follow_redirects=False,
+                    )
             except _transport_errors() as error:
                 if attempt >= self._max_exchange_retries:
                     _raise_transport_error(error)
@@ -245,6 +431,22 @@ class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
         self._http_client = http_client
         self._async_lock = anyio.Lock()
 
+    async def send_api_request(
+        self,
+        request: httpx2.Request,
+        *,
+        expected_origin: httpx2.URL,
+        expected_authorization: str | None,
+        stream: bool,
+        **kwargs: Any,
+    ) -> httpx2.Response:
+        async with _scoped_async_client(
+            self._http_client,
+            expected_origin=expected_origin,
+            expected_authorization=expected_authorization,
+        ) as scoped_client:
+            return await scoped_client.send(request, stream=stream, **kwargs)
+
     @override
     async def get_token_async(self) -> str:
         async with self._async_lock:
@@ -260,11 +462,16 @@ class AsyncX509WorkloadIdentityAuth(_X509WorkloadIdentityAuth):
     async def _fetch_token_from_exchange_async(self) -> dict[str, Any]:
         for attempt in range(self._max_exchange_retries + 1):
             try:
-                response = await self._http_client.send(
-                    _token_exchange_request(self.workload_identity),
-                    auth=None,
-                    follow_redirects=False,
-                )
+                async with _scoped_async_client(
+                    self._http_client,
+                    expected_origin=httpx2.URL(_X509_TOKEN_EXCHANGE_URL),
+                    token_exchange=True,
+                ) as scoped_client:
+                    response = await scoped_client.send(
+                        _token_exchange_request(self.workload_identity, http_client=self._http_client),
+                        auth=None,
+                        follow_redirects=False,
+                    )
             except _transport_errors() as error:
                 if attempt >= self._max_exchange_retries:
                     _raise_transport_error(error)

--- a/src/openai/auth/_x509.py
+++ b/src/openai/auth/_x509.py
@@ -25,6 +25,7 @@ _X509_TOKEN_EXCHANGE_URL = "https://mtls.auth.openai.com/oauth/token"
 _X509_SUBJECT_TOKEN_TYPE = "urn:openai:params:oauth:token-type:x509"
 _MAX_EXCHANGE_RETRIES = 2
 _REPLAY_POSITION_EXTENSION = "openai_x509_replay_position"
+_REPLAY_FILE_POSITIONS_EXTENSION = "openai_x509_replay_file_positions"
 _ALLOWED_IDENTITY_FIELDS = {"type", "identity_provider_id", "service_account_id", "refresh_buffer_seconds"}
 
 
@@ -94,13 +95,21 @@ def _is_replayable_request(request: httpx2.Request) -> bool:
     stream = request.stream
     fields = getattr(stream, "fields", None)
     if isinstance(fields, list):
+        file_positions: list[tuple[object, int]] = []
         for field in cast(list[object], fields):
             file = getattr(field, "file", None)
             if file is None or isinstance(file, (str, bytes)):
                 continue
             seekable = getattr(file, "seekable", None)
-            if not callable(seekable) or not seekable():
+            seek = getattr(file, "seek", None)
+            tell = getattr(file, "tell", None)
+            if not callable(seekable) or not seekable() or not callable(seek) or not callable(tell):
                 return False
+            position = tell()
+            if not isinstance(position, int):
+                return False
+            file_positions.append((file, position))
+        request.extensions[_REPLAY_FILE_POSITIONS_EXTENSION] = file_positions
         return True
 
     source = getattr(stream, "_stream", stream)
@@ -165,6 +174,14 @@ class _X509WorkloadIdentityAuth(_WorkloadIdentityAuth[X509WorkloadIdentity]):
 
     @override
     def _prepare_retry_request(self, request: httpx2.Request) -> None:
+        file_positions = request.extensions.get(_REPLAY_FILE_POSITIONS_EXTENSION)
+        if isinstance(file_positions, list):
+            for file, file_position in cast(list[tuple[object, int]], file_positions):
+                seek = getattr(file, "seek", None)
+                if callable(seek):
+                    seek(file_position)
+            return
+
         position = request.extensions.get(_REPLAY_POSITION_EXTENSION)
         if not isinstance(position, int):
             return

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -7,7 +7,7 @@ from typing_extensions import Self, override
 
 import httpx2
 
-from ..auth import WorkloadIdentity
+from ..auth import WorkloadIdentity, X509WorkloadIdentity
 from .._types import NOT_GIVEN, Omit, Query, Headers, Timeout, NotGiven
 from .._utils import is_given, is_mapping
 from .._client import OpenAI, AsyncOpenAI
@@ -284,7 +284,7 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         *,
         api_key: str | Callable[[], str] | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         provider: _Provider | None | NotGiven = NOT_GIVEN,
         organization: str | None = None,
         project: str | None = None,
@@ -608,7 +608,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         *,
         api_key: str | Callable[[], Awaitable[str]] | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         provider: _Provider | None | NotGiven = NOT_GIVEN,
         organization: str | None = None,
         project: str | None = None,

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -176,7 +176,7 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         api_key: str | Callable[[], str] | None = None,
         admin_api_key: str | None = None,
         # workload_identity is not functional in the Azure client
-        workload_identity: WorkloadIdentity | None = None,  # noqa: ARG002
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         azure_ad_token: str | None = None,
         azure_ad_token_provider: AzureADTokenProvider | None = None,
         organization: str | None = None,
@@ -212,6 +212,9 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
             azure_deployment: A model deployment, if given with `azure_endpoint`, sets the base client URL to include `/deployments/{azure_deployment}`.
                 Not supported with Assistants APIs.
         """
+        if is_x509_workload_identity(workload_identity):
+            raise OpenAIError("X.509 workload identity is not supported by Azure clients")
+
         if api_key is None:
             api_key = os.environ.get("AZURE_OPENAI_API_KEY")
 
@@ -502,7 +505,7 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         api_key: str | Callable[[], Awaitable[str]] | None = None,
         admin_api_key: str | None = None,
         # workload_identity is not functional in the Azure client
-        workload_identity: WorkloadIdentity | None = None,  # noqa: ARG002
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         azure_ad_token: str | None = None,
         azure_ad_token_provider: AsyncAzureADTokenProvider | None = None,
         organization: str | None = None,
@@ -538,6 +541,9 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
             azure_deployment: A model deployment, if given with `azure_endpoint`, sets the base client URL to include `/deployments/{azure_deployment}`.
                 Not supported with Assistants APIs.
         """
+        if is_x509_workload_identity(workload_identity):
+            raise OpenAIError("X.509 workload identity is not supported by Azure clients")
+
         if api_key is None:
             api_key = os.environ.get("AZURE_OPENAI_API_KEY")
 

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -16,6 +16,7 @@ from .._httpx2 import normalize_httpx_url
 from .._models import SecurityOptions, FinalRequestOptions
 from .._provider import _Provider
 from .._streaming import Stream, AsyncStream
+from ..auth._x509 import is_x509_workload_identity
 from .._exceptions import OpenAIError
 from .._base_client import DEFAULT_MAX_RETRIES, BaseClient
 
@@ -309,6 +310,8 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         """
         if not isinstance(provider, NotGiven):
             raise OpenAIError("Configure `provider` on `OpenAI`, not on `AzureOpenAI.with_options()`.")
+        if is_x509_workload_identity(workload_identity):
+            raise OpenAIError("X.509 workload identity is not supported by Azure clients")
 
         return super().copy(
             api_key=api_key,
@@ -633,6 +636,8 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         """
         if not isinstance(provider, NotGiven):
             raise OpenAIError("Configure `provider` on `AsyncOpenAI`, not on `AsyncAzureOpenAI.with_options()`.")
+        if is_x509_workload_identity(workload_identity):
+            raise OpenAIError("X.509 workload identity is not supported by Azure clients")
 
         return super().copy(
             api_key=api_key,

--- a/src/openai/lib/bedrock.py
+++ b/src/openai/lib/bedrock.py
@@ -10,7 +10,7 @@ from typing_extensions import Self, override
 
 import httpx2
 
-from ..auth import WorkloadIdentity
+from ..auth import WorkloadIdentity, X509WorkloadIdentity
 from .._types import NOT_GIVEN, Timeout, NotGiven
 from .._utils import is_given
 from .._client import OpenAI, AsyncOpenAI
@@ -513,7 +513,7 @@ class BedrockOpenAI(OpenAI):
         *,
         api_key: str | BedrockTokenProvider | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         provider: _Provider | None | NotGiven = NOT_GIVEN,
         bedrock_token_provider: BedrockTokenProvider | None = None,
         aws_region: str | None = None,
@@ -749,7 +749,7 @@ class AsyncBedrockOpenAI(AsyncOpenAI):
         *,
         api_key: str | AsyncBedrockTokenProvider | None = None,
         admin_api_key: str | None = None,
-        workload_identity: WorkloadIdentity | None = None,
+        workload_identity: WorkloadIdentity | X509WorkloadIdentity | None = None,
         provider: _Provider | None | NotGiven = NOT_GIVEN,
         bedrock_token_provider: AsyncBedrockTokenProvider | None = None,
         aws_region: str | None = None,

--- a/tests/lib/test_azure.py
+++ b/tests/lib/test_azure.py
@@ -8,6 +8,7 @@ import httpx2
 import pytest
 
 from openai import OpenAIError
+from openai.auth import x509_workload_identity
 from tests.utils import update_env
 from tests.respx2 import MockRouter
 from openai._types import Omit
@@ -77,6 +78,18 @@ def test_client_copying_override_options(client: Client) -> None:
         api_version="2022-05-01",
     )
     assert copied._custom_query == {"api-version": "2022-05-01"}
+
+
+@pytest.mark.parametrize("client", [sync_client, async_client])
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+def test_client_copying_rejects_x509_workload_identity(client: Client, method: Literal["copy", "with_options"]) -> None:
+    identity = x509_workload_identity(identity_provider_id="idp_123", service_account_id="svc_acct_123")
+
+    with pytest.raises(OpenAIError, match="X.509 workload identity is not supported by Azure clients"):
+        if method == "copy":
+            client.copy(workload_identity=identity)
+        else:
+            client.with_options(workload_identity=identity)
 
 
 def test_enforce_credentials_false_sync() -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,5 @@
 import json
-from typing import cast
+from typing import cast, get_type_hints
 from pathlib import Path
 
 import httpx2
@@ -8,12 +8,26 @@ from inline_snapshot import snapshot
 
 from tests import respx2
 from openai import OpenAI, OAuthError
+from openai.auth import WorkloadIdentity, WorkloadIdentityAuth, SubjectTokenWorkloadIdentity
 from tests.respx2.models import Call
 from openai.auth._workload import (
     gcp_id_token_provider,
     k8s_service_account_token_provider,
     azure_managed_identity_token_provider,
 )
+
+
+def test_workload_identity_preserves_callable_typed_dict_api() -> None:
+    identity = WorkloadIdentity(
+        identity_provider_id="idp_existing",
+        service_account_id="svc_acct_existing",
+        provider={"token_type": "jwt", "get_token": lambda: "subject-token"},
+    )
+
+    assert identity["provider"]["get_token"]() == "subject-token"
+    assert SubjectTokenWorkloadIdentity is WorkloadIdentity
+    assert get_type_hints(WorkloadIdentityAuth.__init__)["workload_identity"] is WorkloadIdentity
+    assert WorkloadIdentityAuth(workload_identity=identity).workload_identity is identity
 
 
 @respx2.mock

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,7 +17,7 @@ import pytest
 from pydantic import ValidationError
 
 from openai import OpenAI, AsyncOpenAI, OpenAIError, APIResponseValidationError
-from openai.auth import WorkloadIdentity
+from openai.auth import SubjectTokenWorkloadIdentity
 from tests.respx2 import MockRouter
 from openai._types import Omit
 from openai._utils import asyncify
@@ -42,7 +42,7 @@ T = TypeVar("T")
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 api_key = "My API Key"
 admin_api_key = "My Admin API Key"
-workload_identity: WorkloadIdentity = {
+workload_identity: SubjectTokenWorkloadIdentity = {
     "identity_provider_id": "provider_123",
     "service_account_id": "service_account_123",
     "provider": {

--- a/tests/test_x509_host_authority.py
+++ b/tests/test_x509_host_authority.py
@@ -7,7 +7,6 @@ from openai import OpenAI, AsyncOpenAI, OpenAIError
 from openai.auth import x509_workload_identity
 
 _AUTH_HOST = "mtls.auth.openai.com"
-_API_HOST = "mtls.api.openai.com"
 
 
 def _response(request: httpx2.Request) -> httpx2.Response:

--- a/tests/test_x509_host_authority.py
+++ b/tests/test_x509_host_authority.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI, OpenAIError
+from openai.auth import x509_workload_identity
+
+_AUTH_HOST = "mtls.auth.openai.com"
+_API_HOST = "mtls.api.openai.com"
+
+
+def _response(request: httpx2.Request) -> httpx2.Response:
+    if request.url.host == _AUTH_HOST:
+        return httpx2.Response(200, request=request, json={"access_token": "trusted-token", "expires_in": 3600})
+    return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+
+@pytest.mark.parametrize("source", ["client", "request", "hook"])
+@pytest.mark.parametrize(
+    "host",
+    [
+        "attacker.invalid",
+        "mtls.api.openai.com:8443",
+        "user@mtls.api.openai.com",
+        "mtls.api.openai.com/",
+        "mtls.api.openai.com?",
+        "mtls.api.openai.com#",
+    ],
+)
+def test_sync_x509_rejects_mismatched_effective_host(source: str, host: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    def hook(request: httpx2.Request) -> None:
+        request.headers["Host"] = host
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler),
+        headers={"Host": host} if source == "client" else None,
+        event_hooks={"request": [hook]} if source == "hook" else None,
+        trust_env=False,
+    )
+    identity = x509_workload_identity(identity_provider_id="provider", service_account_id="account")
+    with OpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="Host|authority|credentials"):
+            client.models.list(extra_headers={"Host": host} if source == "request" else None)
+
+    assert [request.url.host for request in requests] == ([_AUTH_HOST] if source == "hook" else [])
+
+
+@pytest.mark.parametrize("source", ["client", "request", "hook"])
+@pytest.mark.parametrize(
+    "host",
+    [
+        "attacker.invalid",
+        "mtls.api.openai.com:8443",
+        "user@mtls.api.openai.com",
+        "mtls.api.openai.com/",
+        "mtls.api.openai.com?",
+        "mtls.api.openai.com#",
+    ],
+)
+async def test_async_x509_rejects_mismatched_effective_host(source: str, host: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    async def hook(request: httpx2.Request) -> None:
+        request.headers["Host"] = host
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler),
+        headers={"Host": host} if source == "client" else None,
+        event_hooks={"request": [hook]} if source == "hook" else None,
+        trust_env=False,
+    )
+    identity = x509_workload_identity(identity_provider_id="provider", service_account_id="account")
+    async with AsyncOpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="Host|authority|credentials"):
+            await client.models.list(extra_headers={"Host": host} if source == "request" else None)
+
+    assert [request.url.host for request in requests] == ([_AUTH_HOST] if source == "hook" else [])
+
+
+@pytest.mark.parametrize("host", ["mtls.api.openai.com", "MTLS.API.OPENAI.COM", "mtls.api.openai.com:443"])
+def test_sync_x509_accepts_normalized_matching_host(host: str) -> None:
+    http_client = httpx2.Client(transport=httpx2.MockTransport(_response), trust_env=False)
+    identity = x509_workload_identity(identity_provider_id="provider", service_account_id="account")
+    with OpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        assert client.models.list(extra_headers={"Host": host}).object == "list"
+
+
+@pytest.mark.parametrize("host", ["mtls.api.openai.com", "MTLS.API.OPENAI.COM", "mtls.api.openai.com:443"])
+async def test_async_x509_accepts_normalized_matching_host(host: str) -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    identity = x509_workload_identity(identity_provider_id="provider", service_account_id="account")
+    async with AsyncOpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list(extra_headers={"Host": host})).object == "list"
+
+
+def test_sync_x509_rejects_duplicate_host_headers_at_final_transport() -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    def hook(request: httpx2.Request) -> None:
+        request.headers = httpx2.Headers([*request.headers.multi_items(), ("Host", "attacker.invalid")])
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    identity = x509_workload_identity(identity_provider_id="provider", service_account_id="account")
+    with OpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="Host|authority"):
+            client.models.list()
+
+    assert [request.url.host for request in requests] == [_AUTH_HOST]
+
+
+async def test_async_x509_rejects_duplicate_host_headers_at_final_transport() -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    async def hook(request: httpx2.Request) -> None:
+        request.headers = httpx2.Headers([*request.headers.multi_items(), ("Host", "attacker.invalid")])
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    identity = x509_workload_identity(identity_provider_id="provider", service_account_id="account")
+    async with AsyncOpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="Host|authority"):
+            await client.models.list()
+
+    assert [request.url.host for request in requests] == [_AUTH_HOST]

--- a/tests/test_x509_security_boundaries.py
+++ b/tests/test_x509_security_boundaries.py
@@ -1,0 +1,604 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Callable, cast
+from contextvars import ContextVar
+from typing_extensions import override
+
+import anyio
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI, OpenAIError
+from openai.auth import X509WorkloadIdentity, x509_workload_identity
+from openai.lib.azure import AzureOpenAI, AsyncAzureOpenAI
+from openai.auth._x509 import is_x509_workload_identity
+
+_TOKEN_URL = "https://mtls.auth.openai.com/oauth/token"
+_API_URL = "https://mtls.api.openai.com/v1/models"
+
+
+def _identity() -> X509WorkloadIdentity:
+    return x509_workload_identity(identity_provider_id="idp_original", service_account_id="svc_original")
+
+
+def _mutate_identity(identity: X509WorkloadIdentity, field: str, value: object) -> None:
+    if field == "identity_provider_id":
+        assert isinstance(value, str)
+        identity["identity_provider_id"] = value
+    elif field == "service_account_id":
+        assert isinstance(value, str)
+        identity["service_account_id"] = value
+    else:
+        assert field == "refresh_buffer_seconds"
+        assert isinstance(value, float)
+        identity["refresh_buffer_seconds"] = value
+
+
+def _response(request: httpx2.Request) -> httpx2.Response:
+    if str(request.url) == _TOKEN_URL:
+        return httpx2.Response(200, request=request, json={"access_token": "trusted-token", "expires_in": 3600})
+    return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize("base_url", ["http://attacker.invalid/v1", "ftp://attacker.invalid/v1"])
+def test_x509_constructor_rejects_insecure_api_base(
+    client_type: type[OpenAI] | type[AsyncOpenAI], base_url: str
+) -> None:
+    with pytest.raises(OpenAIError, match="HTTPS"):
+        client_type(workload_identity=_identity(), base_url=base_url)
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+def test_x509_constructor_rejects_insecure_environment_base(
+    client_type: type[OpenAI] | type[AsyncOpenAI], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://attacker.invalid/v1")
+    with pytest.raises(OpenAIError, match="HTTPS"):
+        client_type(workload_identity=_identity())
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+def test_x509_base_url_setter_rejects_insecure_origin(client_type: type[OpenAI] | type[AsyncOpenAI]) -> None:
+    client = client_type(workload_identity=_identity())
+    try:
+        original_url = client.base_url
+        with pytest.raises(OpenAIError, match="HTTPS"):
+            client.base_url = "http://attacker.invalid/v1"
+        assert client.base_url == original_url
+    finally:
+        if isinstance(client, OpenAI):
+            client.close()
+        else:
+            anyio.run(client.close)
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+def test_api_key_clients_keep_supported_plaintext_local_origins(client_type: type[OpenAI] | type[AsyncOpenAI]) -> None:
+    client = client_type(api_key="local-api-key", base_url="http://localhost:8080/v1")
+    try:
+        assert str(client.base_url) == "http://localhost:8080/v1/"
+    finally:
+        if isinstance(client, OpenAI):
+            client.close()
+        else:
+            anyio.run(client.close)
+
+
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+def test_sync_copy_rejects_insecure_x509_api_base(method: str) -> None:
+    with OpenAI(workload_identity=_identity()) as client:
+        with pytest.raises(OpenAIError, match="HTTPS"):
+            getattr(client, method)(base_url="http://attacker.invalid/v1")
+
+    with OpenAI(api_key="local-api-key", base_url="http://localhost:8080/v1") as client:
+        with pytest.raises(OpenAIError, match="HTTPS"):
+            getattr(client, method)(workload_identity=_identity())
+
+
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+async def test_async_copy_rejects_insecure_x509_api_base(method: str) -> None:
+    async with AsyncOpenAI(workload_identity=_identity()) as client:
+        with pytest.raises(OpenAIError, match="HTTPS"):
+            getattr(client, method)(base_url="http://attacker.invalid/v1")
+
+    async with AsyncOpenAI(api_key="local-api-key", base_url="http://localhost:8080/v1") as client:
+        with pytest.raises(OpenAIError, match="HTTPS"):
+            getattr(client, method)(workload_identity=_identity())
+
+
+_ATTACKER_URLS = [
+    "http://attacker.invalid/v1/models",
+    "https://attacker.invalid/v1/models",
+    "https://mtls.api.openai.com.@attacker.invalid/v1/models",
+    "https://mtls.api.openai.com\\@attacker.invalid/v1/models",
+    "https://mtls.api.openai.com:8443/v1/models",
+]
+
+
+@pytest.mark.parametrize("url", _ATTACKER_URLS)
+def test_sync_x509_rejects_attacker_origin_before_token_exchange(url: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="HTTPS|origin|credentials"):
+            client.get(url, cast_to=object)
+
+    assert requests == []
+
+
+@pytest.mark.parametrize("url", _ATTACKER_URLS)
+async def test_async_x509_rejects_attacker_origin_before_token_exchange(url: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="HTTPS|origin|credentials"):
+            await client.get(url, cast_to=object)
+
+    assert requests == []
+
+
+def test_sync_x509_rejects_subclass_mutated_origin_before_token_exchange() -> None:
+    requests: list[httpx2.Request] = []
+
+    class RedirectingOpenAI(OpenAI):
+        @override
+        def _prepare_request(self, request: httpx2.Request) -> None:
+            request.url = httpx2.URL("https://subclass-attacker.invalid/v1/models")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with RedirectingOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="origin"):
+            client.models.list()
+
+    assert requests == []
+
+
+async def test_async_x509_rejects_subclass_mutated_origin_before_token_exchange() -> None:
+    requests: list[httpx2.Request] = []
+
+    class RedirectingAsyncOpenAI(AsyncOpenAI):
+        @override
+        async def _prepare_request(self, request: httpx2.Request) -> None:
+            request.url = httpx2.URL("https://subclass-attacker.invalid/v1/models")
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with RedirectingAsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="origin"):
+            await client.models.list()
+
+    assert requests == []
+
+
+def test_sync_x509_token_exchange_skips_caller_hooks_and_preserves_api_hooks() -> None:
+    requests: list[httpx2.Request] = []
+    hooked_urls: list[str] = []
+
+    def hook(request: httpx2.Request) -> None:
+        hooked_urls.append(str(request.url))
+        request.headers["X-API-Key"] = "caller-api-secret"
+        request.headers["Cookie"] = "session=caller-cookie"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+
+    assert hooked_urls == [_API_URL]
+    assert requests[0].headers.get("Authorization") is None
+    assert requests[0].headers.get("X-API-Key") is None
+    assert requests[0].headers.get("Cookie") is None
+    assert requests[1].headers["X-API-Key"] == "caller-api-secret"
+    assert requests[1].headers["Cookie"] == "session=caller-cookie"
+
+
+async def test_async_x509_token_exchange_skips_caller_hooks_and_preserves_api_hooks() -> None:
+    requests: list[httpx2.Request] = []
+    hooked_urls: list[str] = []
+
+    async def hook(request: httpx2.Request) -> None:
+        hooked_urls.append(str(request.url))
+        request.headers["X-API-Key"] = "caller-api-secret"
+        request.headers["Cookie"] = "session=caller-cookie"
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert hooked_urls == [_API_URL]
+    assert requests[0].headers.get("Authorization") is None
+    assert requests[0].headers.get("X-API-Key") is None
+    assert requests[0].headers.get("Cookie") is None
+    assert requests[1].headers["X-API-Key"] == "caller-api-secret"
+    assert requests[1].headers["Cookie"] == "session=caller-cookie"
+
+
+@pytest.mark.parametrize("mutation", ["origin", "plaintext", "authorization", "remove_authorization"])
+def test_sync_x509_rejects_hook_mutated_api_request_at_transport(mutation: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def hook(request: httpx2.Request) -> None:
+        if mutation == "authorization":
+            request.headers["Authorization"] = "Bearer hook-override"
+        elif mutation == "remove_authorization":
+            del request.headers["Authorization"]
+        elif mutation == "plaintext":
+            request.url = httpx2.URL("http://hook-attacker.invalid/v1/models")
+        else:
+            request.url = httpx2.URL("https://hook-attacker.invalid/v1/models")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="HTTPS|origin|authorization"):
+            client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+@pytest.mark.parametrize("mutation", ["origin", "plaintext", "authorization", "remove_authorization"])
+async def test_async_x509_rejects_hook_mutated_api_request_at_transport(mutation: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def hook(request: httpx2.Request) -> None:
+        if mutation == "authorization":
+            request.headers["Authorization"] = "Bearer hook-override"
+        elif mutation == "remove_authorization":
+            del request.headers["Authorization"]
+        elif mutation == "plaintext":
+            request.url = httpx2.URL("http://hook-attacker.invalid/v1/models")
+        else:
+            request.url = httpx2.URL("https://hook-attacker.invalid/v1/models")
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="HTTPS|origin|authorization"):
+            await client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+def test_sync_x509_snapshots_original_identity_and_rejects_client_identity_mutation() -> None:
+    identity = _identity()
+    payloads: list[dict[str, Any]] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            payloads.append(json.loads(request.content))
+        return _response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        identity["identity_provider_id"] = "idp_attacker"
+        identity["service_account_id"] = "svc_attacker"
+        assert client.models.list().object == "list"
+        assert client.workload_identity is not None
+        assert client.workload_identity["identity_provider_id"] == "idp_original"
+
+        client.workload_identity["identity_provider_id"] = "idp_changed"
+        with pytest.raises(OpenAIError, match="cannot be changed"):
+            client.models.list()
+
+    assert len(payloads) == 1
+    assert payloads[0]["identity_provider_id"] == "idp_original"
+
+
+async def test_async_x509_snapshots_original_identity_and_rejects_client_identity_mutation() -> None:
+    identity = _identity()
+    payloads: list[dict[str, Any]] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            payloads.append(json.loads(request.content))
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=identity, http_client=http_client, max_retries=0) as client:
+        identity["identity_provider_id"] = "idp_attacker"
+        identity["service_account_id"] = "svc_attacker"
+        assert (await client.models.list()).object == "list"
+        assert client.workload_identity is not None
+        assert client.workload_identity["identity_provider_id"] == "idp_original"
+
+        client.workload_identity["identity_provider_id"] = "idp_changed"
+        with pytest.raises(OpenAIError, match="cannot be changed"):
+            await client.models.list()
+
+    assert len(payloads) == 1
+    assert payloads[0]["identity_provider_id"] == "idp_original"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("identity_provider_id", "idp_changed"),
+        ("service_account_id", "svc_changed"),
+        ("refresh_buffer_seconds", float("nan")),
+    ],
+)
+def test_sync_x509_rejects_mutated_cached_identity_before_network(field: str, value: object) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        client.models.list()
+        assert is_x509_workload_identity(client.workload_identity)
+        _mutate_identity(client.workload_identity, field, value)
+        with pytest.raises(OpenAIError, match="cannot be changed"):
+            client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL]
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("identity_provider_id", "idp_changed"),
+        ("service_account_id", "svc_changed"),
+        ("refresh_buffer_seconds", float("nan")),
+    ],
+)
+async def test_async_x509_rejects_mutated_cached_identity_before_network(field: str, value: object) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        await client.models.list()
+        assert is_x509_workload_identity(client.workload_identity)
+        _mutate_identity(client.workload_identity, field, value)
+        with pytest.raises(OpenAIError, match="cannot be changed"):
+            await client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL]
+
+
+def test_sync_x509_preserves_caller_mounts_response_hooks_and_api_cookie_jar() -> None:
+    routed: list[str] = []
+    hook_hosts: list[str] = []
+    tenant_context: ContextVar[str] = ContextVar("tenant", default="missing")
+    tenant_context.set("tenant-original")
+
+    def auth_handler(request: httpx2.Request) -> httpx2.Response:
+        routed.append("auth:" + str(request.url))
+        assert tenant_context.get() == "tenant-original"
+        return httpx2.Response(
+            200,
+            request=request,
+            headers={"set-cookie": "auth_poison=secret; Domain=.openai.com; Path=/"},
+            json={"access_token": "trusted-token", "expires_in": 3600},
+        )
+
+    def api_handler(request: httpx2.Request) -> httpx2.Response:
+        routed.append("api:" + str(request.url))
+        assert tenant_context.get() == "tenant-original"
+        assert "auth_poison" not in request.headers.get("cookie", "")
+        return httpx2.Response(
+            200,
+            request=request,
+            headers={"set-cookie": "api_session=trusted; Path=/"},
+            json={"object": "list", "data": []},
+        )
+
+    def response_hook(response: httpx2.Response) -> None:
+        hook_hosts.append(str(response.request.url.host))
+
+    default_transport = httpx2.MockTransport(lambda _: pytest.fail("unexpected default transport"))
+    http_client = httpx2.Client(
+        transport=default_transport,
+        mounts={
+            "https://mtls.auth.openai.com": httpx2.MockTransport(auth_handler),
+            "https://mtls.api.openai.com": httpx2.MockTransport(api_handler),
+        },
+        event_hooks={"response": [response_hook]},
+        trust_env=False,
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+        assert http_client.cookies.get("api_session") == "trusted"
+        assert http_client.cookies.get("auth_poison") is None
+
+    assert routed == ["auth:" + _TOKEN_URL, "api:" + _API_URL]
+    assert hook_hosts == ["mtls.api.openai.com"]
+
+
+async def test_async_x509_preserves_caller_mounts_response_hooks_and_api_cookie_jar() -> None:
+    routed: list[str] = []
+    hook_hosts: list[str] = []
+    tenant_context: ContextVar[str] = ContextVar("tenant", default="missing")
+    tenant_context.set("tenant-original")
+
+    async def auth_handler(request: httpx2.Request) -> httpx2.Response:
+        routed.append("auth:" + str(request.url))
+        assert tenant_context.get() == "tenant-original"
+        return httpx2.Response(
+            200,
+            request=request,
+            headers={"set-cookie": "auth_poison=secret; Domain=.openai.com; Path=/"},
+            json={"access_token": "trusted-token", "expires_in": 3600},
+        )
+
+    async def api_handler(request: httpx2.Request) -> httpx2.Response:
+        routed.append("api:" + str(request.url))
+        assert tenant_context.get() == "tenant-original"
+        assert "auth_poison" not in request.headers.get("cookie", "")
+        return httpx2.Response(
+            200,
+            request=request,
+            headers={"set-cookie": "api_session=trusted; Path=/"},
+            json={"object": "list", "data": []},
+        )
+
+    async def response_hook(response: httpx2.Response) -> None:
+        hook_hosts.append(str(response.request.url.host))
+
+    default_transport = httpx2.MockTransport(lambda _: pytest.fail("unexpected default transport"))
+    http_client = httpx2.AsyncClient(
+        transport=default_transport,
+        mounts={
+            "https://mtls.auth.openai.com": httpx2.MockTransport(auth_handler),
+            "https://mtls.api.openai.com": httpx2.MockTransport(api_handler),
+        },
+        event_hooks={"response": [response_hook]},
+        trust_env=False,
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
+        assert http_client.cookies.get("api_session") == "trusted"
+        assert http_client.cookies.get("auth_poison") is None
+
+    assert routed == ["auth:" + _TOKEN_URL, "api:" + _API_URL]
+    assert hook_hosts == ["mtls.api.openai.com"]
+
+
+def test_sync_x509_keeps_supported_admin_credentials_separate() -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(
+        workload_identity=_identity(),
+        admin_api_key="admin-customer-secret",
+        http_client=http_client,
+        max_retries=0,
+    ) as client:
+        client.models.list()
+        client.get("/organization/projects", cast_to=object, options={"security": {"admin_api_key_auth": True}})
+        with pytest.raises(OpenAIError, match="origin"):
+            client.get(
+                "https://attacker.invalid/organization/projects",
+                cast_to=object,
+                options={"security": {"admin_api_key_auth": True}},
+            )
+
+    assert len(requests) == 3
+    assert requests[0].headers.get("Authorization") is None
+    assert requests[1].headers["Authorization"] == "Bearer trusted-token"
+    assert requests[2].headers["Authorization"] == "Bearer admin-customer-secret"
+
+
+async def test_async_x509_keeps_supported_admin_credentials_separate() -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(
+        workload_identity=_identity(),
+        admin_api_key="admin-customer-secret",
+        http_client=http_client,
+        max_retries=0,
+    ) as client:
+        await client.models.list()
+        await client.get("/organization/projects", cast_to=object, options={"security": {"admin_api_key_auth": True}})
+        with pytest.raises(OpenAIError, match="origin"):
+            await client.get(
+                "https://attacker.invalid/organization/projects",
+                cast_to=object,
+                options={"security": {"admin_api_key_auth": True}},
+            )
+
+    assert len(requests) == 3
+    assert requests[0].headers.get("Authorization") is None
+    assert requests[1].headers["Authorization"] == "Bearer trusted-token"
+    assert requests[2].headers["Authorization"] == "Bearer admin-customer-secret"
+
+
+@pytest.mark.parametrize("client_type", [AzureOpenAI, AsyncAzureOpenAI])
+def test_azure_constructors_reject_x509_instead_of_downgrading_to_api_key(
+    client_type: type[AzureOpenAI] | type[AsyncAzureOpenAI],
+) -> None:
+    constructor = cast(Callable[..., object], client_type)
+    with pytest.raises(OpenAIError, match="X.509 workload identity is not supported by Azure clients"):
+        constructor(
+            api_version="2024-02-01",
+            api_key="azure-customer-secret",
+            azure_endpoint="https://example-resource.azure.openai.com",
+            workload_identity=_identity(),
+        )
+
+
+@pytest.mark.parametrize(
+    "base_url,url",
+    [
+        ("https://MTLS.API.OPENAI.COM/v1", "https://mtls.api.openai.com/v1/models"),
+        ("https://mtls.api.openai.com:443/v1", "https://MTLS.API.OPENAI.COM/v1/models"),
+        ("https://custom.example:8443/v1", "https://custom.example:8443/v1/models"),
+    ],
+)
+def test_sync_x509_accepts_normalized_trusted_origin(base_url: str, url: str) -> None:
+    http_client = httpx2.Client(transport=httpx2.MockTransport(_response), trust_env=False)
+    with OpenAI(workload_identity=_identity(), base_url=base_url, http_client=http_client, max_retries=0) as client:
+        assert client.get(url, cast_to=object) is not None
+
+
+@pytest.mark.parametrize(
+    "base_url,url",
+    [
+        ("https://MTLS.API.OPENAI.COM/v1", "https://mtls.api.openai.com/v1/models"),
+        ("https://mtls.api.openai.com:443/v1", "https://MTLS.API.OPENAI.COM/v1/models"),
+        ("https://custom.example:8443/v1", "https://custom.example:8443/v1/models"),
+    ],
+)
+async def test_async_x509_accepts_normalized_trusted_origin(base_url: str, url: str) -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(
+        workload_identity=_identity(), base_url=base_url, http_client=http_client, max_retries=0
+    ) as client:
+        assert await client.get(url, cast_to=object) is not None

--- a/tests/test_x509_security_boundaries.py
+++ b/tests/test_x509_security_boundaries.py
@@ -16,6 +16,22 @@ from openai.auth._x509 import is_x509_workload_identity
 
 _TOKEN_URL = "https://mtls.auth.openai.com/oauth/token"
 _API_URL = "https://mtls.api.openai.com/v1/models"
+_TARGET_CREDENTIAL_HEADERS = [
+    "api-key",
+    "API-Key",
+    "api_key",
+    "API_KEY",
+    "X-API-Key",
+    "x-aPi-kEy",
+    "x_api_key",
+    "X_API_KEY",
+    "X_ApI-Key",
+    "x-aPi_keY",
+    "Proxy-Authorization",
+    "proxy-authorization",
+    "proxy_authorization",
+    "PROXY_AUTHORIZATION",
+]
 
 
 def _identity() -> X509WorkloadIdentity:
@@ -39,6 +55,134 @@ def _response(request: httpx2.Request) -> httpx2.Response:
     if str(request.url) == _TOKEN_URL:
         return httpx2.Response(200, request=request, json={"access_token": "trusted-token", "expires_in": 3600})
     return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+
+@pytest.mark.parametrize("token_type", ["Basic", "MAC", "DPoP", "", None, 42])
+def test_sync_x509_rejects_non_bearer_token_types_before_caching(token_type: object) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(
+            200,
+            request=request,
+            json={"access_token": "trusted-token", "expires_in": 3600, "token_type": token_type},
+        )
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="Bearer token type"):
+            client.models.list()
+        assert client._workload_identity_auth is not None
+        assert client._workload_identity_auth._cached_token is None
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+@pytest.mark.parametrize("token_type", ["Basic", "MAC", "DPoP", "", None, 42])
+async def test_async_x509_rejects_non_bearer_token_types_before_caching(token_type: object) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(
+            200,
+            request=request,
+            json={"access_token": "trusted-token", "expires_in": 3600, "token_type": token_type},
+        )
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="Bearer token type"):
+            await client.models.list()
+        assert client._workload_identity_auth is not None
+        assert client._workload_identity_auth._cached_token is None
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+_UNSAFE_ACCESS_TOKENS = [
+    "trusted\r\nInjected: secret",
+    "trusted\nInjected: secret",
+    "trusted\x00token",
+    "trusted\ttoken",
+    "trusted token",
+    " trusted-token",
+    "trusted-token ",
+    "trusted-\u00e9-token",
+    "trusted,token",
+    "trusted=token",
+]
+
+
+@pytest.mark.parametrize("access_token", _UNSAFE_ACCESS_TOKENS)
+def test_sync_x509_rejects_unsafe_access_tokens_before_caching(access_token: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, request=request, json={"access_token": access_token, "expires_in": 3600})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="valid Bearer access_token"):
+            client.models.list()
+        assert client._workload_identity_auth is not None
+        assert client._workload_identity_auth._cached_token is None
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+@pytest.mark.parametrize("access_token", _UNSAFE_ACCESS_TOKENS)
+async def test_async_x509_rejects_unsafe_access_tokens_before_caching(access_token: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, request=request, json={"access_token": access_token, "expires_in": 3600})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="valid Bearer access_token"):
+            await client.models.list()
+        assert client._workload_identity_auth is not None
+        assert client._workload_identity_auth._cached_token is None
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+@pytest.mark.parametrize("token_type", ["Bearer", "bearer", "BEARER"])
+def test_sync_x509_accepts_explicit_bearer_token_types(token_type: str) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            return httpx2.Response(
+                200,
+                request=request,
+                json={"access_token": "safe.jwt_token~+/==", "expires_in": 3600, "token_type": token_type},
+            )
+        assert request.headers["Authorization"] == "Bearer safe.jwt_token~+/=="
+        return _response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+
+
+@pytest.mark.parametrize("token_type", ["Bearer", "bearer", "BEARER"])
+async def test_async_x509_accepts_explicit_bearer_token_types(token_type: str) -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            return httpx2.Response(
+                200,
+                request=request,
+                json={"access_token": "safe.jwt_token~+/==", "expires_in": 3600, "token_type": token_type},
+            )
+        assert request.headers["Authorization"] == "Bearer safe.jwt_token~+/=="
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
 
 
 @pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
@@ -195,7 +339,7 @@ def test_sync_x509_token_exchange_skips_caller_hooks_and_preserves_api_hooks() -
 
     def hook(request: httpx2.Request) -> None:
         hooked_urls.append(str(request.url))
-        request.headers["X-API-Key"] = "caller-api-secret"
+        request.headers["X-Request-ID"] = "caller-request-id"
         request.headers["Cookie"] = "session=caller-cookie"
 
     def handler(request: httpx2.Request) -> httpx2.Response:
@@ -210,9 +354,9 @@ def test_sync_x509_token_exchange_skips_caller_hooks_and_preserves_api_hooks() -
 
     assert hooked_urls == [_API_URL]
     assert requests[0].headers.get("Authorization") is None
-    assert requests[0].headers.get("X-API-Key") is None
+    assert requests[0].headers.get("X-Request-ID") is None
     assert requests[0].headers.get("Cookie") is None
-    assert requests[1].headers["X-API-Key"] == "caller-api-secret"
+    assert requests[1].headers["X-Request-ID"] == "caller-request-id"
     assert requests[1].headers["Cookie"] == "session=caller-cookie"
 
 
@@ -222,7 +366,7 @@ async def test_async_x509_token_exchange_skips_caller_hooks_and_preserves_api_ho
 
     async def hook(request: httpx2.Request) -> None:
         hooked_urls.append(str(request.url))
-        request.headers["X-API-Key"] = "caller-api-secret"
+        request.headers["X-Request-ID"] = "caller-request-id"
         request.headers["Cookie"] = "session=caller-cookie"
 
     async def handler(request: httpx2.Request) -> httpx2.Response:
@@ -237,10 +381,100 @@ async def test_async_x509_token_exchange_skips_caller_hooks_and_preserves_api_ho
 
     assert hooked_urls == [_API_URL]
     assert requests[0].headers.get("Authorization") is None
-    assert requests[0].headers.get("X-API-Key") is None
+    assert requests[0].headers.get("X-Request-ID") is None
     assert requests[0].headers.get("Cookie") is None
-    assert requests[1].headers["X-API-Key"] == "caller-api-secret"
+    assert requests[1].headers["X-Request-ID"] == "caller-request-id"
     assert requests[1].headers["Cookie"] == "session=caller-cookie"
+
+
+@pytest.mark.parametrize("header", _TARGET_CREDENTIAL_HEADERS)
+@pytest.mark.parametrize("source", ["client", "request"])
+def test_sync_x509_rejects_target_credentials_before_token_exchange(header: str, source: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler),
+        headers={header: "provider-secret"} if source == "client" else None,
+        trust_env=False,
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="API.key"):
+            if source == "request":
+                client.models.list(extra_headers={header: "provider-secret"})
+            else:
+                client.models.list()
+
+    assert requests == []
+
+
+@pytest.mark.parametrize("header", _TARGET_CREDENTIAL_HEADERS)
+@pytest.mark.parametrize("source", ["client", "request"])
+async def test_async_x509_rejects_target_credentials_before_token_exchange(header: str, source: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler),
+        headers={header: "provider-secret"} if source == "client" else None,
+        trust_env=False,
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="API.key"):
+            if source == "request":
+                await client.models.list(extra_headers={header: "provider-secret"})
+            else:
+                await client.models.list()
+
+    assert requests == []
+
+
+@pytest.mark.parametrize("header", _TARGET_CREDENTIAL_HEADERS)
+def test_sync_x509_rejects_hook_injected_target_credentials_at_transport(header: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def hook(request: httpx2.Request) -> None:
+        request.headers[header] = "provider-secret"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="API.key"):
+            client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+@pytest.mark.parametrize("header", _TARGET_CREDENTIAL_HEADERS)
+async def test_async_x509_rejects_hook_injected_target_credentials_at_transport(header: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def hook(request: httpx2.Request) -> None:
+        request.headers[header] = "provider-secret"
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="API.key"):
+            await client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
 
 
 @pytest.mark.parametrize("mutation", ["origin", "plaintext", "authorization", "remove_authorization"])
@@ -555,6 +789,60 @@ async def test_async_x509_keeps_supported_admin_credentials_separate() -> None:
     assert requests[0].headers.get("Authorization") is None
     assert requests[1].headers["Authorization"] == "Bearer trusted-token"
     assert requests[2].headers["Authorization"] == "Bearer admin-customer-secret"
+
+
+@pytest.mark.parametrize("authorization", ["Basic Y3VzdG9tZXI6c2VjcmV0", "Bearer substituted-admin-secret"])
+def test_sync_x509_rejects_hook_overriding_separate_admin_authorization(authorization: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def hook(request: httpx2.Request) -> None:
+        request.headers["Authorization"] = authorization
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    with OpenAI(
+        workload_identity=_identity(),
+        admin_api_key="expected-admin-secret",
+        http_client=http_client,
+        max_retries=0,
+    ) as client:
+        with pytest.raises(OpenAIError, match="authorization"):
+            client.get("/organization/projects", cast_to=object, options={"security": {"admin_api_key_auth": True}})
+
+    assert requests == []
+
+
+@pytest.mark.parametrize("authorization", ["Basic Y3VzdG9tZXI6c2VjcmV0", "Bearer substituted-admin-secret"])
+async def test_async_x509_rejects_hook_overriding_separate_admin_authorization(authorization: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def hook(request: httpx2.Request) -> None:
+        request.headers["Authorization"] = authorization
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return _response(request)
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler), event_hooks={"request": [hook]}, trust_env=False
+    )
+    async with AsyncOpenAI(
+        workload_identity=_identity(),
+        admin_api_key="expected-admin-secret",
+        http_client=http_client,
+        max_retries=0,
+    ) as client:
+        with pytest.raises(OpenAIError, match="authorization"):
+            await client.get(
+                "/organization/projects", cast_to=object, options={"security": {"admin_api_key_auth": True}}
+            )
+
+    assert requests == []
 
 
 @pytest.mark.parametrize("client_type", [AzureOpenAI, AsyncAzureOpenAI])

--- a/tests/test_x509_workload_identity.py
+++ b/tests/test_x509_workload_identity.py
@@ -1,0 +1,842 @@
+from __future__ import annotations
+
+import io
+import os
+import ssl
+import json
+import runpy
+import asyncio
+import inspect
+import logging
+import importlib
+import threading
+from typing import Any, Callable, Iterable, Iterator, AsyncIterator, cast
+from pathlib import Path
+from typing_extensions import override
+from concurrent.futures import ThreadPoolExecutor
+
+import anyio
+import httpx2
+import pytest
+
+import openai.auth._x509 as x509_auth
+from openai import OpenAI, OAuthError, AsyncOpenAI, OpenAIError, APIStatusError, APITimeoutError, APIConnectionError
+from openai.auth import X509WorkloadIdentity, x509_workload_identity
+from openai._client import WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER
+
+_TOKEN_URL = "https://mtls.auth.openai.com/oauth/token"
+_API_URL = "https://mtls.api.openai.com/v1/models"
+_MTLS_FIXTURES = Path(__file__).parent / "fixtures" / "mtls"
+
+
+def _identity(**kwargs: Any) -> X509WorkloadIdentity:
+    return x509_workload_identity(
+        identity_provider_id="idp_123",
+        service_account_id="svc_acct_123",
+        **kwargs,
+    )
+
+
+def _token_response(
+    request: httpx2.Request, *, token: str = "access-token", expires_in: object = 3600
+) -> httpx2.Response:
+    return httpx2.Response(200, request=request, json={"access_token": token, "expires_in": expires_in})
+
+
+def _models_response(request: httpx2.Request, status_code: int = 200) -> httpx2.Response:
+    return httpx2.Response(status_code, request=request, json={"object": "list", "data": []})
+
+
+def test_x509_helper_returns_only_typed_identity_configuration() -> None:
+    assert _identity() == {
+        "type": "x509",
+        "identity_provider_id": "idp_123",
+        "service_account_id": "svc_acct_123",
+    }
+    assert _identity(refresh_buffer_seconds=45.0).get("refresh_buffer_seconds") == 45.0
+    assert "token_exchange_url" not in inspect.signature(x509_workload_identity).parameters
+
+
+@pytest.mark.parametrize("invalid_key", ["provider", "client_id"])
+def test_x509_rejects_subject_token_configuration(invalid_key: str) -> None:
+    identity = cast(X509WorkloadIdentity, {**_identity(), invalid_key: "not-allowed"})
+    with pytest.raises(OpenAIError, match="does not accept a subject-token provider or client ID"):
+        OpenAI(workload_identity=identity)
+
+
+@pytest.mark.parametrize(
+    "invalid_key",
+    ["certificate", "certificate_chain", "private_key", "password", "subject_token", "token_exchange_url"],
+)
+def test_x509_rejects_certificate_and_token_material_without_leaking_it(invalid_key: str) -> None:
+    secret = "certificate-or-token-material-never-visible"
+    identity = cast(X509WorkloadIdentity, {**_identity(), invalid_key: secret})
+    with pytest.raises(OpenAIError, match="only identity IDs and an optional refresh buffer") as error:
+        OpenAI(workload_identity=identity)
+    assert secret not in str(error.value)
+
+
+@pytest.mark.parametrize("refresh_buffer", [-1.0, float("inf"), float("nan"), True])
+def test_x509_rejects_invalid_refresh_buffer(refresh_buffer: float) -> None:
+    with pytest.raises(OpenAIError, match="finite, non-negative refresh buffer"):
+        OpenAI(workload_identity=_identity(refresh_buffer_seconds=refresh_buffer))
+
+
+def test_sync_x509_uses_one_transport_pinned_endpoint_and_cached_token() -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            return _token_response(request)
+        return _models_response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    client = OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0)
+    assert requests == []
+    assert str(client.base_url) == "https://mtls.api.openai.com/v1/"
+
+    assert client.models.list().object == "list"
+    assert client.models.list().object == "list"
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL, _API_URL]
+    assert json.loads(requests[0].content) == {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token_type": "urn:openai:params:oauth:token-type:x509",
+        "identity_provider_id": "idp_123",
+        "service_account_id": "svc_acct_123",
+    }
+    assert "subject_token" not in json.loads(requests[0].content)
+    assert [request.headers["authorization"] for request in requests[1:]] == ["Bearer access-token"] * 2
+    assert not http_client.is_closed
+    client.close()
+
+
+def test_sync_x509_does_not_mutate_or_independently_close_caller_transport() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return _token_response(request) if str(request.url) == _TOKEN_URL else _models_response(request)
+
+    tls_context = ssl.create_default_context(cafile=_MTLS_FIXTURES / "root.pem")
+    tls_context.load_cert_chain(_MTLS_FIXTURES / "client-chain.pem", _MTLS_FIXTURES / "client.key")
+    transport = httpx2.MockTransport(handler)
+    http_client = httpx2.Client(transport=transport, verify=tls_context, follow_redirects=True, trust_env=False)
+    initial_timeout = http_client.timeout
+    initial_headers = dict(http_client.headers)
+
+    client = OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0)
+    assert client.models.list().object == "list"
+    assert http_client._transport is transport
+    assert http_client.follow_redirects is True
+    assert http_client.timeout == initial_timeout
+    assert dict(http_client.headers) == initial_headers
+    assert not http_client.is_closed
+    auth = client._workload_identity_auth
+    assert auth is not None
+    assert all(not isinstance(value, ssl.SSLContext) for value in vars(auth).values())
+
+    client.close()
+    assert http_client.is_closed
+
+
+async def test_async_x509_uses_one_transport_without_threaded_exchange(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            return _token_response(request)
+        return _models_response(request)
+
+    async def reject_thread(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("X.509 exchange must not use a worker thread")
+
+    monkeypatch.setattr("openai.auth._workload.to_thread", reject_thread)
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert requests == []
+        assert str(client.base_url) == "https://mtls.api.openai.com/v1/"
+        assert (await client.models.list()).object == "list"
+        assert (await client.models.list()).object == "list"
+        assert not http_client.is_closed
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL, _API_URL]
+    assert "subject_token" not in json.loads(requests[0].content)
+
+
+async def test_async_x509_does_not_mutate_or_independently_close_caller_transport() -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return _token_response(request) if str(request.url) == _TOKEN_URL else _models_response(request)
+
+    tls_context = ssl.create_default_context(cafile=_MTLS_FIXTURES / "root.pem")
+    tls_context.load_cert_chain(_MTLS_FIXTURES / "client-chain.pem", _MTLS_FIXTURES / "client.key")
+    transport = httpx2.MockTransport(handler)
+    http_client = httpx2.AsyncClient(transport=transport, verify=tls_context, follow_redirects=True, trust_env=False)
+    initial_timeout = http_client.timeout
+    initial_headers = dict(http_client.headers)
+
+    client = AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0)
+    assert (await client.models.list()).object == "list"
+    assert http_client._transport is transport
+    assert http_client.follow_redirects is True
+    assert http_client.timeout == initial_timeout
+    assert dict(http_client.headers) == initial_headers
+    assert not http_client.is_closed
+    auth = client._workload_identity_auth
+    assert auth is not None
+    assert all(not isinstance(value, ssl.SSLContext) for value in vars(auth).values())
+
+    await client.close()
+    assert http_client.is_closed
+
+
+@pytest.mark.parametrize("base_url", ["https://custom.example/v1", "https://eu.api.openai.com/v1"])
+def test_x509_preserves_explicit_base_url(base_url: str) -> None:
+    client = OpenAI(workload_identity=_identity(), base_url=base_url)
+    assert str(client.base_url) == f"{base_url}/"
+    client.close()
+
+
+def test_x509_preserves_environment_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://custom.example/v1")
+    client = OpenAI(workload_identity=_identity())
+    assert str(client.base_url) == "https://custom.example/v1/"
+    client.close()
+
+
+def test_api_key_clients_keep_ordinary_api_endpoint() -> None:
+    with OpenAI(api_key="ordinary-api-key") as client:
+        assert str(client.base_url) == "https://api.openai.com/v1/"
+
+
+@pytest.mark.parametrize("expires_in", [0, -1, True, "3600", None])
+def test_x509_rejects_nonpositive_or_nonnumeric_expiration(expires_in: object) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return _token_response(request, expires_in=expires_in)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="expires_in"):
+            client.models.list()
+
+
+def test_x509_short_lived_token_clamps_refresh_buffer_to_half_ttl() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return _token_response(request, expires_in=8) if str(request.url) == _TOKEN_URL else _models_response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(refresh_buffer_seconds=1200), http_client=http_client) as client:
+        client.models.list()
+        auth = client._workload_identity_auth
+        assert auth is not None
+        assert auth._cached_token_expires_at_monotonic is not None
+        assert auth._cached_token_refresh_at_monotonic is not None
+        assert abs(auth._cached_token_expires_at_monotonic - auth._cached_token_refresh_at_monotonic - 4.0) < 0.001
+
+
+@pytest.mark.parametrize("deadline", ["_cached_token_expires_at_monotonic", "_cached_token_refresh_at_monotonic"])
+def test_sync_x509_refreshes_expired_or_proactively_stale_token(deadline: str) -> None:
+    token_count = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal token_count
+        if str(request.url) == _TOKEN_URL:
+            token_count += 1
+            return _token_response(request, token=f"token-{token_count}")
+        return _models_response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        client.models.list()
+        auth = client._workload_identity_auth
+        assert auth is not None
+        setattr(auth, deadline, 0.0)
+        client.models.list()
+
+    assert token_count == 2
+
+
+@pytest.mark.parametrize("deadline", ["_cached_token_expires_at_monotonic", "_cached_token_refresh_at_monotonic"])
+async def test_async_x509_refreshes_expired_or_proactively_stale_token(deadline: str) -> None:
+    token_count = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal token_count
+        if str(request.url) == _TOKEN_URL:
+            token_count += 1
+            return _token_response(request, token=f"token-{token_count}")
+        return _models_response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        await client.models.list()
+        auth = client._workload_identity_auth
+        assert auth is not None
+        setattr(auth, deadline, 0.0)
+        await client.models.list()
+
+    assert token_count == 2
+
+
+def test_sync_x509_concurrent_requests_share_one_exchange() -> None:
+    exchange_calls = 0
+    lock = threading.Lock()
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            with lock:
+                exchange_calls += 1
+            threading.Event().wait(0.03)
+            return _token_response(request)
+        return _models_response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+
+        def list_models(_: int) -> str:
+            return client.models.list().object
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            assert list(executor.map(list_models, range(8))) == ["list"] * 8
+
+    assert exchange_calls == 1
+
+
+async def test_async_x509_concurrent_requests_share_one_exchange() -> None:
+    exchange_calls = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            await anyio.sleep(0.03)
+            return _token_response(request)
+        return _models_response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        responses = await asyncio.gather(*(client.models.list() for _ in range(8)))
+
+    assert [response.object for response in responses] == ["list"] * 8
+    assert exchange_calls == 1
+
+
+async def test_async_x509_cancelled_waiter_does_not_cancel_shared_refresh() -> None:
+    exchange_started = anyio.Event()
+    finish_exchange = anyio.Event()
+    exchange_calls = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            exchange_started.set()
+            await finish_exchange.wait()
+            return _token_response(request)
+        return _models_response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+
+        async def list_models() -> str:
+            return (await client.models.list()).object
+
+        owner = asyncio.create_task(list_models())
+        await exchange_started.wait()
+        waiter = asyncio.create_task(list_models())
+        await anyio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+        finish_exchange.set()
+        assert await owner == "list"
+        assert (await client.models.list()).object == "list"
+
+    assert exchange_calls == 1
+
+
+async def test_async_x509_cancelled_refresh_owner_releases_waiters() -> None:
+    exchange_started = anyio.Event()
+    exchange_calls = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            if exchange_calls == 1:
+                exchange_started.set()
+                await anyio.Event().wait()
+            return _token_response(request)
+        return _models_response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+
+        async def list_models() -> str:
+            return (await client.models.list()).object
+
+        owner = asyncio.create_task(list_models())
+        await exchange_started.wait()
+        waiter = asyncio.create_task(list_models())
+        await anyio.sleep(0)
+        owner.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await owner
+        assert await waiter == "list"
+
+    assert exchange_calls == 2
+
+
+@pytest.mark.parametrize("status_code", [408, 409, 429, 500, 503])
+def test_sync_x509_retries_transient_exchange_and_honors_retry_after(
+    status_code: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    exchange_calls = 0
+    delays: list[float] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) != _TOKEN_URL:
+            return _models_response(request)
+        exchange_calls += 1
+        if exchange_calls == 1:
+            return httpx2.Response(status_code, request=request, headers={"retry-after": "0.25"})
+        return _token_response(request)
+
+    monkeypatch.setattr(x509_auth.time, "sleep", delays.append)
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=2) as client:
+        assert client.models.list().object == "list"
+
+    assert exchange_calls == 2
+    assert delays == [0.25]
+
+
+async def test_async_x509_retries_transient_exchange() -> None:
+    exchange_calls = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) != _TOKEN_URL:
+            return _models_response(request)
+        exchange_calls += 1
+        if exchange_calls == 1:
+            return httpx2.Response(429, request=request, headers={"retry-after": "0"})
+        return _token_response(request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=2) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert exchange_calls == 2
+
+
+async def test_async_x509_honors_retry_after_without_blocking(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchange_calls = 0
+    delays: list[float] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) != _TOKEN_URL:
+            return _models_response(request)
+        exchange_calls += 1
+        if exchange_calls == 1:
+            return httpx2.Response(429, request=request, headers={"retry-after": "0.25"})
+        return _token_response(request)
+
+    async def record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(x509_auth.anyio, "sleep", record_sleep)
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=2) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert delays == [0.25]
+
+
+def test_x509_exchange_retries_are_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    exchange_calls = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        exchange_calls += 1
+        return httpx2.Response(503, request=request)
+
+    def skip_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(x509_auth.time, "sleep", skip_sleep)
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=20) as client:
+        with pytest.raises(OpenAIError, match="status 503"):
+            client.models.list()
+
+    assert exchange_calls == 3
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_error"),
+    [(httpx2.ConnectError, APIConnectionError), (httpx2.ReadTimeout, APITimeoutError)],
+)
+def test_x509_connection_retries_are_bounded_without_outer_api_retries(
+    failure: type[httpx2.TransportError], expected_error: type[APIConnectionError], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    exchange_calls = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        exchange_calls += 1
+        raise failure("exchange unavailable", request=request)
+
+    def skip_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr(x509_auth.time, "sleep", skip_sleep)
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=20) as client:
+        with pytest.raises(expected_error) as error:
+            client.models.list()
+
+    assert isinstance(error.value.__cause__, failure)
+    assert exchange_calls == 3
+
+
+async def test_async_x509_exchange_connection_error_preserves_original_cause() -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ConnectError("exchange unavailable", request=request)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIConnectionError) as error:
+            await client.models.list()
+
+    assert isinstance(error.value.__cause__, httpx2.ConnectError)
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403])
+def test_x509_does_not_retry_oauth_failures(status_code: int) -> None:
+    exchange_calls = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        exchange_calls += 1
+        return httpx2.Response(status_code, request=request, json={"error": "invalid_grant"})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=2) as client:
+        with pytest.raises(OAuthError):
+            client.models.list()
+
+    assert exchange_calls == 1
+
+
+@pytest.mark.parametrize("status_code", [400, 401, 403])
+def test_x509_oauth_errors_redact_untrusted_descriptions(status_code: int, caplog: pytest.LogCaptureFixture) -> None:
+    token_secret = "bearer-token-never-visible"
+    certificate_secret = "certificate-subject-never-visible"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            status_code,
+            request=request,
+            json={
+                "error": "invalid_grant",
+                "error_description": f"{token_secret} {certificate_secret}",
+                "access_token": token_secret,
+            },
+        )
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with caplog.at_level(logging.DEBUG):
+        with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=2) as client:
+            with pytest.raises(OAuthError) as error:
+                client.models.list()
+
+    assert error.value.error == "invalid_grant"
+    assert error.value.body == {"error": "invalid_grant"}
+    assert token_secret not in str(error.value)
+    assert certificate_secret not in str(error.value)
+    assert token_secret not in caplog.text
+    assert certificate_secret not in caplog.text
+
+
+def test_x509_success_logs_and_auth_repr_do_not_leak_tokens(caplog: pytest.LogCaptureFixture) -> None:
+    token_secret = "bearer-token-never-visible"
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return (
+            _token_response(request, token=token_secret)
+            if str(request.url) == _TOKEN_URL
+            else _models_response(request)
+        )
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with caplog.at_level(logging.DEBUG):
+        with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+            assert client.models.list().object == "list"
+            assert token_secret not in repr(client._workload_identity_auth)
+
+    assert token_secret not in caplog.text
+
+
+def test_x509_never_falls_back_to_environment_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[httpx2.Request] = []
+    monkeypatch.setenv("OPENAI_API_KEY", "api-key-never-used")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(401, request=request, json={"error": "invalid_grant"})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OAuthError):
+            client.models.list()
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL]
+
+
+def test_x509_refuses_exchange_redirects_even_when_transport_follows_them() -> None:
+    urls: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        urls.append(str(request.url))
+        return httpx2.Response(302, request=request, headers={"location": "https://other.example/oauth/token"})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), follow_redirects=True, trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="status 302"):
+            client.models.list()
+
+    assert urls == [_TOKEN_URL]
+
+
+def test_x509_refuses_api_redirects_even_when_transport_follows_them() -> None:
+    urls: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        urls.append(str(request.url))
+        if str(request.url) == _TOKEN_URL:
+            return _token_response(request)
+        return httpx2.Response(302, request=request, headers={"location": "https://other.example/v1/models"})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), follow_redirects=True, trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError):
+            client.models.list()
+
+    assert urls == [_TOKEN_URL, _API_URL]
+
+
+def test_sync_x509_retries_replayable_401_request_once() -> None:
+    requests: list[httpx2.Request] = []
+    api_authorizations: list[str] = []
+    token_count = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal token_count
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            token_count += 1
+            return _token_response(request, token=f"token-{token_count}")
+        api_authorizations.append(request.headers["authorization"])
+        return _models_response(request, 401 if token_count == 1 else 200)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL, _TOKEN_URL, _API_URL]
+    assert api_authorizations == ["Bearer token-1", "Bearer token-2"]
+
+
+async def test_async_x509_retries_replayable_401_request_once() -> None:
+    api_authorizations: list[str] = []
+    token_count = 0
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal token_count
+        if str(request.url) == _TOKEN_URL:
+            token_count += 1
+            return _token_response(request, token=f"token-{token_count}")
+        api_authorizations.append(request.headers["authorization"])
+        return _models_response(request, 401 if token_count == 1 else 200)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert api_authorizations == ["Bearer token-1", "Bearer token-2"]
+
+
+@pytest.mark.parametrize("seekable", [True, False])
+def test_sync_x509_401_retries_only_replayable_uploads(seekable: bool) -> None:
+    requests: list[httpx2.Request] = []
+
+    class Upload(io.BytesIO):
+        @override
+        def seekable(self) -> bool:
+            return seekable
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            return _token_response(request, token=f"token-{len(requests)}")
+        return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError):
+            client.files.create(file=("document.txt", Upload(b"contents")), purpose="assistants")
+
+    assert len(requests) == (4 if seekable else 2)
+
+
+def test_sync_x509_rewinds_seekable_request_stream_to_its_original_position() -> None:
+    request_bodies: list[bytes] = []
+    token_count = 0
+
+    class StreamingTransport(httpx2.BaseTransport):
+        @override
+        def handle_request(self, request: httpx2.Request) -> httpx2.Response:
+            nonlocal token_count
+            if str(request.url) == _TOKEN_URL:
+                token_count += 1
+                return _token_response(request, token=f"token-{token_count}")
+
+            request_bodies.append(b"".join(cast(Iterable[bytes], request.stream)))
+            return _models_response(request, 401 if token_count == 1 else 200)
+
+    stream = io.BytesIO(b"prefix-body")
+    stream.seek(len(b"prefix-"))
+    request = httpx2.Request(
+        "POST",
+        _API_URL,
+        content=stream,
+        headers={"authorization": f"Bearer {WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}"},
+    )
+    http_client = httpx2.Client(transport=StreamingTransport(), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        response = client._send_request(request, stream=False)
+
+    assert response.status_code == 200
+    assert request_bodies == [b"body", b"body"]
+
+
+@pytest.mark.parametrize("seekable", [True, False])
+async def test_async_x509_401_retries_only_replayable_uploads(seekable: bool) -> None:
+    requests: list[httpx2.Request] = []
+
+    class Upload(io.BytesIO):
+        @override
+        def seekable(self) -> bool:
+            return seekable
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            return _token_response(request, token=f"token-{len(requests)}")
+        return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError):
+            await client.files.create(file=("document.txt", Upload(b"contents")), purpose="assistants")
+
+    assert len(requests) == (4 if seekable else 2)
+
+
+def test_x509_does_not_retry_one_shot_sync_request_stream() -> None:
+    def chunks() -> Iterator[bytes]:
+        yield b"body"
+
+    request = httpx2.Request("POST", _API_URL, content=chunks())
+    assert not x509_auth._is_replayable_request(request)
+
+
+async def test_x509_does_not_retry_one_shot_async_request_stream() -> None:
+    async def chunks() -> AsyncIterator[bytes]:
+        yield b"body"
+
+    request = httpx2.Request("POST", _API_URL, content=chunks())
+    assert not x509_auth._is_replayable_request(request)
+
+
+@pytest.mark.skipif(os.getenv("OPENAI_TEST_LEGACY_HTTPX") != "1", reason="requires legacy HTTPX compatibility lane")
+def test_sync_x509_reuses_legacy_httpx_transport() -> None:
+    httpx = cast(Any, importlib.import_module("httpx"))
+    requests: list[Any] = []
+
+    def handler(request: Any) -> Any:
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            return httpx.Response(200, request=request, json={"access_token": "legacy-token", "expires_in": 3600})
+        return httpx.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx.Client(transport=httpx.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL]
+
+
+@pytest.mark.skipif(os.getenv("OPENAI_TEST_LEGACY_HTTPX") != "1", reason="requires legacy HTTPX compatibility lane")
+async def test_async_x509_reuses_legacy_httpx_transport() -> None:
+    httpx = cast(Any, importlib.import_module("httpx"))
+    requests: list[Any] = []
+
+    async def handler(request: Any) -> Any:
+        requests.append(request)
+        if str(request.url) == _TOKEN_URL:
+            return httpx.Response(200, request=request, json={"access_token": "legacy-token", "expires_in": 3600})
+        return httpx.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx.AsyncClient(transport=httpx.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert [str(request.url) for request in requests] == [_TOKEN_URL, _API_URL]
+
+
+def test_x509_copy_reuses_effective_transport_and_preserves_identity() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return _token_response(request) if str(request.url) == _TOKEN_URL else _models_response(request)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    client = OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0)
+    copied = client.with_options()
+    assert copied._client is http_client
+    assert copied.workload_identity == client.workload_identity
+    assert copied.models.list().object == "list"
+    client.close()
+
+
+@pytest.mark.parametrize("example", ["x509_workload_identity.py", "x509_workload_identity_async.py"])
+@pytest.mark.parametrize("mode", ["api_key", "x509"])
+def test_x509_rollout_examples_construct_clients_without_network(
+    example: str, mode: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_AUTH_MODE", mode)
+    monkeypatch.setenv("OPENAI_API_KEY", "example-api-key")
+    monkeypatch.setenv("OPENAI_IDENTITY_PROVIDER_ID", "idp_example")
+    monkeypatch.setenv("OPENAI_SERVICE_ACCOUNT_ID", "svc_acct_example")
+    monkeypatch.setenv("OPENAI_MTLS_CA_BUNDLE", str(_MTLS_FIXTURES / "root.pem"))
+    monkeypatch.setenv("OPENAI_MTLS_CERTIFICATE_CHAIN", str(_MTLS_FIXTURES / "client-chain.pem"))
+    monkeypatch.setenv("OPENAI_MTLS_PRIVATE_KEY", str(_MTLS_FIXTURES / "client.key"))
+
+    namespace = runpy.run_path(str(Path(__file__).parent.parent / "examples" / example))
+    create_client = cast(Callable[[], OpenAI | AsyncOpenAI], namespace["create_client"])
+    client = create_client()
+    if mode == "x509":
+        assert client.workload_identity == {
+            "type": "x509",
+            "identity_provider_id": "idp_example",
+            "service_account_id": "svc_acct_example",
+        }
+        assert client._client.follow_redirects is False
+    else:
+        assert client.api_key == "example-api-key"
+
+    if isinstance(client, OpenAI):
+        client.close()
+    else:
+        anyio.run(client.close)

--- a/tests/test_x509_workload_identity.py
+++ b/tests/test_x509_workload_identity.py
@@ -76,7 +76,7 @@ def test_x509_rejects_certificate_and_token_material_without_leaking_it(invalid_
     assert secret not in str(error.value)
 
 
-@pytest.mark.parametrize("refresh_buffer", [-1.0, float("inf"), float("nan"), True])
+@pytest.mark.parametrize("refresh_buffer", [-1.0, float("inf"), float("nan"), True, 10**400])
 def test_x509_rejects_invalid_refresh_buffer(refresh_buffer: float) -> None:
     with pytest.raises(OpenAIError, match="finite, non-negative refresh buffer"):
         OpenAI(workload_identity=_identity(refresh_buffer_seconds=refresh_buffer))
@@ -207,7 +207,7 @@ def test_api_key_clients_keep_ordinary_api_endpoint() -> None:
         assert str(client.base_url) == "https://api.openai.com/v1/"
 
 
-@pytest.mark.parametrize("expires_in", [0, -1, True, "3600", None])
+@pytest.mark.parametrize("expires_in", [0, -1, True, "3600", None, 10**400])
 def test_x509_rejects_nonpositive_or_nonnumeric_expiration(expires_in: object) -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:
         return _token_response(request, expires_in=expires_in)

--- a/tests/test_x509_workload_identity.py
+++ b/tests/test_x509_workload_identity.py
@@ -345,8 +345,8 @@ async def test_async_x509_cancelled_waiter_does_not_cancel_shared_refresh() -> N
         waiter = asyncio.create_task(list_models())
         await anyio.sleep(0)
         waiter.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await waiter
+        await asyncio.gather(waiter, return_exceptions=True)
+        assert waiter.cancelled()
         finish_exchange.set()
         assert await owner == "list"
         assert (await client.models.list()).object == "list"
@@ -379,8 +379,8 @@ async def test_async_x509_cancelled_refresh_owner_releases_waiters() -> None:
         waiter = asyncio.create_task(list_models())
         await anyio.sleep(0)
         owner.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await owner
+        await asyncio.gather(owner, return_exceptions=True)
+        assert owner.cancelled()
         assert await waiter == "list"
 
     assert exchange_calls == 2

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -380,7 +380,7 @@ def test_sync_x509_exchange_does_not_inherit_caller_request_state() -> None:
         transport=httpx2.MockTransport(handler),
         headers={
             "Authorization": "Bearer private-api-credential",
-            "X-API-Key": "private-api-credential",
+            "X-Customer-Metadata": "private-api-metadata",
             "Content-Type": "application/private",
         },
         cookies={"session": "private-cookie"},
@@ -391,12 +391,12 @@ def test_sync_x509_exchange_does_not_inherit_caller_request_state() -> None:
 
     assert len(exchange_headers) == 1
     assert exchange_headers[0].get("Authorization") is None
-    assert exchange_headers[0].get("X-API-Key") is None
+    assert exchange_headers[0].get("X-Customer-Metadata") is None
     assert exchange_headers[0].get("Cookie") is None
     assert exchange_headers[0]["Content-Type"] == "application/json"
     assert len(api_headers) == 1
     assert api_headers[0]["Authorization"] == "Bearer safe-token"
-    assert api_headers[0]["X-API-Key"] == "private-api-credential"
+    assert api_headers[0]["X-Customer-Metadata"] == "private-api-metadata"
     assert api_headers[0]["Cookie"] == "session=private-cookie"
     assert api_headers[0]["Content-Type"] == "application/private"
 
@@ -416,7 +416,7 @@ async def test_async_x509_exchange_does_not_inherit_caller_request_state() -> No
         transport=httpx2.MockTransport(handler),
         headers={
             "Authorization": "Bearer private-api-credential",
-            "X-API-Key": "private-api-credential",
+            "X-Customer-Metadata": "private-api-metadata",
             "Content-Type": "application/private",
         },
         cookies={"session": "private-cookie"},
@@ -427,12 +427,12 @@ async def test_async_x509_exchange_does_not_inherit_caller_request_state() -> No
 
     assert len(exchange_headers) == 1
     assert exchange_headers[0].get("Authorization") is None
-    assert exchange_headers[0].get("X-API-Key") is None
+    assert exchange_headers[0].get("X-Customer-Metadata") is None
     assert exchange_headers[0].get("Cookie") is None
     assert exchange_headers[0]["Content-Type"] == "application/json"
     assert len(api_headers) == 1
     assert api_headers[0]["Authorization"] == "Bearer safe-token"
-    assert api_headers[0]["X-API-Key"] == "private-api-credential"
+    assert api_headers[0]["X-Customer-Metadata"] == "private-api-metadata"
     assert api_headers[0]["Cookie"] == "session=private-cookie"
     assert api_headers[0]["Content-Type"] == "application/private"
 

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -114,7 +114,7 @@ async def test_async_copy_accepts_an_explicit_x509_identity(method: str) -> None
 
 
 @pytest.mark.parametrize("method", ["copy", "with_options"])
-@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1", "https://api.openai.com/v1"])
 def test_sync_copy_can_switch_from_api_key_to_x509_identity(method: str, base_url: str | None) -> None:
     api_authorizations: list[str] = []
 
@@ -141,7 +141,7 @@ def test_sync_copy_can_switch_from_api_key_to_x509_identity(method: str, base_ur
 
 
 @pytest.mark.parametrize("method", ["copy", "with_options"])
-@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1", "https://api.openai.com/v1"])
 async def test_async_copy_can_switch_from_api_key_to_x509_identity(method: str, base_url: str | None) -> None:
     api_authorizations: list[str] = []
 
@@ -170,7 +170,7 @@ async def test_async_copy_can_switch_from_api_key_to_x509_identity(method: str, 
 
 
 @pytest.mark.parametrize("method", ["copy", "with_options"])
-@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1", "https://mtls.api.openai.com/v1"])
 def test_sync_copy_can_switch_from_x509_identity_to_api_key(method: str, base_url: str | None) -> None:
     requests: list[httpx2.Request] = []
 
@@ -197,7 +197,7 @@ def test_sync_copy_can_switch_from_x509_identity_to_api_key(method: str, base_ur
 
 
 @pytest.mark.parametrize("method", ["copy", "with_options"])
-@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1", "https://mtls.api.openai.com/v1"])
 async def test_async_copy_can_switch_from_x509_identity_to_api_key(method: str, base_url: str | None) -> None:
     requests: list[httpx2.Request] = []
 
@@ -223,6 +223,22 @@ async def test_async_copy_can_switch_from_x509_identity_to_api_key(method: str, 
 
     assert len(requests) == 1
     assert requests[0].headers["Authorization"] == "Bearer replacement-api-key"
+
+
+def test_sync_copy_preserves_implicit_base_url_provenance_across_chained_copies() -> None:
+    http_client = httpx2.Client(trust_env=False)
+    with OpenAI(api_key="original-api-key", http_client=http_client) as client:
+        copied = client.copy(timeout=1).copy(workload_identity=_identity())
+
+    assert str(copied.base_url) == "https://mtls.api.openai.com/v1/"
+
+
+async def test_async_copy_preserves_implicit_base_url_provenance_across_chained_copies() -> None:
+    http_client = httpx2.AsyncClient(trust_env=False)
+    async with AsyncOpenAI(api_key="original-api-key", http_client=http_client) as client:
+        copied = client.copy(timeout=1).copy(workload_identity=_identity())
+
+    assert str(copied.base_url) == "https://mtls.api.openai.com/v1/"
 
 
 @pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import asyncio
 import threading
-from typing import get_args, get_type_hints
+from typing import cast, get_args, get_type_hints
 from typing_extensions import override
 from concurrent.futures import ThreadPoolExecutor
 
@@ -43,6 +43,33 @@ def test_x509_auth_initializes_its_typed_common_superclass(client_type: type[Ope
 def test_copy_signatures_accept_typed_x509_workload_identities(client_type: type[OpenAI] | type[AsyncOpenAI]) -> None:
     assert X509WorkloadIdentity in get_args(get_type_hints(client_type.copy)["workload_identity"])
     assert X509WorkloadIdentity in get_args(get_type_hints(client_type.with_options)["workload_identity"])
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {"identity_provider_id": "idp_123", "service_account_id": "svc_acct_123"},
+        {"type": "x590", "identity_provider_id": "idp_123", "service_account_id": "svc_acct_123"},
+        {},
+    ],
+)
+def test_client_rejects_unrecognized_workload_identity_shapes(
+    client_type: type[OpenAI] | type[AsyncOpenAI], identity: dict[str, str]
+) -> None:
+    with pytest.raises(OpenAIError, match="Invalid `workload_identity` configuration"):
+        client_type(workload_identity=cast(X509WorkloadIdentity, identity))
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize("missing_key", ["identity_provider_id", "service_account_id"])
+def test_client_rejects_x509_identity_missing_a_required_id(
+    client_type: type[OpenAI] | type[AsyncOpenAI], missing_key: str
+) -> None:
+    identity = {key: value for key, value in _identity().items() if key != missing_key}
+
+    with pytest.raises(OpenAIError, match="requires identity-provider and service-account IDs"):
+        client_type(workload_identity=cast(X509WorkloadIdentity, identity))
 
 
 @pytest.mark.parametrize("method", ["copy", "with_options"])
@@ -119,6 +146,46 @@ async def test_async_x509_disables_redirects_without_placeholder_authorization(a
 
     assert response.status_code == 302
     assert urls == [_API_URL]
+
+
+def test_sync_x509_exchange_does_not_inherit_caller_http_auth() -> None:
+    exchange_authorizations: list[str | None] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            exchange_authorizations.append(request.headers.get("Authorization"))
+            return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler),
+        auth=httpx2.BasicAuth("caller", "private-api-credential"),
+        trust_env=False,
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+
+    assert exchange_authorizations == [None]
+
+
+async def test_async_x509_exchange_does_not_inherit_caller_http_auth() -> None:
+    exchange_authorizations: list[str | None] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            exchange_authorizations.append(request.headers.get("Authorization"))
+            return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler),
+        auth=httpx2.BasicAuth("caller", "private-api-credential"),
+        trust_env=False,
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert exchange_authorizations == [None]
 
 
 @pytest.mark.parametrize("response_body", [[], "not-an-object", 42, True])
@@ -206,6 +273,60 @@ async def test_async_x509_invalidates_rejected_token_without_replaying_one_shot_
     assert uploaded.id == "file_123"
     assert exchange_calls == 2
     assert api_authorizations == ["Bearer token-1", "Bearer token-2"]
+
+
+def test_sync_x509_invalidates_a_rejected_replay_token() -> None:
+    exchange_calls = 0
+    api_authorizations: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            return httpx2.Response(
+                200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+            )
+
+        api_authorizations.append(request.headers["Authorization"])
+        if exchange_calls < 3:
+            return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError, match="401"):
+            client.models.list()
+        assert client.models.list().object == "list"
+
+    assert exchange_calls == 3
+    assert api_authorizations == ["Bearer token-1", "Bearer token-2", "Bearer token-3"]
+
+
+async def test_async_x509_invalidates_a_rejected_replay_token() -> None:
+    exchange_calls = 0
+    api_authorizations: list[str] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            return httpx2.Response(
+                200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+            )
+
+        api_authorizations.append(request.headers["Authorization"])
+        if exchange_calls < 3:
+            return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError, match="401"):
+            await client.models.list()
+        assert (await client.models.list()).object == "list"
+
+    assert exchange_calls == 3
+    assert api_authorizations == ["Bearer token-1", "Bearer token-2", "Bearer token-3"]
 
 
 def test_sync_x509_concurrent_stale_401_responses_share_one_replacement_token() -> None:

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -169,6 +169,62 @@ async def test_async_copy_can_switch_from_api_key_to_x509_identity(method: str, 
     assert api_authorizations == ["Bearer switched-token"]
 
 
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+def test_sync_copy_can_switch_from_x509_identity_to_api_key(method: str, base_url: str | None) -> None:
+    requests: list[httpx2.Request] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), base_url=base_url, http_client=http_client, max_retries=0) as client:
+        copied = (
+            client.copy(api_key="replacement-api-key")
+            if method == "copy"
+            else client.with_options(api_key="replacement-api-key")
+        )
+        assert client.workload_identity == _identity()
+        assert copied.workload_identity is None
+        assert copied.api_key == "replacement-api-key"
+        assert str(copied.base_url) == f"{base_url or 'https://api.openai.com/v1'}/"
+        assert copied._client is http_client
+        assert copied.models.list().object == "list"
+
+    assert len(requests) == 1
+    assert requests[0].headers["Authorization"] == "Bearer replacement-api-key"
+
+
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+async def test_async_copy_can_switch_from_x509_identity_to_api_key(method: str, base_url: str | None) -> None:
+    requests: list[httpx2.Request] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(
+        workload_identity=_identity(), base_url=base_url, http_client=http_client, max_retries=0
+    ) as client:
+        copied = (
+            client.copy(api_key="replacement-api-key")
+            if method == "copy"
+            else client.with_options(api_key="replacement-api-key")
+        )
+        assert client.workload_identity == _identity()
+        assert copied.workload_identity is None
+        assert copied.api_key == "replacement-api-key"
+        assert str(copied.base_url) == f"{base_url or 'https://api.openai.com/v1'}/"
+        assert copied._client is http_client
+        assert (await copied.models.list()).object == "list"
+
+    assert len(requests) == 1
+    assert requests[0].headers["Authorization"] == "Bearer replacement-api-key"
+
+
 @pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])
 def test_sync_x509_disables_redirects_without_placeholder_authorization(authorization: str | None) -> None:
     urls: list[str] = []

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -241,6 +241,48 @@ async def test_async_copy_preserves_implicit_base_url_provenance_across_chained_
     assert str(copied.base_url) == "https://mtls.api.openai.com/v1/"
 
 
+@pytest.mark.parametrize("starts_with_x509", [False, True])
+def test_sync_copy_preserves_base_url_assigned_through_setter(starts_with_x509: bool) -> None:
+    http_client = httpx2.Client(trust_env=False)
+    client = (
+        OpenAI(workload_identity=_identity(), http_client=http_client)
+        if starts_with_x509
+        else OpenAI(api_key="original-api-key", http_client=http_client)
+    )
+    with client:
+        client.base_url = "https://assigned.example/v1"
+        same_mode_copy = client.copy(timeout=1)
+        copied = (
+            same_mode_copy.copy(api_key="replacement-api-key")
+            if starts_with_x509
+            else same_mode_copy.copy(workload_identity=_identity())
+        )
+
+    assert str(same_mode_copy.base_url) == "https://assigned.example/v1/"
+    assert str(copied.base_url) == "https://assigned.example/v1/"
+
+
+@pytest.mark.parametrize("starts_with_x509", [False, True])
+async def test_async_copy_preserves_base_url_assigned_through_setter(starts_with_x509: bool) -> None:
+    http_client = httpx2.AsyncClient(trust_env=False)
+    client = (
+        AsyncOpenAI(workload_identity=_identity(), http_client=http_client)
+        if starts_with_x509
+        else AsyncOpenAI(api_key="original-api-key", http_client=http_client)
+    )
+    async with client:
+        client.base_url = "https://assigned.example/v1"
+        same_mode_copy = client.copy(timeout=1)
+        copied = (
+            same_mode_copy.copy(api_key="replacement-api-key")
+            if starts_with_x509
+            else same_mode_copy.copy(workload_identity=_identity())
+        )
+
+    assert str(same_mode_copy.base_url) == "https://assigned.example/v1/"
+    assert str(copied.base_url) == "https://assigned.example/v1/"
+
+
 @pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])
 def test_sync_x509_disables_redirects_without_placeholder_authorization(authorization: str | None) -> None:
     urls: list[str] = []
@@ -323,50 +365,76 @@ async def test_async_x509_exchange_does_not_inherit_caller_http_auth() -> None:
     assert api_authorizations == ["Bearer safe-token"]
 
 
-def test_sync_x509_exchange_does_not_inherit_caller_authorization_header() -> None:
-    exchange_authorizations: list[str | None] = []
-    api_authorizations: list[str | None] = []
+def test_sync_x509_exchange_does_not_inherit_caller_request_state() -> None:
+    exchange_headers: list[httpx2.Headers] = []
+    api_headers: list[httpx2.Headers] = []
 
     def handler(request: httpx2.Request) -> httpx2.Response:
         if str(request.url) == _TOKEN_URL:
-            exchange_authorizations.append(request.headers.get("Authorization"))
+            exchange_headers.append(request.headers)
             return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
-        api_authorizations.append(request.headers.get("Authorization"))
+        api_headers.append(request.headers)
         return httpx2.Response(200, request=request, json={"object": "list", "data": []})
 
     http_client = httpx2.Client(
         transport=httpx2.MockTransport(handler),
-        headers={"Authorization": "Bearer private-api-credential"},
+        headers={
+            "Authorization": "Bearer private-api-credential",
+            "X-API-Key": "private-api-credential",
+            "Content-Type": "application/private",
+        },
+        cookies={"session": "private-cookie"},
         trust_env=False,
     )
     with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
         assert client.models.list().object == "list"
 
-    assert exchange_authorizations == [None]
-    assert api_authorizations == ["Bearer safe-token"]
+    assert len(exchange_headers) == 1
+    assert exchange_headers[0].get("Authorization") is None
+    assert exchange_headers[0].get("X-API-Key") is None
+    assert exchange_headers[0].get("Cookie") is None
+    assert exchange_headers[0]["Content-Type"] == "application/json"
+    assert len(api_headers) == 1
+    assert api_headers[0]["Authorization"] == "Bearer safe-token"
+    assert api_headers[0]["X-API-Key"] == "private-api-credential"
+    assert api_headers[0]["Cookie"] == "session=private-cookie"
+    assert api_headers[0]["Content-Type"] == "application/private"
 
 
-async def test_async_x509_exchange_does_not_inherit_caller_authorization_header() -> None:
-    exchange_authorizations: list[str | None] = []
-    api_authorizations: list[str | None] = []
+async def test_async_x509_exchange_does_not_inherit_caller_request_state() -> None:
+    exchange_headers: list[httpx2.Headers] = []
+    api_headers: list[httpx2.Headers] = []
 
     async def handler(request: httpx2.Request) -> httpx2.Response:
         if str(request.url) == _TOKEN_URL:
-            exchange_authorizations.append(request.headers.get("Authorization"))
+            exchange_headers.append(request.headers)
             return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
-        api_authorizations.append(request.headers.get("Authorization"))
+        api_headers.append(request.headers)
         return httpx2.Response(200, request=request, json={"object": "list", "data": []})
 
     http_client = httpx2.AsyncClient(
         transport=httpx2.MockTransport(handler),
-        headers={"Authorization": "Bearer private-api-credential"},
+        headers={
+            "Authorization": "Bearer private-api-credential",
+            "X-API-Key": "private-api-credential",
+            "Content-Type": "application/private",
+        },
+        cookies={"session": "private-cookie"},
         trust_env=False,
     )
     async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
         assert (await client.models.list()).object == "list"
 
-    assert exchange_authorizations == [None]
-    assert api_authorizations == ["Bearer safe-token"]
+    assert len(exchange_headers) == 1
+    assert exchange_headers[0].get("Authorization") is None
+    assert exchange_headers[0].get("X-API-Key") is None
+    assert exchange_headers[0].get("Cookie") is None
+    assert exchange_headers[0]["Content-Type"] == "application/json"
+    assert len(api_headers) == 1
+    assert api_headers[0]["Authorization"] == "Bearer safe-token"
+    assert api_headers[0]["X-API-Key"] == "private-api-credential"
+    assert api_headers[0]["Cookie"] == "session=private-cookie"
+    assert api_headers[0]["Content-Type"] == "application/private"
 
 
 @pytest.mark.parametrize("response_body", [[], "not-an-object", 42, True])

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import io
 import asyncio
 import threading
+from typing import get_args, get_type_hints
+from typing_extensions import override
 from concurrent.futures import ThreadPoolExecutor
 
 import anyio
 import httpx2
 import pytest
 
-from openai import OpenAI, AsyncOpenAI, OpenAIError
+from openai import OpenAI, AsyncOpenAI, OpenAIError, APIStatusError
 from openai.auth import X509WorkloadIdentity, x509_workload_identity
 from openai.auth._workload import _WorkloadIdentityAuth
 
@@ -34,6 +37,52 @@ def test_x509_auth_initializes_its_typed_common_superclass(client_type: type[Ope
         client.close()
     else:
         anyio.run(client.close)
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+def test_copy_signatures_accept_typed_x509_workload_identities(client_type: type[OpenAI] | type[AsyncOpenAI]) -> None:
+    assert X509WorkloadIdentity in get_args(get_type_hints(client_type.copy)["workload_identity"])
+    assert X509WorkloadIdentity in get_args(get_type_hints(client_type.with_options)["workload_identity"])
+
+
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+def test_sync_copy_accepts_an_explicit_x509_identity(method: str) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            return httpx2.Response(200, request=request, json={"access_token": "copied-token", "expires_in": 3600})
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    replacement = x509_workload_identity(identity_provider_id="idp_replacement", service_account_id="svc_replacement")
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        copied = (
+            client.copy(workload_identity=replacement)
+            if method == "copy"
+            else client.with_options(workload_identity=replacement)
+        )
+        assert copied.workload_identity == replacement
+        assert copied._client is http_client
+        assert copied.models.list().object == "list"
+
+
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+async def test_async_copy_accepts_an_explicit_x509_identity(method: str) -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            return httpx2.Response(200, request=request, json={"access_token": "copied-token", "expires_in": 3600})
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    replacement = x509_workload_identity(identity_provider_id="idp_replacement", service_account_id="svc_replacement")
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        copied = (
+            client.copy(workload_identity=replacement)
+            if method == "copy"
+            else client.with_options(workload_identity=replacement)
+        )
+        assert copied.workload_identity == replacement
+        assert copied._client is http_client
+        assert (await copied.models.list()).object == "list"
 
 
 @pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])
@@ -92,6 +141,71 @@ async def test_async_x509_rejects_non_object_token_responses(response_body: obje
     async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
         with pytest.raises(OpenAIError, match="response body was not a JSON object"):
             await client.models.list()
+
+
+def test_sync_x509_invalidates_rejected_token_without_replaying_one_shot_upload() -> None:
+    exchange_calls = 0
+    api_authorizations: list[str] = []
+
+    class OneShotUpload(io.BytesIO):
+        @override
+        def seekable(self) -> bool:
+            return False
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            return httpx2.Response(
+                200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+            )
+
+        api_authorizations.append(request.headers["Authorization"])
+        if exchange_calls == 1:
+            return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+        return httpx2.Response(200, request=request, json={"id": "file_123", "object": "file"})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError):
+            client.files.create(file=("first.txt", OneShotUpload(b"first")), purpose="assistants")
+        assert client.files.create(file=("second.txt", OneShotUpload(b"second")), purpose="assistants").id == "file_123"
+
+    assert exchange_calls == 2
+    assert api_authorizations == ["Bearer token-1", "Bearer token-2"]
+
+
+async def test_async_x509_invalidates_rejected_token_without_replaying_one_shot_upload() -> None:
+    exchange_calls = 0
+    api_authorizations: list[str] = []
+
+    class OneShotUpload(io.BytesIO):
+        @override
+        def seekable(self) -> bool:
+            return False
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            return httpx2.Response(
+                200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+            )
+
+        api_authorizations.append(request.headers["Authorization"])
+        if exchange_calls == 1:
+            return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+        return httpx2.Response(200, request=request, json={"id": "file_123", "object": "file"})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(APIStatusError):
+            await client.files.create(file=("first.txt", OneShotUpload(b"first")), purpose="assistants")
+        uploaded = await client.files.create(file=("second.txt", OneShotUpload(b"second")), purpose="assistants")
+
+    assert uploaded.id == "file_123"
+    assert exchange_calls == 2
+    assert api_authorizations == ["Bearer token-1", "Bearer token-2"]
 
 
 def test_sync_x509_concurrent_stale_401_responses_share_one_replacement_token() -> None:

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import anyio
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI, OpenAIError
+from openai.auth import X509WorkloadIdentity, x509_workload_identity
+
+_TOKEN_URL = "https://mtls.auth.openai.com/oauth/token"
+_API_URL = "https://mtls.api.openai.com/v1/models"
+
+
+def _identity() -> X509WorkloadIdentity:
+    return x509_workload_identity(identity_provider_id="idp_123", service_account_id="svc_acct_123")
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])
+def test_sync_x509_disables_redirects_without_placeholder_authorization(authorization: str | None) -> None:
+    urls: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        urls.append(str(request.url))
+        return httpx2.Response(302, request=request, headers={"location": "https://other.example/v1/models"})
+
+    headers = {} if authorization is None else {"Authorization": authorization}
+    request = httpx2.Request("GET", _API_URL, headers=headers)
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), follow_redirects=True, trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        response = client._send_request(request, stream=False)
+
+    assert response.status_code == 302
+    assert urls == [_API_URL]
+
+
+@pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])
+async def test_async_x509_disables_redirects_without_placeholder_authorization(authorization: str | None) -> None:
+    urls: list[str] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        urls.append(str(request.url))
+        return httpx2.Response(302, request=request, headers={"location": "https://other.example/v1/models"})
+
+    headers = {} if authorization is None else {"Authorization": authorization}
+    request = httpx2.Request("GET", _API_URL, headers=headers)
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), follow_redirects=True, trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        response = await client._send_request(request, stream=False)
+
+    assert response.status_code == 302
+    assert urls == [_API_URL]
+
+
+@pytest.mark.parametrize("response_body", [[], "not-an-object", 42, True])
+def test_sync_x509_rejects_non_object_token_responses(response_body: object) -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, request=request, json=response_body)
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="response body was not a JSON object"):
+            client.models.list()
+
+
+@pytest.mark.parametrize("response_body", [[], "not-an-object", 42, True])
+async def test_async_x509_rejects_non_object_token_responses(response_body: object) -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, request=request, json=response_body)
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        with pytest.raises(OpenAIError, match="response body was not a JSON object"):
+            await client.models.list()
+
+
+def test_sync_x509_concurrent_stale_401_responses_share_one_replacement_token() -> None:
+    exchange_calls = 0
+    stale_requests = 0
+    state_lock = threading.Lock()
+    both_stale_requests = threading.Barrier(2)
+    replacement_issued = threading.Event()
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls, stale_requests
+        if str(request.url) == _TOKEN_URL:
+            with state_lock:
+                exchange_calls += 1
+                token_number = exchange_calls
+            if token_number == 2:
+                replacement_issued.set()
+            return httpx2.Response(
+                200, request=request, json={"access_token": f"token-{token_number}", "expires_in": 3600}
+            )
+
+        authorization = request.headers["Authorization"]
+        if authorization == "Bearer token-1":
+            with state_lock:
+                stale_requests += 1
+                request_number = stale_requests
+            both_stale_requests.wait(timeout=5)
+            if request_number == 2:
+                assert replacement_issued.wait(timeout=5)
+            return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+
+        assert authorization == "Bearer token-2"
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+
+        def list_models(_: int) -> str:
+            return client.models.list().object
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            responses = list(executor.map(list_models, range(2)))
+
+    assert responses == ["list", "list"]
+    assert exchange_calls == 2
+
+
+async def test_async_x509_concurrent_stale_401_responses_share_one_replacement_token() -> None:
+    exchange_calls = 0
+    stale_requests = 0
+    both_stale_requests = anyio.Event()
+    replacement_issued = anyio.Event()
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal exchange_calls, stale_requests
+        if str(request.url) == _TOKEN_URL:
+            exchange_calls += 1
+            if exchange_calls == 2:
+                replacement_issued.set()
+            return httpx2.Response(
+                200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+            )
+
+        authorization = request.headers["Authorization"]
+        if authorization == "Bearer token-1":
+            stale_requests += 1
+            request_number = stale_requests
+            if stale_requests == 2:
+                both_stale_requests.set()
+            await both_stale_requests.wait()
+            if request_number == 2:
+                await replacement_issued.wait()
+            return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+
+        assert authorization == "Bearer token-2"
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        responses = await asyncio.gather(client.models.list(), client.models.list())
+
+    assert [response.object for response in responses] == ["list", "list"]
+    assert exchange_calls == 2

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -307,6 +307,52 @@ async def test_async_x509_exchange_does_not_inherit_caller_http_auth() -> None:
     assert api_authorizations == ["Bearer safe-token"]
 
 
+def test_sync_x509_exchange_does_not_inherit_caller_authorization_header() -> None:
+    exchange_authorizations: list[str | None] = []
+    api_authorizations: list[str | None] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            exchange_authorizations.append(request.headers.get("Authorization"))
+            return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
+        api_authorizations.append(request.headers.get("Authorization"))
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.Client(
+        transport=httpx2.MockTransport(handler),
+        headers={"Authorization": "Bearer private-api-credential"},
+        trust_env=False,
+    )
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert client.models.list().object == "list"
+
+    assert exchange_authorizations == [None]
+    assert api_authorizations == ["Bearer safe-token"]
+
+
+async def test_async_x509_exchange_does_not_inherit_caller_authorization_header() -> None:
+    exchange_authorizations: list[str | None] = []
+    api_authorizations: list[str | None] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            exchange_authorizations.append(request.headers.get("Authorization"))
+            return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
+        api_authorizations.append(request.headers.get("Authorization"))
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.AsyncClient(
+        transport=httpx2.MockTransport(handler),
+        headers={"Authorization": "Bearer private-api-credential"},
+        trust_env=False,
+    )
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        assert (await client.models.list()).object == "list"
+
+    assert exchange_authorizations == [None]
+    assert api_authorizations == ["Bearer safe-token"]
+
+
 @pytest.mark.parametrize("response_body", [[], "not-an-object", 42, True])
 def test_sync_x509_rejects_non_object_token_responses(response_body: object) -> None:
     def handler(request: httpx2.Request) -> httpx2.Response:

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -13,6 +13,7 @@ import pytest
 
 from openai import OpenAI, AsyncOpenAI, OpenAIError, APIStatusError
 from openai.auth import X509WorkloadIdentity, x509_workload_identity
+from openai._client import WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER
 from openai.auth._workload import _WorkloadIdentityAuth
 
 _TOKEN_URL = "https://mtls.auth.openai.com/oauth/token"
@@ -112,6 +113,62 @@ async def test_async_copy_accepts_an_explicit_x509_identity(method: str) -> None
         assert (await copied.models.list()).object == "list"
 
 
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+def test_sync_copy_can_switch_from_api_key_to_x509_identity(method: str, base_url: str | None) -> None:
+    api_authorizations: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            return httpx2.Response(200, request=request, json={"access_token": "switched-token", "expires_in": 3600})
+        api_authorizations.append(request.headers["Authorization"])
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False)
+    with OpenAI(api_key="original-api-key", base_url=base_url, http_client=http_client, max_retries=0) as client:
+        copied = (
+            client.copy(workload_identity=_identity())
+            if method == "copy"
+            else client.with_options(workload_identity=_identity())
+        )
+        assert client.api_key == "original-api-key"
+        assert copied.api_key == WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER
+        assert str(copied.base_url) == f"{base_url or 'https://mtls.api.openai.com/v1'}/"
+        assert copied._client is http_client
+        assert copied.models.list().object == "list"
+
+    assert api_authorizations == ["Bearer switched-token"]
+
+
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1"])
+async def test_async_copy_can_switch_from_api_key_to_x509_identity(method: str, base_url: str | None) -> None:
+    api_authorizations: list[str] = []
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        if str(request.url) == _TOKEN_URL:
+            return httpx2.Response(200, request=request, json={"access_token": "switched-token", "expires_in": 3600})
+        api_authorizations.append(request.headers["Authorization"])
+        return httpx2.Response(200, request=request, json={"object": "list", "data": []})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False)
+    async with AsyncOpenAI(
+        api_key="original-api-key", base_url=base_url, http_client=http_client, max_retries=0
+    ) as client:
+        copied = (
+            client.copy(workload_identity=_identity())
+            if method == "copy"
+            else client.with_options(workload_identity=_identity())
+        )
+        assert client.api_key == "original-api-key"
+        assert copied.api_key == WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER
+        assert str(copied.base_url) == f"{base_url or 'https://mtls.api.openai.com/v1'}/"
+        assert copied._client is http_client
+        assert (await copied.models.list()).object == "list"
+
+    assert api_authorizations == ["Bearer switched-token"]
+
+
 @pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])
 def test_sync_x509_disables_redirects_without_placeholder_authorization(authorization: str | None) -> None:
     urls: list[str] = []
@@ -150,11 +207,13 @@ async def test_async_x509_disables_redirects_without_placeholder_authorization(a
 
 def test_sync_x509_exchange_does_not_inherit_caller_http_auth() -> None:
     exchange_authorizations: list[str | None] = []
+    api_authorizations: list[str | None] = []
 
     def handler(request: httpx2.Request) -> httpx2.Response:
         if str(request.url) == _TOKEN_URL:
             exchange_authorizations.append(request.headers.get("Authorization"))
             return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
+        api_authorizations.append(request.headers.get("Authorization"))
         return httpx2.Response(200, request=request, json={"object": "list", "data": []})
 
     http_client = httpx2.Client(
@@ -166,15 +225,18 @@ def test_sync_x509_exchange_does_not_inherit_caller_http_auth() -> None:
         assert client.models.list().object == "list"
 
     assert exchange_authorizations == [None]
+    assert api_authorizations == ["Bearer safe-token"]
 
 
 async def test_async_x509_exchange_does_not_inherit_caller_http_auth() -> None:
     exchange_authorizations: list[str | None] = []
+    api_authorizations: list[str | None] = []
 
     async def handler(request: httpx2.Request) -> httpx2.Response:
         if str(request.url) == _TOKEN_URL:
             exchange_authorizations.append(request.headers.get("Authorization"))
             return httpx2.Response(200, request=request, json={"access_token": "safe-token", "expires_in": 3600})
+        api_authorizations.append(request.headers.get("Authorization"))
         return httpx2.Response(200, request=request, json={"object": "list", "data": []})
 
     http_client = httpx2.AsyncClient(
@@ -186,6 +248,7 @@ async def test_async_x509_exchange_does_not_inherit_caller_http_auth() -> None:
         assert (await client.models.list()).object == "list"
 
     assert exchange_authorizations == [None]
+    assert api_authorizations == ["Bearer safe-token"]
 
 
 @pytest.mark.parametrize("response_body", [[], "not-an-object", 42, True])
@@ -273,6 +336,74 @@ async def test_async_x509_invalidates_rejected_token_without_replaying_one_shot_
     assert uploaded.id == "file_123"
     assert exchange_calls == 2
     assert api_authorizations == ["Bearer token-1", "Bearer token-2"]
+
+
+def test_sync_x509_rewinds_seekable_multipart_upload_to_its_original_position() -> None:
+    upload = io.BytesIO(b"prefix-upload-payload")
+    upload.seek(len(b"prefix-"))
+    initial_position = upload.tell()
+    positions: list[int] = []
+    bodies: list[bytes] = []
+    exchange_calls = 0
+
+    class ConsumingTransport(httpx2.BaseTransport):
+        @override
+        def handle_request(self, request: httpx2.Request) -> httpx2.Response:
+            nonlocal exchange_calls
+            if str(request.url) == _TOKEN_URL:
+                exchange_calls += 1
+                return httpx2.Response(
+                    200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+                )
+
+            positions.append(upload.tell())
+            bodies.append(request.read())
+            if exchange_calls == 1:
+                return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+            return httpx2.Response(200, request=request, json={"id": "file_123", "object": "file"})
+
+    http_client = httpx2.Client(transport=ConsumingTransport(), trust_env=False)
+    with OpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        uploaded = client.files.create(file=("upload.txt", upload), purpose="assistants")
+
+    assert uploaded.id == "file_123"
+    assert positions == [initial_position, initial_position]
+    assert len(bodies) == 2 and bodies[0] == bodies[1]
+    assert b"upload-payload" in bodies[0]
+
+
+async def test_async_x509_rewinds_seekable_multipart_upload_to_its_original_position() -> None:
+    upload = io.BytesIO(b"prefix-upload-payload")
+    upload.seek(len(b"prefix-"))
+    initial_position = upload.tell()
+    positions: list[int] = []
+    bodies: list[bytes] = []
+    exchange_calls = 0
+
+    class ConsumingTransport(httpx2.AsyncBaseTransport):
+        @override
+        async def handle_async_request(self, request: httpx2.Request) -> httpx2.Response:
+            nonlocal exchange_calls
+            if str(request.url) == _TOKEN_URL:
+                exchange_calls += 1
+                return httpx2.Response(
+                    200, request=request, json={"access_token": f"token-{exchange_calls}", "expires_in": 3600}
+                )
+
+            positions.append(upload.tell())
+            bodies.append(await request.aread())
+            if exchange_calls == 1:
+                return httpx2.Response(401, request=request, json={"error": {"message": "unauthorized"}})
+            return httpx2.Response(200, request=request, json={"id": "file_123", "object": "file"})
+
+    http_client = httpx2.AsyncClient(transport=ConsumingTransport(), trust_env=False)
+    async with AsyncOpenAI(workload_identity=_identity(), http_client=http_client, max_retries=0) as client:
+        uploaded = await client.files.create(file=("upload.txt", upload), purpose="assistants")
+
+    assert uploaded.id == "file_123"
+    assert positions == [initial_position, initial_position]
+    assert len(bodies) == 2 and bodies[0] == bodies[1]
+    assert b"upload-payload" in bodies[0]
 
 
 def test_sync_x509_invalidates_a_rejected_replay_token() -> None:

--- a/tests/test_x509_workload_identity_regressions.py
+++ b/tests/test_x509_workload_identity_regressions.py
@@ -10,6 +10,7 @@ import pytest
 
 from openai import OpenAI, AsyncOpenAI, OpenAIError
 from openai.auth import X509WorkloadIdentity, x509_workload_identity
+from openai.auth._workload import _WorkloadIdentityAuth
 
 _TOKEN_URL = "https://mtls.auth.openai.com/oauth/token"
 _API_URL = "https://mtls.api.openai.com/v1/models"
@@ -17,6 +18,22 @@ _API_URL = "https://mtls.api.openai.com/v1/models"
 
 def _identity() -> X509WorkloadIdentity:
     return x509_workload_identity(identity_provider_id="idp_123", service_account_id="svc_acct_123")
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+def test_x509_auth_initializes_its_typed_common_superclass(client_type: type[OpenAI] | type[AsyncOpenAI]) -> None:
+    client = client_type(workload_identity=_identity())
+    auth = client._workload_identity_auth
+
+    assert isinstance(auth, _WorkloadIdentityAuth)
+    assert auth.workload_identity == _identity()
+    assert auth._cached_token is None
+    assert auth._follow_redirects is False
+
+    if isinstance(client, OpenAI):
+        client.close()
+    else:
+        anyio.run(client.close)
 
 
 @pytest.mark.parametrize("authorization", [None, "Bearer caller-override"])


### PR DESCRIPTION
## What and why

Implement Phase 1 (HTTP only) of [X.509 Workload Identity Federation in OpenAI SDKs: Design Proposal](https://app.notion.com/p/openai/X-509-Workload-Identity-Federation-in-OpenAI-SDKs-Design-Proposal-3bc8e50b62b0814a9c36c3cf6d897f04). Customers can exchange workload identity established by their existing mutually authenticated HTTP transport for an OpenAI access token without introducing SDK-owned certificates, private keys, token providers, or a configurable token endpoint.

Both `OpenAI` and `AsyncOpenAI` support the same additive, typed public API:

```python
from openai import OpenAI
from openai.auth import x509_workload_identity

client = OpenAI(
    workload_identity=x509_workload_identity(
        identity_provider_id="idp_...",
        service_account_id="svc_acct_...",
    ),
    http_client=caller_configured_mtls_http_client,
)
```

`refresh_buffer_seconds` is optional. `WorkloadIdentity` remains the existing callable, backward-compatible subject-token TypedDict; both `OpenAI` and `AsyncOpenAI` accept the explicit typed union `WorkloadIdentity | X509WorkloadIdentity`. `SubjectTokenWorkloadIdentity` is a compatibility alias, and the public `WorkloadIdentityAuth` constructor remains narrowed to subject-token identities. The helper name, snake_case options, TypedDict configuration, SDK exception types, injected-client lifecycle, typed `copy()`/`with_options()`, and explicit sync/async implementations follow neighboring Python SDK patterns. Azure/Bedrock overriding copy signatures retain Python-compatible parameter variance without changing their provider authentication behavior. Async refresh uses AnyIO-compatible locking and sleep; it never runs an asynchronous exchange through blocking thread work.

## Security, transport ownership, and compatibility

- Exchange tokens only with `POST https://mtls.auth.openai.com/oauth/token`; the JSON structurally omits `subject_token`, the exchange URL is not public configuration, and redirects are disabled per request.
- Reuse the effective caller-configured HTTPX2 or legacy HTTPX client for the exchange and the subsequent API request. Certificate chains, private keys, passphrases, trust, proxies, HSM integration, pooling, and rotation remain entirely owned by that native transport.
- Never mutate caller transport settings, retain certificate/key material, or include token/provider-controlled error details in exceptions or logs. Preserve the SDK's existing HTTP-client close/aclose ownership behavior.
- Use monotonic, bounded token caching with positive finite `expires_in` validation, half-TTL refresh-buffer clamping, sync and async single-flight refresh, cancellation-safe async waiters, bounded transient retries, and `Retry-After` handling.
- Invalidate once after a 401 and replay only genuinely replayable requests. Seekable uploads are rewound to their original offsets; one-shot upload streams and non-replayable bodies are never replayed.
- Default only X.509-mode clients without an explicit/environment base URL to `https://mtls.api.openai.com/v1`. Existing API-key authentication, JWT/ID-token workload identity, their separate exchange client, explicit base URLs, Python support policy, and dependency set are unchanged.
- **Realtime/WebSockets are explicitly excluded; they belong to Phase 2.**

## Verification

| Gate | Result |
| --- | --- |
| Full OpenAPI-mock-backed suite, Python 3.10 | **7,255 passed, 31 skipped** against a dedicated healthy local Steady OpenAPI mock |
| Built-wheel auth/client/X.509 matrix, Python 3.11 | **7,255 passed, 31 skipped** for the complete installed-wheel suite, including HTTPX2/aiohttp/Azure/Bedrock regressions |
| Built-wheel auth/client/X.509 matrix, Python 3.12 | **7,255 passed, 31 skipped** for the complete installed-wheel suite, including HTTPX2/aiohttp/Azure/Bedrock regressions |
| Built-wheel auth/client/X.509 matrix, Python 3.13 | **7,255 passed, 31 skipped** for the complete installed-wheel suite, including HTTPX2/aiohttp/Azure/Bedrock regressions |
| Built-wheel auth/client/X.509 matrix, Python 3.14 | **7,255 passed, 31 skipped** for the complete installed-wheel suite, including HTTPX2/aiohttp/Azure/Bedrock regressions |
| Dedicated legacy HTTPX compatibility lane, Python 3.10 | **130 passed** |
| Repository `./scripts/lint` | **Passed**: Ruff, whole-project Pyright (0 errors/0 warnings), whole-project mypy (1,547 source files), import validation |
| Ruff checks | **Passed**: `ruff check .`; changed-file formatting; 1,717 repository files format-clean after excluding one independently verified, untouched upstream baseline defect |
| Documentation/example checks | **Passed**: README documentation lint; auth/example/test `compileall`; both examples construct offline in API-key and X.509 modes |
| Source/wheel build | **Passed**: `python -m build --no-isolation` |
| HTTPX2 wheel validator | **Passed**: HTTPX2-only 20 passed/2 skipped, aiohttp 4 passed, isolated legacy HTTPX/aiohttp 3 passed |
| Python-version wheel, Bedrock wheel, and support-policy validators | **Passed**; supported release matrix Python 3.10–3.14 and prerelease 3.15 |
| Patch hygiene | **Passed**: `git diff --check`; exact fourteen-path branch diff and clean committed worktree |

The focused X.509 tests cover exact host/path/body and absence of `subject_token`, redirect refusal, transport/certificate ownership, transient retries and `Retry-After`, sync/async concurrency and cancellation, invalid/expired token responses and refresh windows, replayable versus one-shot upload/body behavior, safe error redaction, and API-key/JWT/ID-token regressions.

Formatting baseline disclosure: the unmodified upstream `src/openai/resources/responses/responses.py` already fails a whole-repository `ruff format --check .` on the exact base revision. The repository's actual `./scripts/lint`, every changed file, and the other 1,717 files all pass; this PR intentionally does not modify unrelated generated code.

## Maintainability and Python idiom review

The required strict `thermo-nuclear-code-quality-review` was completed against the complete exact fourteen-file publication diff: **no structural blockers**. X.509 logic is isolated in one 269-line handwritten auth module; neither new production nor test files exceed 1,000 lines. Mode selection occurs once in each existing sync/async constructor, subject-token and X.509 implementations share one properly initialized generic auth/cache base without identity casts, existing auth/retry/error layers remain canonical, and sync/async differences stay explicit.

The Python idiom review compared neighboring auth TypedDict/provider helpers, `OpenAI`/`AsyncOpenAI` injection and ownership, HTTPX/HTTPX2 request semantics, AnyIO cancellation, native SSLContext/transport boundaries, existing exception chaining/retry constants, pytest fixture style, and README examples. The result preserves established Python SDK naming, caller-client lifecycle, sync/async parity, and existing auth behavior without cross-language builder abstractions or hidden transport mutation.

Refreshed upstream base: `10ee3f0da2ac6f93345c1204bd7bb1a2faa79ff2`

Validated publication head: `9512899eb98aab917ec9cf4c59342c77eb45c394`

## Prior independent installed-artifact mTLS validation

Built the exact committed wheel with `.venv/bin/python -m build --no-isolation --outdir /private/tmp/openai-python-x509-round3-dist`, installed that wheel into a clean temporary virtual environment, and executed `/private/tmp/openai-python-x509-round3-venv/bin/python /private/tmp/openai-python-x509-second-round-e2e.py` from outside the repository. The harness generates an ephemeral CA plus fresh server/client certificates, requires and verifies client-certificate presentation on every local HTTPS request, and connects the unmodified native HTTPX2 transport to the exact pinned authentication and API origins through a hermetic local CONNECT proxy.

Result: **19 sync/async scenarios passed; 48 real mTLS requests carried a verified client certificate (24 token exchanges, 24 API requests)**. Scenarios cover pinned host/path and token JSON without `subject_token`, bearer injection, token caching, actual clock-based refresh, transient retry/`Retry-After`, 401 refresh/replay, non-replayable multipart uploads that invalidate rejected tokens without replay, typed `with_options()` client copies that preserve their effective mTLS transport, async single-flight and waiter cancellation, sync/async timeouts, exchange/API redirect refusal including overridden auth, malformed token JSON, OAuth-error redaction, and the original callable `WorkloadIdentity` public API.

Residual scope limitation: no customer-enrolled production identity provider was contacted or required; the independent end-to-end exchange uses a real local mutually authenticated TLS service with freshly generated certificates.

## Current exact-head independent verification

Final independently verified head: `9512899eb98aab917ec9cf4c59342c77eb45c394`; fresh mergeable base: `10ee3f0da2ac6f93345c1204bd7bb1a2faa79ff2` (zero commits behind).

- Addressed all eight latest automated-review findings with 36 new sync/async regression cases: compare-and-invalidate rejected replay tokens; record and restore every seekable multipart upload's original file offset; support API-key-to-X.509 and X.509-to-API-key copies while preserving custom origins and resetting implicit defaults; prevent caller HTTP auth from leaking to the token endpoint or replacing exchanged API bearer tokens; explicitly reject X.509 identities from Azure copies; and reject malformed/missing-ID identities with typed errors. Each review thread has an exact fix explanation and is resolved.
- Built both wheel and source distribution from this exact committed tree with `rye build --clean`, installed the wheel into a freshly created virtual environment, and ran an external consumer through public `OpenAI` / `AsyncOpenAI` with a native HTTPX2 transport, ephemeral CA/server/client certificates, and a hermetic local CONNECT proxy. **32 independently reproduced scenarios passed over 78 real client-certificate-verified HTTPS requests: 38 exact-origin token exchanges and 40 API requests.** The exchange body never contains `subject_token` and never inherits caller `Authorization`; scenarios also prove actual `BasicAuth` suppression, bearer injection, cache reuse/real-time refresh, transient retry, 401 replay and rejected-replay invalidation, real seekable multipart upload replay, one-shot upload invalidation, bidirectional API-key/X.509 mode switching, redirect refusal, timeout, cancellation/single-flight, typed/redacted errors, malformed identity rejection, and Azure boundaries.
- Ran the **complete** OpenAPI-mock-backed installed-wheel suite on **every supported Python release**: Python **3.10, 3.11, 3.12, 3.13, and 3.14 each passed 7,255 tests with 31 expected skips**. The additional Python 3.10/Pydantic 1 suite passed **7,241 tests with 45 expected skips**; the independently reproduced dedicated legacy HTTPX lane passed **130 tests**.
- `./scripts/lint` passes Ruff, Pyright (**0 errors / 0 warnings**), mypy (**1,547 source files**), and import validation. Python support-policy validation, Python 3.9 wheel rejection, Bedrock wheel validation, HTTPX2/aiohttp/legacy wheel validation, README formatting, changed-file formatting, Python compilation, and `git diff --check` all pass.
- The independently reproduced `uv lock --check` failure and one unrelated generated-file `ruff format --check .` failure are present unchanged on the exact upstream base; neither dependency locks nor generated baseline code were altered.
- Strict thermo-nuclear maintainability review and a separate Python-idiom review found no remaining structural or compatibility blocker. Scope remains HTTP-only; Realtime/WebSockets are Phase 2, and no production endpoint or customer credentials were used.
