### PR TITLE
chore: remove unused dependencies and pin build tooling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
   "anyio>=4.10.0, <5",
   "distro>=1.7.0, <2",
   "sniffio",
-    "tqdm > 4",
-    "jiter>=0.10.0, <1",
+  "jiter>=0.10.0, <1",
 ]
 
 requires-python = ">= 3.10"
@@ -46,7 +45,7 @@ aiohttp = [
   "aiohttp>=3.14.1",
 ]
 realtime = ["websockets >= 13, < 16"]
-datalib = ["numpy >= 1", "pandas >= 1.2.3", "pandas-stubs >= 1.1.0.11"]
+datalib = ["numpy >= 1", "pandas >= 1.2.3"]
 voice_helpers = ["sounddevice>=0.5.1", "numpy>=2.0.2"]
 bedrock = [
   "botocore>=1.40.0,<2",
@@ -62,18 +61,13 @@ dev-dependencies = [
     "pytest-asyncio",
     "jsonschema>=4.23.0",
     "ruff",
-    "time-machine",
     "nox",
-    "dirty-equals>=0.6.0",
-    "importlib-metadata>=6.7.0",
     "rich>=13.7.1",
     "inline-snapshot>=0.28.0",
     "azure-identity >=1.14.1",
     "botocore==1.42.97",
-    "types-tqdm > 4",
-    "types-pyaudio > 0",
+    "pandas-stubs >= 1.1.0.11",
     "trio >=0.22.2",
-    "nest_asyncio==1.6.0",
     "pytest-xdist>=3.6.1",
     "griffe>=1",
 ]
@@ -108,7 +102,7 @@ typecheck = { chain = [
 "typecheck:mypy" = "mypy ."
 
 [build-system]
-requires = ["hatchling==1.26.3", "hatch-fancy-pypi-readme"]
+requires = ["hatchling==1.26.3", "hatch-fancy-pypi-readme==25.1.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -53,7 +53,6 @@ colorama==0.4.6
     # via colorlog
     # via griffe
     # via pytest
-    # via tqdm
 colorlog==6.10.1
     # via nox
 cryptography==46.0.3
@@ -62,7 +61,6 @@ cryptography==46.0.3
     # via pyjwt
 dependency-groups==1.3.1
     # via nox
-dirty-equals==0.11
 distlib==0.4.0
     # via virtualenv
 distro==1.9.0
@@ -95,7 +93,6 @@ idna==3.18
     # via requests
     # via trio
     # via yarl
-importlib-metadata==8.7.1
 iniconfig==2.1.0
     # via pytest
 inline-snapshot==0.31.1
@@ -121,7 +118,6 @@ multidict==6.7.1
 mypy==1.17.0
 mypy-extensions==1.1.0
     # via mypy
-nest-asyncio==1.6.0
 nodeenv==1.9.1
     # via pyright
 nox==2025.11.12
@@ -142,7 +138,6 @@ packaging==25.0
 pandas==2.3.3
     # via openai
 pandas-stubs==2.2.2.240807
-    # via openai
 pathspec==0.12.1
     # via mypy
 platformdirs==4.4.0
@@ -173,7 +168,6 @@ pytest-xdist==3.8.0
 python-dateutil==2.9.0.post0
     # via botocore
     # via pandas
-    # via time-machine
 pytz==2025.2
     # via pandas
 referencing==0.36.2
@@ -197,27 +191,18 @@ sortedcontainers==2.4.0
     # via trio
 sounddevice==0.5.3
     # via openai
-time-machine==2.19.0
 tomli==2.4.0 ; python_full_version < '3.11'
     # via dependency-groups
     # via inline-snapshot
     # via mypy
     # via nox
     # via pytest
-tqdm==4.67.1
-    # via openai
 trio==0.31.0
 truststore==0.10.4
     # via httpcore2
     # via httpx2
-types-pyaudio==0.2.16.20250801
 types-pytz==2025.2.0.20251108
     # via pandas-stubs
-types-requests==2.31.0.6
-    # via types-tqdm
-types-tqdm==4.67.0.20250809
-types-urllib3==1.26.25.14
-    # via types-requests
 typing-extensions==4.15.0
     # via aiohttp
     # via aiosignal
@@ -250,5 +235,3 @@ websockets==15.0.1
     # via openai
 yarl==1.24.2
     # via aiohttp
-zipp==3.23.0
-    # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -29,8 +29,6 @@ botocore==1.42.97
     # via openai
 cffi==2.0.0
     # via sounddevice
-colorama==0.4.6 ; sys_platform == 'win32'
-    # via tqdm
 distro==1.9.0
     # via openai
 exceptiongroup==1.3.1 ; python_full_version < '3.11'
@@ -58,14 +56,10 @@ multidict==6.7.1
 numpy==2.2.6 ; python_full_version < '3.11'
     # via openai
     # via pandas
-    # via pandas-stubs
 numpy==2.4.6 ; python_full_version >= '3.11'
     # via openai
     # via pandas
-    # via pandas-stubs
 pandas==2.3.3
-    # via openai
-pandas-stubs==2.2.2.240807
     # via openai
 propcache==0.5.2
     # via aiohttp
@@ -87,13 +81,9 @@ sniffio==1.3.1
     # via openai
 sounddevice==0.5.3
     # via openai
-tqdm==4.67.1
-    # via openai
 truststore==0.10.4
     # via httpcore2
     # via httpx2
-types-pytz==2025.2.0.20251108
-    # via pandas-stubs
 typing-extensions==4.15.0
     # via aiohttp
     # via aiosignal

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import anyio
 import pytest
-from dirty_equals import IsDict, IsList, IsBytes, IsTuple
 
 from openai._files import to_httpx_files, deepcopy_with_paths, async_to_httpx_files
 from openai._utils import extract_files
@@ -12,35 +11,30 @@ readme_path = Path(__file__).parent.parent.joinpath("README.md")
 
 def test_pathlib_includes_file_name() -> None:
     result = to_httpx_files({"file": readme_path})
-    print(result)
-    assert result == IsDict({"file": IsTuple("README.md", IsBytes())})
+    assert result == {"file": ("README.md", readme_path.read_bytes())}
 
 
 def test_tuple_input() -> None:
     result = to_httpx_files([("file", readme_path)])
-    print(result)
-    assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
+    assert result == [("file", ("README.md", readme_path.read_bytes()))]
 
 
 @pytest.mark.asyncio
 async def test_async_pathlib_includes_file_name() -> None:
     result = await async_to_httpx_files({"file": readme_path})
-    print(result)
-    assert result == IsDict({"file": IsTuple("README.md", IsBytes())})
+    assert result == {"file": ("README.md", readme_path.read_bytes())}
 
 
 @pytest.mark.asyncio
 async def test_async_supports_anyio_path() -> None:
     result = await async_to_httpx_files({"file": anyio.Path(readme_path)})
-    print(result)
-    assert result == IsDict({"file": IsTuple("README.md", IsBytes())})
+    assert result == {"file": ("README.md", readme_path.read_bytes())}
 
 
 @pytest.mark.asyncio
 async def test_async_tuple_input() -> None:
     result = await async_to_httpx_files([("file", readme_path)])
-    print(result)
-    assert result == IsList(IsTuple("file", IsTuple("README.md", IsBytes())))
+    assert result == [("file", ("README.md", readme_path.read_bytes()))]
 
 
 def test_string_not_allowed() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -308,15 +308,6 @@ wheels = [
 ]
 
 [[package]]
-name = "colorama"
-version = "0.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -330,7 +321,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -918,7 +909,6 @@ dependencies = [
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
 
@@ -934,8 +924,6 @@ datalib = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 realtime = [
     { name = "websockets" },
@@ -957,11 +945,9 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'datalib'", specifier = ">=1" },
     { name = "numpy", marker = "extra == 'voice-helpers'", specifier = ">=2.0.2" },
     { name = "pandas", marker = "extra == 'datalib'", specifier = ">=1.2.3" },
-    { name = "pandas-stubs", marker = "extra == 'datalib'", specifier = ">=1.1.0.11" },
     { name = "pydantic", specifier = ">=1.9.0,<3" },
     { name = "sniffio" },
     { name = "sounddevice", marker = "extra == 'voice-helpers'", specifier = ">=0.5.1" },
-    { name = "tqdm", specifier = ">4" },
     { name = "typing-extensions", specifier = ">=4.14,<5" },
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=13,<16" },
 ]
@@ -975,10 +961,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -1044,9 +1030,9 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -1097,42 +1083,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
     { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
     { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
-]
-
-[[package]]
-name = "pandas-stubs"
-version = "2.3.3.260113"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "types-pytz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
-]
-
-[[package]]
-name = "pandas-stubs"
-version = "3.0.3.260530"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
 ]
 
 [[package]]
@@ -1459,33 +1409,12 @@ wheels = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.68.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
-]
-
-[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
-]
-
-[[package]]
-name = "types-pytz"
-version = "2026.2.0.20260518"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/d9/9fa4019d2235bd374293e1fd4153879b28b6ae1d2bae98addd352c9713f2/types_pytz-2026.2.0.20260518.tar.gz", hash = "sha256:e5d254329e9c4e91f0781b22c43a4bb2d10bb044d97b24c4b05d45567b0eae16", size = 10871, upload-time = "2026-05-18T06:02:45.789Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/89/41e80670779a223d8bc8bc83019a619988cfa5c432cedac5cec23884fbc4/types_pytz-2026.2.0.20260518-py3-none-any.whl", hash = "sha256:3a12eaa38f476bd650902a9c9bb442f03f3c7dee2be5c5848bce61bd708d205a", size = 10125, upload-time = "2026-05-18T06:02:44.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Remove unused runtime and development dependencies.
- Keep pandas type stubs in the development environment rather than the `datalib` extra.
- Replace the affected file-test matchers with direct assertions and pin the existing README build hook.
- Refresh the lockfiles without upgrading retained packages. No SDK API or Python-version changes.

## Dependency counts

Counts are unique third-party distribution names across supported lockfile markers.

| Scope | Before | After |
| --- | ---: | ---: |
| Default runtime | 17 | 15 |
| All runtime extras | 41 | 37 |
| Development lock | 98 | 88 |

## Validation

- Ruff, Pyright, mypy, and import checks pass.
- Wheel and source distribution build and dependency-metadata checks pass.
- Full mocked tests: 7,664 passed / 31 skipped with Pydantic v2; 7,650 passed / 45 skipped with v1.

[Full dependency review (internal access required)](https://github.com/openai/openai-python-internal/blob/67531d875450449e2120a3aa54e4343fecf7bf21/docs/dependency-audit/2026-08-18/README.md).
