### PR TITLE
fix: handle bare dict annotation in construct_type and _transform_recursive

### DIFF
--- a/src/openai/_models.py
+++ b/src/openai/_models.py
@@ -657,7 +657,8 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
         if not is_mapping(value):
             return value
 
-        _, items_type = get_args(type_)  # Dict[_, items_type]
+        _type_args = get_args(type_)
+        items_type = _type_args[1] if len(_type_args) >= 2 else Any  # bare dict has no type args
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
     if (

--- a/src/openai/_utils/_transform.py
+++ b/src/openai/_utils/_transform.py
@@ -180,7 +180,8 @@ def _transform_recursive(
         return _transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _type_args = get_args(stripped_type)
+        items_type = _type_args[1] if len(_type_args) >= 2 else Any  # bare dict has no type args
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (
@@ -346,7 +347,8 @@ async def _async_transform_recursive(
         return await _async_transform_typeddict(data, stripped_type)
 
     if origin == dict and is_mapping(data):
-        items_type = get_args(stripped_type)[1]
+        _type_args = get_args(stripped_type)
+        items_type = _type_args[1] if len(_type_args) >= 2 else Any  # bare dict has no type args
         return {key: _transform_recursive(value, annotation=items_type) for key, value in data.items()}
 
     if (

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1015,3 +1015,10 @@ def test_iterable_construction_str_falls_back_to_list() -> None:
     # falls back to list of chars rather than calling str(["h", "e", "l", "l", "o"])
     assert m.data["items"] == ["h", "e", "l", "l", "o"]
     assert m.model_dump()["data"]["items"] == ["h", "e", "l", "l", "o"]
+
+
+def test_construct_type_bare_dict() -> None:
+    # Regression: bare `dict` annotation (no type args) crashed with ValueError
+    # because get_args(dict) returns () and the old code did `_, v = get_args(dict)`.
+    result = construct_type(value={"key": "value"}, type_=dict)
+    assert result == {"key": "value"}

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -458,3 +458,16 @@ async def test_strips_notgiven(use_async: bool) -> None:
 async def test_strips_omit(use_async: bool) -> None:
     assert await transform({"foo_bar": "bar"}, Foo1, use_async) == {"fooBar": "bar"}
     assert await transform({"foo_bar": omit}, Foo1, use_async) == {}
+
+
+class BareDict(TypedDict, total=False):
+    metadata: dict  # bare dict, no type parameters
+
+
+@parametrize
+@pytest.mark.asyncio
+async def test_bare_dict_annotation(use_async: bool) -> None:
+    # Regression: bare `dict` TypedDict field crashed with IndexError because
+    # get_args(dict) returns () and the old code did get_args(dict)[1].
+    result = await transform({"metadata": {"key": "value"}}, BareDict, use_async)
+    assert result == {"metadata": {"key": "value"}}


### PR DESCRIPTION
## Summary

Fixes #3341 and #3338.

`construct_type()` in `_models.py` and `_transform_recursive()` / `_async_transform_recursive()` in `_utils/_transform.py` all crashed when a field was annotated with a bare, unparameterised `dict` (no `[K, V]` type arguments):

- `_models.py:660`: `_, items_type = get_args(type_)` — `get_args(dict)` returns `()`, so the unpack raises `ValueError: not enough values to unpack (expected 2, got 0)`.
- `_transform.py:183` and `_transform.py:349`: `get_args(stripped_type)[1]` — same empty tuple, raises `IndexError`.

The fix guards each site with a length check and falls back to `Any` when the dict is unparameterised, which preserves the existing value pass-through behaviour.

## Test plan

- [x] Added `test_construct_type_bare_dict` in `tests/test_models.py` — reproduces the exact crash from issue #3341.
- [x] Added `test_bare_dict_annotation` in `tests/test_transform.py` — reproduces the exact crash from issue #3338, covers both sync and async paths via the `@parametrize` fixture.
- [x] Full `tests/test_models.py` and `tests/test_transform.py` suite: 117 passed, 0 failures.
- [x] Ruff lint: all checks passed.