### PR TITLE
fix(responses): guard parse_response against null response.output

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -58,7 +58,7 @@ def parse_response(
 ) -> ParsedResponse[TextFormatT]:
     output_list: List[ParsedResponseOutputItem[TextFormatT]] = []
 
-    for output in response.output:
+    for output in (response.output or []):
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
             for item in output.content:


### PR DESCRIPTION
## Summary

Fixes #3312 (and the related duplicates #3314, #3321, #3325, #3313).

`parse_response()` in `src/openai/lib/_parsing/_responses.py` iterates `response.output` unconditionally. Several backends (chatgpt.com Codex, OAI-compatible servers under load) emit `response.completed` with `output: null`, which causes:

```
TypeError: 'NoneType' object is not iterable
```

One-character fix: `response.output or []` short-circuits to an empty list when the field is null, returning a `ParsedResponse` with an empty output list rather than crashing.

## Test plan

- [x] `tests/test_models.py`, `tests/test_transform.py`, `tests/lib/responses/`: 121 passed, 0 failures.
- [x] Ruff lint: all checks passed.