### PR TITLE
fix(responses): guard against null item/text in stream accumulator and output_text

### DIFF
--- a/src/openai/lib/streaming/responses/_responses.py
+++ b/src/openai/lib/streaming/responses/_responses.py
@@ -328,7 +328,9 @@ class ResponseStreamState(Generic[TextFormatT]):
             return self._create_initial_response(event)
 
         if event.type == "response.output_item.added":
-            if event.item.type == "function_call":
+            if event.item is None:
+                pass
+            elif event.item.type == "function_call":
                 snapshot.output.append(
                     construct_type_unchecked(
                         type_=cast(Any, ParsedResponseFunctionToolCall), value=event.item.to_dict()

--- a/src/openai/types/beta/beta_response_output_item_added_event.py
+++ b/src/openai/types/beta/beta_response_output_item_added_event.py
@@ -19,7 +19,7 @@ class Agent(BaseModel):
 class BetaResponseOutputItemAddedEvent(BaseModel):
     """Emitted when a new output item is added."""
 
-    item: BetaResponseOutputItem
+    item: Optional[BetaResponseOutputItem] = None
     """The output item that was added.
 
     For reasoning items, `encrypted_content` may be incomplete while the item is in

--- a/src/openai/types/responses/response.py
+++ b/src/openai/types/responses/response.py
@@ -486,7 +486,7 @@ class Response(BaseModel):
         for output in self.output:
             if output.type == "message":
                 for content in output.content:
-                    if content.type == "output_text":
+                    if content.type == "output_text" and content.text is not None:
                         texts.append(content.text)
 
         return "".join(texts)

--- a/src/openai/types/responses/response_output_item_added_event.py
+++ b/src/openai/types/responses/response_output_item_added_event.py
@@ -1,5 +1,6 @@
 # File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
 
+from typing import Optional
 from typing_extensions import Literal
 
 from ..._models import BaseModel
@@ -11,7 +12,7 @@ __all__ = ["ResponseOutputItemAddedEvent"]
 class ResponseOutputItemAddedEvent(BaseModel):
     """Emitted when a new output item is added."""
 
-    item: ResponseOutputItem
+    item: Optional[ResponseOutputItem] = None
     """The output item that was added.
 
     For reasoning items, `encrypted_content` may be incomplete while the item is in


### PR DESCRIPTION
## Summary

Fixes #3125 and #3011 — both are null-safety gaps in the Responses API path.

**#3125 — stream accumulator crashes on `item=null`**

`ResponseStreamState._accumulate_event` accessed `event.item.type` unconditionally for `response.output_item.added` events. OpenAI-compatible providers can emit this event with `item: null`, causing `AttributeError: 'NoneType' object has no attribute 'type'`. Added a `if event.item is None: pass` guard before the type dispatch.

**#3011 — `Response.output_text` crashes on `text=null`**

The `output_text` property appended `content.text` without a null check. Models such as `gpt-oss-safeguard-120b` can return `output_text` content blocks with `text: null`, causing `TypeError` during `"".join(texts)`. Added `and content.text is not None` to the filter condition.

## Test plan

- [x] `tests/test_models.py`, `tests/test_transform.py`, `tests/lib/responses/`: 121 passed, 0 failures.
- [x] Ruff lint: all checks passed.