### PR TITLE
fix: type APIStatusError.code as int | str | None (gh-3531)

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -58,7 +58,7 @@ class APIError(OpenAIError):
     If there was no response associated with this error then it will be `None`.
     """
 
-    code: Optional[str] = None
+    code: int | str | None = None
     param: Optional[str] = None
     type: Optional[str]
 


### PR DESCRIPTION
Hi! I've opened a fix for this issue in PR #3652.

**The problem:** `APIStatusError.code` is typed `Optional[str]` but at runtime can hold an `int` (e.g. `{"error": {"code": 404}}`). The `construct_type` call returns the value unchanged when it doesn't match the target type, and `cast(Any, ...)` suppresses the type checker, so the annotation is misleading. Downstream code that trusts it and calls `exc.code.strip()` crashes with `AttributeError`.

**The fix:** Changed the annotation to `int | str | None` in `src/openai/_exceptions.py:61` to match actual runtime behavior.

PR: https://github.com/openai/openai-python/pull/3652