### PR TITLE
fix(streaming): merge duplicate-index entries in first tool_call chunk

### DIFF
--- a/src/openai/lib/streaming/_deltas.py
+++ b/src/openai/lib/streaming/_deltas.py
@@ -6,8 +6,13 @@ from ..._utils import is_dict, is_list
 def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> dict[object, object]:
     for key, delta_value in delta.items():
         if key not in acc:
-            acc[key] = delta_value
-            continue
+            # Seed indexed-dict lists with [] so duplicate-index entries in the
+            # first chunk are merged by the list path below instead of stored raw.
+            if is_list(delta_value) and delta_value and is_dict(delta_value[0]) and "index" in delta_value[0]:
+                acc[key] = []
+            else:
+                acc[key] = delta_value
+                continue
 
         acc_value = acc[key]
         if acc_value is None:
@@ -33,7 +38,7 @@ def accumulate_delta(acc: dict[object, object], delta: dict[object, object]) -> 
         elif is_list(acc_value) and is_list(delta_value):
             # for lists of non-dictionary items we'll only ever get new entries
             # in the array, existing entries will never be changed
-            if all(isinstance(x, (str, int, float)) for x in acc_value):
+            if acc_value and all(isinstance(x, (str, int, float)) for x in acc_value):
                 acc_value.extend(delta_value)
                 continue
 


### PR DESCRIPTION
## Summary

Fixes #3201.

`accumulate_delta` in `src/openai/lib/streaming/_deltas.py` had a fast-path for the first-time-seen case:

```python
if key not in acc:
    acc[key] = delta_value
    continue
```

When a first streaming chunk contained two `tool_calls` entries with the same `index: 0` (the API sends partial updates for the same item in one chunk), this stored the raw list directly — bypassing the index-based merge logic used for all subsequent chunks. Later chunks for `index: 0` then merged into physical position 0, ignoring the second entry, and the arguments JSON ended up truncated/invalid.

**Fix:** detect indexed-dict lists on first sight, seed `acc[key] = []`, and fall through to the existing merge path. Also guard the primitive-list `extend` branch with `acc_value and ...` so the empty seed list doesn't incorrectly short-circuit into `extend`.

## Test plan

- [x] Smoke test: first chunk with two `tool_calls[index:0]` entries merges correctly; subsequent chunk appends to the same entry.
- [x] `tests/test_streaming.py` + `tests/lib/`: 276 passed, 0 failures.
- [x] Ruff lint: all checks passed.