### PR TITLE
fix(realtime): strip Omit/NotGiven in ConnectionManager.send pre-connect

### DIFF
--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -605,7 +605,7 @@ class AsyncRealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 
@@ -1073,7 +1073,7 @@ class RealtimeConnectionManager:
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
-            else json.dumps(event)
+            else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
         self.__send_queue.enqueue(data)
 


### PR DESCRIPTION
## Summary

Fixes #3402.

`AsyncRealtimeConnectionManager.send()` and `RealtimeConnectionManager.send()` called `json.dumps(event)` directly on dict payloads without first running `maybe_transform()`. The post-connect `connection.send()` paths already wrap with `maybe_transform` / `async_maybe_transform` to strip `Omit` / `NotGiven` sentinels before serialization — the pre-connect manager paths were missing this step, causing:

```
TypeError: Object of type Omit is not JSON serializable
```

The fix adds `maybe_transform(event, RealtimeClientEventParam)` to both manager `send()` paths, matching the existing post-connect behavior. Both managers have synchronous `send()` signatures (queuing for later dispatch), so `maybe_transform` (not the async variant) is correct here.

## Test plan

- [x] `tests/test_models.py` and `tests/test_transform.py`: 114 passed, 0 failures.
- [x] Ruff lint: all checks passed.
- [x] `maybe_transform` was already imported in the file — no import changes needed.