### PR TITLE
fix(client): sanitize newlines in proxy env vars before httpx sees them

### DIFF
--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -94,6 +94,15 @@ __all__ = ["Timeout", "Transport", "ProxiesTypes", "RequestOptions", "OpenAI", "
 
 WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER = "workload-identity-auth"
 
+_PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy")
+
+
+def _sanitize_proxy_env_vars() -> None:
+    for key in _PROXY_ENV_VARS:
+        val = os.environ.get(key)
+        if val is not None and "\n" in val:
+            os.environ[key] = ",".join(p.strip() for p in val.splitlines() if p.strip())
+
 
 def _has_header(headers: Headers, header: str) -> bool:
     header = header.lower()
@@ -262,6 +271,7 @@ class OpenAI(SyncAPIClient):
                     parsed[line[:colon].strip()] = line[colon + 1 :].strip()
             default_headers = {**parsed, **(default_headers if is_mapping_t(default_headers) else {})}
 
+        _sanitize_proxy_env_vars()
         super().__init__(
             version=__version__,
             base_url=base_url,
@@ -868,6 +878,7 @@ class AsyncOpenAI(AsyncAPIClient):
                     parsed[line[:colon].strip()] = line[colon + 1 :].strip()
             default_headers = {**parsed, **(default_headers if is_mapping_t(default_headers) else {})}
 
+        _sanitize_proxy_env_vars()
         super().__init__(
             version=__version__,
             base_url=base_url,


### PR DESCRIPTION
## Summary

Fixes #3303.

Docker, `.env` files, and some shell scripts can produce proxy env vars with embedded newlines (e.g. `NO_PROXY=localhost\n192.168.1.1`). httpx splits `NO_PROXY` only on `,`, so the newline character becomes part of a hostname string, which triggers `httpx.InvalidURL: Invalid non-printable ASCII character in URL`.

A fix in httpx upstream is blocked (project not accepting external PRs). The fix here sanitizes `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and their lowercase equivalents in `os.environ` before the httpx client is constructed — both in `OpenAI.__init__` and `AsyncOpenAI.__init__`.

## Test plan

- [x] Smoke test: `os.environ['NO_PROXY'] = 'localhost\n192.168.1.1'` then `OpenAI(api_key='...')` no longer raises `InvalidURL`; env var is cleaned to `'localhost,192.168.1.1'`.
- [x] `tests/test_client.py`: 198 passed, 2 skipped, 0 failures.
- [x] Ruff lint: all checks passed.