### PR TITLE
fix(types): make ResponseFunctionWebSearch.action Optional

### DIFF
--- a/src/openai/types/beta/beta_response_function_web_search.py
+++ b/src/openai/types/beta/beta_response_function_web_search.py
@@ -86,10 +86,11 @@ class BetaResponseFunctionWebSearch(BaseModel):
     id: str
     """The unique ID of the web search tool call."""
 
-    action: Action
+    action: Optional[Action] = None
     """
     An object describing the specific action taken in this web search call. Includes
-    details on how the model used the web (search, open_page, find_in_page).
+    details on how the model used the web (search, open_page, find_in_page). May be
+    None when the search completed without a recorded action (e.g. cached results).
     """
 
     status: Literal["in_progress", "searching", "completed", "failed"]

--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -78,10 +78,11 @@ class ResponseFunctionWebSearch(BaseModel):
     id: str
     """The unique ID of the web search tool call."""
 
-    action: Action
+    action: Optional[Action] = None
     """
     An object describing the specific action taken in this web search call. Includes
-    details on how the model used the web (search, open_page, find_in_page).
+    details on how the model used the web (search, open_page, find_in_page). May be
+    None when the search completed without a recorded action (e.g. cached results).
     """
 
     status: Literal["in_progress", "searching", "completed", "failed"]


### PR DESCRIPTION
## Summary

Fixes #3179.

The API returns `web_search_call` items with `action=null` for completed searches (observed when results come from cache). The `action` field was typed as non-optional `Action`, so any code accessing `item.action.type` raised `AttributeError: 'NoneType' object has no attribute 'type'`.

Changed `action: Action` to `action: Optional[Action] = None` in both the `responses/` and `beta/` variants of `ResponseFunctionWebSearch`.

## Test plan

- [x] `tests/test_models.py` and `tests/test_transform.py`: 114 passed, 0 failures.
- [x] Ruff lint: all checks passed.
- [x] Verified `Optional` was already imported in both files — no import changes needed.