### PR TITLE
Preserve required argument order in errors

### DIFF
--- a/src/openai/_utils/_utils.py
+++ b/src/openai/_utils/_utils.py
@@ -288,8 +288,7 @@ def required_args(*variants: Sequence[str]) -> Callable[[CallableT], CallableT]:
                 else:
                     assert len(variants) > 0
 
-                    # TODO: this error message is not deterministic
-                    missing = list(set(variants[0]) - given_params)
+                    missing = [param for param in variants[0] if param not in given_params]
                     if len(missing) > 1:
                         msg = f"Missing required arguments: {human_join([quote(arg) for arg in missing])}"
                     else:

--- a/tests/test_required_args.py
+++ b/tests/test_required_args.py
@@ -47,10 +47,11 @@ def test_multiple_params() -> None:
 
     assert foo(a="a", b="b", c="c") == "a b c"
 
-    error_message = r"Missing required arguments.*"
-
-    with pytest.raises(TypeError, match=error_message):
+    with pytest.raises(TypeError) as exc_info:
         foo()
+    assert str(exc_info.value) == "Missing required arguments: 'a', 'b' or 'c'"
+
+    error_message = r"Missing required arguments.*"
 
     with pytest.raises(TypeError, match=error_message):
         foo(a="a")


### PR DESCRIPTION
## Summary

- preserve each `required_args` variant's declaration order when listing missing arguments
- add an exact regression assertion for multi-argument error messages

## Why

The single-variant error path currently computes missing arguments with a set difference. Set iteration depends on Python's randomized hash seed, so an identical invalid SDK call can list parameters in a different order across processes. For example, the same declaration produced both `'model', 'messages' or 'stream'` and `'messages', 'stream' or 'model'` under different `PYTHONHASHSEED` values.

Filtering the declared variant in place makes the message deterministic and keeps it aligned with the method signature.

## Validation

- verified identical output across 8 different `PYTHONHASHSEED` values
- `python -m pytest -q -n 0 tests/test_required_args.py tests/test_utils tests/test_models.py` (197 passed)
- `ruff check .`
- `ruff format --check .`
- `mypy src/openai/_utils/_utils.py`
