### PR TITLE
fix(types): make ResponseOutputText.text Optional to accept null from API

### DIFF
--- a/src/openai/types/beta/beta_response_output_text.py
+++ b/src/openai/types/beta/beta_response_output_text.py
@@ -122,7 +122,7 @@ class BetaResponseOutputText(BaseModel):
     annotations: List[Annotation]
     """The annotations of the text output."""
 
-    text: str
+    text: Optional[str] = None
     """The text output from the model."""
 
     type: Literal["output_text"]

--- a/src/openai/types/responses/response_output_text.py
+++ b/src/openai/types/responses/response_output_text.py
@@ -122,7 +122,7 @@ class ResponseOutputText(BaseModel):
     annotations: List[Annotation]
     """The annotations of the text output."""
 
-    text: str
+    text: Optional[str] = None
     """The text output from the model."""
 
     type: Literal["output_text"]


### PR DESCRIPTION
## Summary

Fixes #3063 (layer 1).

Some models (`gpt-oss-safeguard-120b` and others) return `output_text` content items with `text: null`. The strict `text: str` annotation caused pydantic to reject the entire response payload at parse time.

Changed `text: str` to `text: Optional[str] = None` in `ResponseOutputText`. This is consistent with how `action: Optional[Action]` is already handled on `ResponseFunctionWebSearch`.

Note: layer 2 of this issue (the `Response.output_text` property crashing when text is null) is covered by a companion PR fixing the `content.text is not None` guard — see PR #3628.

## Test plan

- [x] `tests/test_models.py` + `tests/lib/responses/`: 65 passed, 0 failures.
- [x] Ruff lint: all checks passed.