### PR TITLE
fix(client): restore api_key="" support for local OAI-compatible servers

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -197,6 +197,7 @@ class OpenAI(SyncAPIClient):
 
         self.workload_identity = workload_identity if provider_runtime is None else None
 
+        _api_key_provided = api_key is not None
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -224,6 +225,7 @@ class OpenAI(SyncAPIClient):
             provider_runtime is None
             and _enforce_credentials
             and not self.api_key
+            and not _api_key_provided
             and self._api_key_provider is None
             and workload_identity is None
             and self.admin_api_key is None
@@ -803,6 +805,7 @@ class AsyncOpenAI(AsyncAPIClient):
 
         self.workload_identity = workload_identity if provider_runtime is None else None
 
+        _api_key_provided = api_key is not None
         if provider_runtime is not None:
             self.api_key = ""
             self._api_key_provider = None
@@ -830,6 +833,7 @@ class AsyncOpenAI(AsyncAPIClient):
             provider_runtime is None
             and _enforce_credentials
             and not self.api_key
+            and not _api_key_provided
             and self._api_key_provider is None
             and workload_identity is None
             and self.admin_api_key is None


### PR DESCRIPTION
## Summary

Fixes #3224.

v2.34.0 introduced credential validation that checks `not self.api_key`, which is truthy for an explicitly-passed empty string. This broke users pointing the SDK at local OAI-compatible servers (llama.cpp, llamafile, LM Studio, vLLM) that pass `api_key=""` because they require no authentication — a pattern that worked in all prior versions.

**Root cause:** the check fires on `api_key=""` the same as on no key provided, because both result in `self.api_key = ""`.

**Fix:** capture whether the caller explicitly provided `api_key` before the env-var lookup. If they did (even as `""`), skip the credential error. Applied to both `OpenAI` and `AsyncOpenAI`.

```python
_api_key_provided = api_key is not None   # +1 line per class
...
and not _api_key_provided                  # +1 line per class in the check
```

## Test plan

- [x] `OpenAI(api_key="", base_url="http://localhost:11434/v1")` no longer raises.
- [x] `AsyncOpenAI(api_key="", base_url="http://localhost:11434/v1")` no longer raises.
- [x] `OpenAI()` with no env var still raises `OpenAIError: Missing credentials`.
- [x] `tests/test_client.py` + `tests/test_models.py`: 256 passed, 2 skipped, 0 failures.
- [x] Ruff lint: all checks passed.