### PR TITLE
Fix #315: Support `openai api --json completions.create ...`

### DIFF
--- a/src/openai/types/completion_choice.py
+++ b/src/openai/types/completion_choice.py
@@ -19,7 +19,7 @@ class Logprobs(BaseModel):
 
 
 class CompletionChoice(BaseModel):
-    finish_reason: Literal["stop", "length", "content_filter"]
+    finish_reason: Optional[Literal["stop", "length", "content_filter"]] = None
     """The reason the model stopped generating tokens.
 
     This will be `stop` if the model hit a natural stop point or a provided stop


### PR DESCRIPTION
Fix #315: Support `openai api --json completions.create ...`

(No detailed fix description was generated — see the diff below for the actual change.)