### PR TITLE
ci: tighten Python workflow credential and token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     name: examples
     environment: ci
     runs-on: ubuntu-latest
-    if: github.repository == 'openai/openai-python' && github.ref != 'refs/heads/release-please--branches--main' && (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
+    if: github.repository == 'openai/openai-python' && github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -45,7 +45,6 @@ jobs:
     # PyPI Trusted Publishing requires id-token: write. Keep it scoped to this
     # minimal upload-only job rather than the build job.
     permissions:
-      contents: read
       id-token: write
 
     steps:

--- a/.github/workflows/python-version-review.yml
+++ b/.github/workflows/python-version-review.yml
@@ -175,7 +175,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: read
       issues: write
     steps:
       - name: Download the Codex assessment


### PR DESCRIPTION
## Summary
- Run existing live-API examples only on trusted `main` pushes; preserve all required pull-request and merge-queue checks.
- Remove unnecessary repository-content access from the upload-only manual PyPI publishing job while preserving `id-token: write` and Trusted Publishing.
- Remove unnecessary repository-content access from isolated Python-version issue automation while preserving `issues: write`.
- Leave CodeQL, release GitHub App permissions, protected publishing configuration, and fully pinned Actions unchanged.

## Verification
- Validated all six workflow YAML documents against the GitHub Actions schema.
- Audited effective permissions for all 17 jobs and verified all 46 external Actions remain pinned to full commit SHAs.
- Verified trusted-main event behavior, unchanged required checks, separate build/upload permissions, same-run artifact handling, and unchanged CodeQL/release scopes.
- Confirmed the existing release workflow has successfully published with the same OIDC-only upload permissions.
- Python support-policy check passed; `git diff --check` passed.

Administrator-managed repository and environment settings are intentionally unchanged.