### PR TITLE
feat: support named data-residency endpoints

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: e8613c5d-522c-4786-b0b1-1be514cf0c19
+generation_id: 04cb977a-ba1d-438c-a56e-94f269e79218
 openapi_spec_hash: dd725fb7d43ceec7fb2de6f8713d14b6
 openapi_transformed_spec_hash: 10930179c5f116288e24e0c6fda46559
-config_hash: 28f37c225c55c75547d4feb84ee71044
-codegen_sha: 2f6710b1a3501b9c0ee796f45ebada0d93d27bfd
+config_hash: 85382dd94c503b5d225adc7636a77c9f
+codegen_sha: 6e990f52e3cbdeaae602710a1b0f2a2c944a5c35

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -39,6 +39,7 @@ from ._exceptions import (
 )
 from ._base_client import DefaultHttpxClient, DefaultAioHttpClient, DefaultAsyncHttpxClient
 from ._utils._logs import setup_logging as _setup_logging
+from ._data_residency import DataResidency
 from ._legacy_response import HttpxBinaryResponseContent as HttpxBinaryResponseContent
 from .types.websocket_reconnection import ReconnectingEvent, ReconnectingOverrides
 
@@ -74,6 +75,7 @@ __all__ = [
     "InvalidWebhookSignatureError",
     "Timeout",
     "RequestOptions",
+    "DataResidency",
     "Client",
     "AsyncClient",
     "Stream",

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -49,6 +49,7 @@ from ._base_client import (
     SyncAPIClient,
     AsyncAPIClient,
 )
+from ._data_residency import DataResidency, resolve_data_residency
 
 if TYPE_CHECKING:
     from .resources import (
@@ -158,7 +159,8 @@ class OpenAI(SyncAPIClient):
         project: str | None = None,
         webhook_secret: str | None = None,
         provider: _Provider | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = not_given,
+        data_residency: DataResidency | None = None,
         websocket_base_url: str | httpx2.URL | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
@@ -189,7 +191,12 @@ class OpenAI(SyncAPIClient):
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
 
         When `provider` is supplied, authentication and the base URL are configured by that provider instead.
+        `data_residency` selects an OpenAI regional endpoint and cannot be combined with
+        `base_url`, `websocket_base_url`, or `provider`.
         """
+        base_url = resolve_data_residency(
+            data_residency, base_url, provider=provider, websocket_base_url=websocket_base_url
+        )
         provider_runtime: _ProviderRuntime | None = None
         if provider is not None:
             provider_name = _provider_name(provider)
@@ -656,7 +663,8 @@ class OpenAI(SyncAPIClient):
         project: str | None = None,
         webhook_secret: str | None = None,
         websocket_base_url: str | httpx2.URL | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = not_given,
+        data_residency: DataResidency | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx2.Client | None = None,
         max_retries: int | NotGiven = not_given,
@@ -669,6 +677,7 @@ class OpenAI(SyncAPIClient):
     ) -> Self:
         """
         Create a new client instance re-using the same options given to the current client with optional overriding.
+        `data_residency` replaces the inherited HTTP and WebSocket endpoints, without changing this client.
         """
         if default_headers is not None and set_default_headers is not None:
             raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
@@ -695,6 +704,9 @@ class OpenAI(SyncAPIClient):
         http_client = http_client or self._client
 
         next_provider = self._provider if isinstance(provider, NotGiven) else provider
+        base_url = resolve_data_residency(
+            data_residency, base_url, provider=next_provider, websocket_base_url=websocket_base_url
+        )
         preserve_default_base_url = False
         auth_options: dict[str, Any]
         if next_provider is not None:
@@ -734,7 +746,7 @@ class OpenAI(SyncAPIClient):
             organization=organization or inherited_organization,
             project=project or inherited_project,
             webhook_secret=webhook_secret or self.webhook_secret,
-            websocket_base_url=websocket_base_url or self.websocket_base_url,
+            websocket_base_url=None if data_residency is not None else websocket_base_url or self.websocket_base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,
@@ -831,7 +843,8 @@ class AsyncOpenAI(AsyncAPIClient):
         project: str | None = None,
         webhook_secret: str | None = None,
         provider: _Provider | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = not_given,
+        data_residency: DataResidency | None = None,
         websocket_base_url: str | httpx2.URL | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         max_retries: int = DEFAULT_MAX_RETRIES,
@@ -862,7 +875,12 @@ class AsyncOpenAI(AsyncAPIClient):
         - `webhook_secret` from `OPENAI_WEBHOOK_SECRET`
 
         When `provider` is supplied, authentication and the base URL are configured by that provider instead.
+        `data_residency` selects an OpenAI regional endpoint and cannot be combined with
+        `base_url`, `websocket_base_url`, or `provider`.
         """
+        base_url = resolve_data_residency(
+            data_residency, base_url, provider=provider, websocket_base_url=websocket_base_url
+        )
         provider_runtime: _ProviderRuntime | None = None
         if provider is not None:
             provider_name = _provider_name(provider)
@@ -1342,7 +1360,8 @@ class AsyncOpenAI(AsyncAPIClient):
         project: str | None = None,
         webhook_secret: str | None = None,
         websocket_base_url: str | httpx2.URL | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = not_given,
+        data_residency: DataResidency | None = None,
         timeout: float | Timeout | None | NotGiven = not_given,
         http_client: httpx2.AsyncClient | None = None,
         max_retries: int | NotGiven = not_given,
@@ -1355,6 +1374,7 @@ class AsyncOpenAI(AsyncAPIClient):
     ) -> Self:
         """
         Create a new client instance re-using the same options given to the current client with optional overriding.
+        `data_residency` replaces the inherited HTTP and WebSocket endpoints, without changing this client.
         """
         if default_headers is not None and set_default_headers is not None:
             raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
@@ -1380,6 +1400,9 @@ class AsyncOpenAI(AsyncAPIClient):
 
         http_client = http_client or self._client
         next_provider = self._provider if isinstance(provider, NotGiven) else provider
+        base_url = resolve_data_residency(
+            data_residency, base_url, provider=next_provider, websocket_base_url=websocket_base_url
+        )
         preserve_default_base_url = False
         auth_options: dict[str, Any]
         if next_provider is not None:
@@ -1419,7 +1442,7 @@ class AsyncOpenAI(AsyncAPIClient):
             organization=organization or inherited_organization,
             project=project or inherited_project,
             webhook_secret=webhook_secret or self.webhook_secret,
-            websocket_base_url=websocket_base_url or self.websocket_base_url,
+            websocket_base_url=None if data_residency is not None else websocket_base_url or self.websocket_base_url,
             timeout=self.timeout if isinstance(timeout, NotGiven) else timeout,
             http_client=http_client,
             max_retries=max_retries if is_given(max_retries) else self.max_retries,

--- a/src/openai/_data_residency.py
+++ b/src/openai/_data_residency.py
@@ -1,0 +1,40 @@
+# File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+import httpx2
+
+from ._types import NotGiven
+from ._exceptions import OpenAIError
+
+DataResidency = Literal["global", "us", "eu", "ae"]
+
+_DATA_RESIDENCY_BASE_URLS: dict[DataResidency, str] = {
+    "global": "https://api.openai.com/v1",
+    "us": "https://us.api.openai.com/v1",
+    "eu": "https://eu.api.openai.com/v1",
+    "ae": "https://ae.api.openai.com/v1",
+}
+
+
+def resolve_data_residency(
+    data_residency: DataResidency | None,
+    base_url: str | httpx2.URL | None | NotGiven,
+    *,
+    provider: object | None = None,
+    websocket_base_url: str | httpx2.URL | None = None,
+) -> str | httpx2.URL | None:
+    """Resolve a named endpoint before inherited or environment options are applied."""
+    if data_residency is None:
+        return None if isinstance(base_url, NotGiven) else base_url
+    if not isinstance(base_url, NotGiven):
+        raise ValueError("The `data_residency` and `base_url` arguments are mutually exclusive")
+    if websocket_base_url is not None:
+        raise ValueError("The `data_residency` and `websocket_base_url` arguments are mutually exclusive")
+    if provider is not None:
+        raise OpenAIError("The `data_residency` and `provider` arguments are mutually exclusive")
+    if not isinstance(cast(object, data_residency), str) or data_residency not in _DATA_RESIDENCY_BASE_URLS:
+        raise ValueError("Invalid `data_residency`; expected one of 'global', 'us', 'eu', or 'ae'")
+    return _DATA_RESIDENCY_BASE_URLS[data_residency]

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -19,6 +19,7 @@ from .._streaming import Stream, AsyncStream
 from ..auth._x509 import is_x509_workload_identity
 from .._exceptions import OpenAIError
 from .._base_client import DEFAULT_MAX_RETRIES, BaseClient
+from .._data_residency import DataResidency
 
 _deployments_endpoints = set(
     [
@@ -297,7 +298,8 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         api_version: str | None = None,
         azure_ad_token: str | None = None,
         azure_ad_token_provider: AzureADTokenProvider | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = NOT_GIVEN,
+        data_residency: DataResidency | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx2.Client | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
@@ -311,6 +313,9 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         """
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
+        if data_residency is not None:
+            raise OpenAIError("`data_residency` is only supported by OpenAI clients")
+        base_url = None if isinstance(base_url, NotGiven) else base_url
         if not isinstance(provider, NotGiven):
             raise OpenAIError("Configure `provider` on `OpenAI`, not on `AzureOpenAI.with_options()`.")
         if is_x509_workload_identity(workload_identity):
@@ -626,7 +631,8 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         api_version: str | None = None,
         azure_ad_token: str | None = None,
         azure_ad_token_provider: AsyncAzureADTokenProvider | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = NOT_GIVEN,
+        data_residency: DataResidency | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx2.AsyncClient | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
@@ -640,6 +646,9 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         """
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
+        if data_residency is not None:
+            raise OpenAIError("`data_residency` is only supported by OpenAI clients")
+        base_url = None if isinstance(base_url, NotGiven) else base_url
         if not isinstance(provider, NotGiven):
             raise OpenAIError("Configure `provider` on `AsyncOpenAI`, not on `AsyncAzureOpenAI.with_options()`.")
         if is_x509_workload_identity(workload_identity):

--- a/src/openai/lib/bedrock.py
+++ b/src/openai/lib/bedrock.py
@@ -18,6 +18,7 @@ from .._models import FinalRequestOptions
 from .._provider import _Provider, _configure_provider
 from .._exceptions import OpenAIError
 from .._base_client import DEFAULT_MAX_RETRIES
+from .._data_residency import DataResidency
 from ..providers.bedrock import (
     AwsCredentialsProvider,
     bedrock,
@@ -549,7 +550,8 @@ class BedrockOpenAI(OpenAI):
         project: str | None = None,
         webhook_secret: str | None = None,
         websocket_base_url: str | httpx2.URL | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = NOT_GIVEN,
+        data_residency: DataResidency | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx2.Client | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
@@ -560,6 +562,9 @@ class BedrockOpenAI(OpenAI):
         _enforce_credentials: bool | None = None,
         _extra_kwargs: Mapping[str, Any] = {},
     ) -> Self:
+        if data_residency is not None:
+            raise OpenAIError("`data_residency` is only supported by OpenAI clients")
+        base_url = None if isinstance(base_url, NotGiven) else base_url
         if callable(api_key):
             raise OpenAIError("Pass refreshable Bedrock credentials via `bedrock_token_provider`, not `api_key`.")
         if not isinstance(provider, NotGiven):
@@ -783,7 +788,8 @@ class AsyncBedrockOpenAI(AsyncOpenAI):
         project: str | None = None,
         webhook_secret: str | None = None,
         websocket_base_url: str | httpx2.URL | None = None,
-        base_url: str | httpx2.URL | None = None,
+        base_url: str | httpx2.URL | None | NotGiven = NOT_GIVEN,
+        data_residency: DataResidency | None = None,
         timeout: float | Timeout | None | NotGiven = NOT_GIVEN,
         http_client: httpx2.AsyncClient | None = None,
         max_retries: int | NotGiven = NOT_GIVEN,
@@ -794,6 +800,9 @@ class AsyncBedrockOpenAI(AsyncOpenAI):
         _enforce_credentials: bool | None = None,
         _extra_kwargs: Mapping[str, Any] = {},
     ) -> Self:
+        if data_residency is not None:
+            raise OpenAIError("`data_residency` is only supported by OpenAI clients")
+        base_url = None if isinstance(base_url, NotGiven) else base_url
         if callable(api_key):
             raise OpenAIError("Pass refreshable Bedrock credentials via `bedrock_token_provider`, not `api_key`.")
         if not isinstance(provider, NotGiven):

--- a/tests/test_data_residency_contract.py
+++ b/tests/test_data_residency_contract.py
@@ -1,0 +1,134 @@
+# File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast, get_args
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI, DataResidency
+
+REGIONS: list[tuple[DataResidency, str]] = [
+    ("global", "https://api.openai.com/v1"),
+    ("us", "https://us.api.openai.com/v1"),
+    ("eu", "https://eu.api.openai.com/v1"),
+    ("ae", "https://ae.api.openai.com/v1"),
+]
+
+
+@pytest.fixture(autouse=True)
+def clear_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("OPENAI_API_KEY", "OPENAI_ADMIN_KEY", "OPENAI_BASE_URL", "OPENAI_CUSTOM_HEADERS"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_public_type() -> None:
+    assert set(get_args(DataResidency)) == {region for region, _ in REGIONS}
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize(("region", "url"), REGIONS)
+def test_constructor_and_copy_mappings(
+    client_type: type[OpenAI] | type[AsyncOpenAI], region: DataResidency, url: str
+) -> None:
+    original = client_type(api_key="test-key", base_url="https://original.example/v1")
+    regional = original.with_options(data_residency=region)
+    assert regional.base_url == httpx2.URL(url.rstrip("/") + "/")
+    assert client_type(api_key="test-key", data_residency=region).base_url == regional.base_url
+    assert original.base_url == httpx2.URL("https://original.example/v1/")
+    assert regional._client is original._client
+    assert regional.copy().base_url == regional.base_url
+    assert regional.with_options(data_residency=None).base_url == regional.base_url
+    assert regional.with_options(base_url="https://override.example/v1").base_url == httpx2.URL(
+        "https://override.example/v1/"
+    )
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize("base_url", [None, "https://custom.example/v1", httpx2.URL("https://custom.example/v1")])
+def test_explicit_base_url_conflicts(
+    client_type: type[OpenAI] | type[AsyncOpenAI], base_url: str | httpx2.URL | None
+) -> None:
+    region = REGIONS[0][0]
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        client_type(api_key="test-key", data_residency=region, base_url=base_url)
+    client = client_type(api_key="test-key")
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        client.with_options(base_url=base_url, data_residency=region)
+    assert client.with_options(base_url=base_url, data_residency=None).base_url == (
+        httpx2.URL(str(base_url).rstrip("/") + "/") if base_url is not None else client.base_url
+    )
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize("region", ["", "UNKNOWN-RESIDENCY", 42, []])
+def test_unknown_regions_fail_locally(client_type: type[OpenAI] | type[AsyncOpenAI], region: object) -> None:
+    with pytest.raises(ValueError, match="Invalid `data_residency`"):
+        client_type(api_key="test-key", data_residency=cast(Any, region))
+    with pytest.raises(ValueError, match="Invalid `data_residency`"):
+        client_type(api_key="test-key").copy(data_residency=cast(Any, region))
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize(("region", "url"), REGIONS)
+def test_environment_is_not_an_explicit_conflict(
+    client_type: type[OpenAI] | type[AsyncOpenAI], region: DataResidency, url: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://environment.example/v1")
+    assert client_type(api_key="test-key", data_residency=region).base_url == httpx2.URL(url.rstrip("/") + "/")
+    original = client_type(api_key="test-key", base_url=None)
+    assert original.base_url == httpx2.URL("https://environment.example/v1/")
+    regional = original.copy(data_residency=region)
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://changed.example/v1")
+    assert regional.copy().base_url == regional.base_url
+    assert regional.copy(base_url=None).base_url == regional.base_url
+
+
+def check_request(request: httpx2.Request) -> httpx2.Response:
+    assert request.url == httpx2.URL(REGIONS[0][1].rstrip("/") + "/data-residency-contract")
+    assert json.loads(request.content) == {"message": "hello"}
+    assert not any("residency" in name for name in request.headers)
+    assert request.headers["Authorization"] == "Bearer test-key"
+    return httpx2.Response(200, request=request, json={"ok": True})
+
+
+def test_sync_request_only_changes_destination() -> None:
+    with httpx2.Client(transport=httpx2.MockTransport(check_request), trust_env=False) as transport:
+        client = OpenAI(api_key="test-key", base_url="https://original.example/v1", http_client=transport)
+        result = client.with_options(data_residency=REGIONS[0][0]).post(
+            "/data-residency-contract", cast_to=object, body={"message": "hello"}
+        )
+        assert result == {"ok": True}
+        assert client.base_url == httpx2.URL("https://original.example/v1/")
+
+
+async def test_async_request_only_changes_destination() -> None:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(check_request), trust_env=False) as transport:
+        client = AsyncOpenAI(api_key="test-key", base_url="https://original.example/v1", http_client=transport)
+        result = await client.with_options(data_residency=REGIONS[0][0]).post(
+            "/data-residency-contract", cast_to=object, body={"message": "hello"}
+        )
+        assert result == {"ok": True}
+        assert client.base_url == httpx2.URL("https://original.example/v1/")
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize(("region", "url"), REGIONS)
+def test_residency_replaces_inherited_websocket_url(
+    client_type: type[OpenAI] | type[AsyncOpenAI], region: DataResidency, url: str
+) -> None:
+    original = client_type(api_key="test-key", websocket_base_url="wss://original.example/v1")
+    regional = original.with_options(data_residency=region)
+    assert original.copy().websocket_base_url == original.websocket_base_url
+    assert original.copy(data_residency=None).websocket_base_url == original.websocket_base_url
+    assert regional.websocket_base_url is None
+    assert regional.copy().websocket_base_url is None
+    assert regional.base_url == httpx2.URL(url.rstrip("/") + "/")
+    for websocket_base_url in ("wss://custom.example/v1", httpx2.URL("wss://custom.example/v1")):
+        with pytest.raises(ValueError, match="`data_residency` and `websocket_base_url`"):
+            client_type(api_key="test-key", data_residency=region, websocket_base_url=websocket_base_url)
+        with pytest.raises(ValueError, match="`data_residency` and `websocket_base_url`"):
+            original.with_options(data_residency=region, websocket_base_url=websocket_base_url)
+    assert original.with_options(data_residency=region, websocket_base_url=None).websocket_base_url is None

--- a/tests/test_data_residency_regressions.py
+++ b/tests/test_data_residency_regressions.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+
+import httpx2
+import pytest
+
+from openai import (
+    OpenAI,
+    AsyncOpenAI,
+    AzureOpenAI,
+    OpenAIError,
+    BedrockOpenAI,
+    DataResidency,
+    AsyncAzureOpenAI,
+    AsyncBedrockOpenAI,
+)
+from openai.providers import bedrock
+from openai._data_residency import _DATA_RESIDENCY_BASE_URLS
+
+REGIONS: list[tuple[DataResidency, str]] = [
+    (region, url.rstrip("/") + "/") for region, url in _DATA_RESIDENCY_BASE_URLS.items()
+]
+
+
+@pytest.fixture(autouse=True)
+def clear_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("OPENAI_API_KEY", "OPENAI_ADMIN_KEY", "OPENAI_BASE_URL", "OPENAI_CUSTOM_HEADERS"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+def test_provider_conflicts_and_explicit_switch(client_type: type[OpenAI] | type[AsyncOpenAI]) -> None:
+    provider = bedrock(region="us-east-1", api_key="test-bedrock-key")
+    with pytest.raises(OpenAIError, match="`data_residency` and `provider`"):
+        client_type(provider=provider, data_residency="eu")
+    original = client_type(provider=provider)
+    with pytest.raises(OpenAIError, match="`data_residency` and `provider`"):
+        original.with_options(data_residency="eu")
+    with pytest.raises(OpenAIError, match="`data_residency` and `provider`"):
+        client_type(api_key="test-key").with_options(provider=provider, data_residency="eu")
+    assert original.with_options(data_residency=None).base_url == original.base_url
+    assert original.with_options(provider=None, api_key="test-key", data_residency="eu").base_url == httpx2.URL(
+        "https://eu.api.openai.com/v1/"
+    )
+    regional = client_type(api_key="test-key", data_residency="eu")
+    assert regional.with_options(provider=provider).base_url == original.base_url
+
+
+@pytest.mark.parametrize("client_type", [AzureOpenAI, AsyncAzureOpenAI])
+def test_legacy_azure_rejects_residency(client_type: type[AzureOpenAI] | type[AsyncAzureOpenAI]) -> None:
+    client = client_type(api_key="test-azure-key", api_version="test", azure_endpoint="https://azure.example")
+    with pytest.raises(OpenAIError, match="only supported by OpenAI clients"):
+        client.with_options(data_residency="eu")
+    assert client.with_options(data_residency=None).base_url == client.base_url
+
+
+@pytest.mark.parametrize("client_type", [BedrockOpenAI, AsyncBedrockOpenAI])
+def test_legacy_bedrock_rejects_residency(client_type: type[BedrockOpenAI] | type[AsyncBedrockOpenAI]) -> None:
+    client = client_type(api_key="test-bedrock-key", aws_region="us-east-1")
+    with pytest.raises(OpenAIError, match="only supported by OpenAI clients"):
+        client.with_options(data_residency="eu")
+    assert client.with_options(data_residency=None).base_url == client.base_url
+
+
+def check_request(request: httpx2.Request) -> httpx2.Response:
+    assert request.url == httpx2.URL("https://eu.api.openai.com/v1/responses")
+    assert json.loads(request.content) == {"input": "Hello", "model": "gpt-5.6-sol"}
+    assert not any("residency" in name for name in request.headers)
+    assert request.headers["Authorization"] == "Bearer test-key"
+    return httpx2.Response(200, request=request, json={"id": "resp_test", "output": []})
+
+
+def test_sync_request_only_changes_destination() -> None:
+    with httpx2.Client(transport=httpx2.MockTransport(check_request), trust_env=False) as transport:
+        client = OpenAI(api_key="test-key", http_client=transport)
+        response = client.with_options(data_residency="eu").responses.create(model="gpt-5.6-sol", input="Hello")
+        assert response.id == "resp_test"
+        assert client.base_url == httpx2.URL("https://api.openai.com/v1/")
+
+
+async def test_async_request_only_changes_destination() -> None:
+    async with httpx2.AsyncClient(transport=httpx2.MockTransport(check_request), trust_env=False) as transport:
+        client = AsyncOpenAI(api_key="test-key", http_client=transport)
+        response = await client.with_options(data_residency="eu").responses.create(model="gpt-5.6-sol", input="Hello")
+        assert response.id == "resp_test"
+        assert client.base_url == httpx2.URL("https://api.openai.com/v1/")
+
+
+@pytest.mark.parametrize("client_type", [OpenAI, AsyncOpenAI])
+@pytest.mark.parametrize(("region", "url"), REGIONS)
+def test_residency_replaces_inherited_websocket_routing(
+    client_type: type[OpenAI] | type[AsyncOpenAI], region: DataResidency, url: str
+) -> None:
+    original = client_type(api_key="test-key", websocket_base_url="wss://third-party.example/v1")
+    regional = original.with_options(data_residency=region)
+    assert original.copy().websocket_base_url == original.websocket_base_url
+    assert original.copy(data_residency=None).websocket_base_url == original.websocket_base_url
+    assert original.realtime.connect()._prepare_url() == httpx2.URL("wss://third-party.example/v1/realtime")
+    assert original.responses.connect()._prepare_url() == httpx2.URL("wss://third-party.example/v1/responses")
+
+    for client in (regional, regional.copy(), client_type(api_key="test-key", data_residency=region)):
+        assert client.websocket_base_url is None
+        ws_url = url.replace("https://", "wss://")
+        assert client.realtime.connect()._prepare_url() == httpx2.URL(ws_url + "realtime")
+        assert client.responses.connect()._prepare_url() == httpx2.URL(ws_url + "responses")
+        assert client.beta.realtime.connect(model="gpt-4o")._prepare_url() == httpx2.URL(ws_url + "realtime")
+        assert client.beta.responses.connect()._prepare_url() == httpx2.URL(ws_url + "responses")


### PR DESCRIPTION
## Summary

Let applications select an OpenAI regional endpoint by name instead of assembling base URLs themselves. The new `data_residency` option supports `global`, `us`, `eu`, and `ae`, applies consistently to synchronous/asynchronous clients and their copies, and keeps HTTP and WebSocket routing aligned.

Explicit endpoint conflicts and third-party provider combinations fail locally. This selects routing only; it does not change project eligibility or provide regional fallback.
