### PR TITLE
ci: run CodeQL analysis for merge-queue entries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 permissions:
@@ -23,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Run the existing advanced Python CodeQL analysis on `merge_group` `checks_requested` events, in addition to the existing main-targeted pull-request, main-push, and manual paths.
- Preserve the stable `Analyze Python` job/check name, SARIF category, Python language, timeout, full-SHA CodeQL/checkout action pins, and existing `actions: read`, `contents: read`, `security-events: write` permissions.
- Set `persist-credentials: false` on checkout so repository credentials are not left available to subsequent analysis steps.
- Keep ordinary `pull_request` behavior for external forks; existing repository policy still requires a maintainer to approve external-contributor workflow execution.

## Verification

- Parsed as YAML 1.2 and validated against the current GitHub Actions workflow JSON Schema.
- Structural/event assertions confirm real CodeQL `init` + `analyze`, existing PR/push/manual behavior, merge-queue-only `checks_requested`, unchanged job/check identity and permissions, three immutable action pins, and no skipped placeholder or `pull_request_target`.
- Confirmed a previously maintainer-approved external-fork PR completed the real `Analyze Python` job successfully.
- `python scripts/check-python-version-policy.py`
- `git diff origin/main...HEAD --check`

## Required-check rollout safety

The active `main` ruleset already requires a merge queue, but there have been **zero** CodeQL `merge_group` runs. Requiring any CodeQL check immediately would deadlock legitimate merges, so this PR does not modify live rules.

After this workflow reaches `main`, confirm `Analyze Python` succeeds on an actual merge-group SHA and an approved fork PR. Only then add `{ "context": "Analyze Python", "integration_id": 15368 }` to the existing required checks while preserving every current rule. The separate `CodeQL` Advanced Security check and dynamic `Analyze (python)` check are not proven to run on merge-group events.