### PR TITLE
docs: strengthen Python SDK security contribution guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,10 @@ explicitly requires it.
   `OPENAI_API_KEY`, `OPENAI_ADMIN_KEY`, `OPENAI_WEBHOOK_SECRET`, and other
   credentials from the environment; use clearly fake examples and fixtures.
 - Redact credentials, `Authorization` and `api-key` headers, customer data, and
-  request or response bodies from logs, exceptions, snapshots, and test output.
-  Preserve existing sensitive-header filtering, including debug logging.
+  sensitive request or response bodies from logs, exceptions, snapshots, and
+  test output. Clearly fake or sanitized fixtures and safe `APIError.body`
+  diagnostics may remain. Preserve existing sensitive-header filtering,
+  including debug logging.
 - Review direct and transitive dependency changes in `pyproject.toml`, optional
   extras, `requirements.lock`, `requirements-dev.lock`, and `uv.lock`. Check
   package provenance, build backends, and install scripts before accepting or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,33 @@ changing generated files. Handwritten policy, automation, tests, and examples
 should remain small and should not alter exported SDK APIs unless the change
 explicitly requires it.
 
+## Security requirements for coding agents
+
+- Never commit real API or admin keys, bearer tokens, webhook secrets, cloud
+  credentials, X.509 private keys, release credentials, or `.env` files. Read
+  `OPENAI_API_KEY`, `OPENAI_ADMIN_KEY`, `OPENAI_WEBHOOK_SECRET`, and other
+  credentials from the environment; use clearly fake examples and fixtures.
+- Redact credentials, `Authorization` and `api-key` headers, customer data, and
+  request or response bodies from logs, exceptions, snapshots, and test output.
+  Preserve existing sensitive-header filtering, including debug logging.
+- Review direct and transitive dependency changes in `pyproject.toml`, optional
+  extras, `requirements.lock`, `requirements-dev.lock`, and `uv.lock`. Check
+  package provenance, build backends, and install scripts before accepting or
+  running them.
+- Pin third-party GitHub Actions to reviewed full commit SHAs. Minimize
+  job-level token permissions and never expose secrets or write-capable tokens
+  to untrusted pull-request code.
+- Preserve separate build and publish jobs, protected release credentials, and
+  PyPI Trusted Publishing. Grant `id-token: write` only to the trusted,
+  upload-only publishing job; do not introduce long-lived PyPI tokens.
+- Obtain SDK CODEOWNER review and add focused synchronous and asynchronous
+  security regression tests, as applicable, for changes to authentication,
+  X.509 or webhook verification, HTTP destinations, redirects, proxies, TLS,
+  cloud metadata, file uploads, serialization, dependencies, GitHub Actions,
+  or release workflows.
+- Report suspected vulnerabilities privately as described in `SECURITY.md`;
+  never disclose them in public issues, pull requests, or logs.
+
 ## Python version policy
 
 - `requires-python` in `pyproject.toml` is the authoritative technical minimum.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,32 @@ Most of the SDK is generated code. Modifications to code will be persisted betwe
 result in merge conflicts between manual patches and changes from the generator. The generator will never
 modify the contents of the `src/openai/lib/` and `examples/` directories.
 
+## Security requirements for contributions
+
+- Never commit API or admin keys, bearer tokens, webhook secrets, cloud
+  credentials, private keys, publishing credentials, or `.env` files. Load real
+  credentials from environment variables such as `OPENAI_API_KEY`,
+  `OPENAI_ADMIN_KEY`, and `OPENAI_WEBHOOK_SECRET`; use clearly fake values and
+  sanitized data in examples, tests, fixtures, and recorded responses.
+- Redact `Authorization` and `api-key` headers, other credentials, and customer
+  request or response data from logs, exceptions, snapshots, and debug output.
+  Prefer the mock server or mocked HTTP transport over live credentials in tests.
+- Review direct and transitive dependency changes, package provenance, build or
+  install hooks, and diffs to `pyproject.toml`, optional extras,
+  `requirements.lock`, `requirements-dev.lock`, and `uv.lock`.
+- Pin third-party GitHub Actions to reviewed full commit SHAs, minimize job
+  permissions, and keep secrets and write-capable tokens away from untrusted
+  pull-request code. Protect release-app credentials and preserve the separate
+  build and upload jobs, protected publishing environment, and PyPI Trusted
+  Publishing. Limit OIDC access to the trusted publishing job.
+- Request SDK CODEOWNER review for authentication, X.509, webhook verification,
+  network destinations, redirects, TLS, cloud metadata, file handling,
+  serialization, dependency, CI, and release changes. Add synchronous and
+  asynchronous regression tests as applicable, including credential redaction
+  and invalid signatures.
+- Report suspected vulnerabilities privately through the process in
+  [SECURITY.md](./SECURITY.md), never through public issues or pull requests.
+
 ## Adding and running examples
 
 All files in the `examples/` directory are not modified by the generator and can be freely edited or added to.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,11 @@ Please report potential security vulnerabilities through OpenAI's
 [coordinated vulnerability disclosure process](https://openai.com/policies/coordinated-vulnerability-disclosure-policy).
 For questions about that process, contact disclosure@openai.com.
 
+Do not report vulnerabilities through public GitHub issues, discussions, pull
+requests, or other public channels. When reporting privately, include the
+affected SDK version, impact, and reproduction steps where possible; redact API
+keys, authentication headers, private keys, and customer data from all reports.
+
 ## Responsible Disclosure
 
 Please allow OpenAI a reasonable amount of time to investigate and address the


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add focused Python SDK security requirements for coding agents and contributors: safe fake fixtures, credential and log redaction, direct/transitive dependency and lockfile review, reviewed GitHub Action pins, least-privilege CI, and protected PyPI Trusted Publishing.
- Require SDK CODEOWNER review and relevant synchronous/asynchronous regression tests for authentication, X.509, webhook, network, file, serialization, dependency, and release-sensitive changes.
- Explicitly direct vulnerability reports to the existing private coordinated-disclosure process instead of public issues, discussions, or pull requests.

## Verification

- `git diff --check`
- CommonMark parsing, local-link validation, security-policy coverage assertions, and credential-like-literal checks for all three changed Markdown files.
- `python scripts/check-python-version-policy.py` — passed.
- `python -m pytest -o addopts= -p no:cacheprovider -k 'not aiohttp' tests/test_utils/test_logging.py tests/test_auth.py tests/api_resources/test_webhooks.py` — 72 passed; 13 optional `aiohttp` cases were deselected because that extra is absent from the existing environment.

## Additional context & links

Documentation only: no generated SDK source, GitHub workflows, repository settings, credentials, or release controls were changed.