### PR TITLE
[2/n] Keep the package README hook in the repository

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ pydantic-v2 = ["pydantic>=2,<3"]
 # Isolated build requirements are exported with hashes by scripts/build.
 build = [
     "hatchling==1.26.3",
-    "hatch-fancy-pypi-readme==25.1.0",
     "packaging==26.3",
     "pathspec==1.1.1",
     "pluggy==1.6.0",
@@ -90,7 +89,6 @@ conflicts = [[{ group = "pydantic-v1" }, { group = "pydantic-v2" }]]
 # Also constrain editable/source builds performed by uv sync.
 build-constraint-dependencies = [
     "hatchling==1.26.3",
-    "hatch-fancy-pypi-readme==25.1.0",
     "packaging==26.3",
     "pathspec==1.1.1",
     "pluggy==1.6.0",
@@ -100,7 +98,7 @@ build-constraint-dependencies = [
 
 
 [build-system]
-requires = ["hatchling==1.26.3", "hatch-fancy-pypi-readme==25.1.0"]
+requires = ["hatchling==1.26.3"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
@@ -126,16 +124,8 @@ include = [
   "tests/*",
 ]
 
-[tool.hatch.metadata.hooks.fancy-pypi-readme]
-content-type = "text/markdown"
-
-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
-path = "README.md"
-
-[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
-# replace relative links with absolute links
-pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
-replacement = '[\1](https://github.com/openai/openai-python/tree/main/\g<2>)'
+[tool.hatch.metadata.hooks.custom]
+path = "scripts/hatch_metadata.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -166,6 +156,8 @@ exclude = [
     ".git",
     "tests/respx2",
     "src/openai/_vendor",
+    # Loaded in Hatchling's isolated build environment.
+    "scripts/hatch_metadata.py",
 
     # uses inline `uv` script dependencies
     # which means it can't be type checked
@@ -195,6 +187,7 @@ show_error_codes = true
 exclude = [
   'src/openai/_files.py',
   'src/openai/_vendor/.*',
+  'scripts/hatch_metadata.py',
   '_dev/.*.py',
   'tests/.*',
   'src/openai/_utils/_logs.py',

--- a/scripts/hatch_metadata.py
+++ b/scripts/hatch_metadata.py
@@ -1,0 +1,28 @@
+"""Prepare the package README without importing the SDK or extra build plugins."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from pathlib import Path
+
+
+def render_readme(text: str) -> str:
+    # Preserve the relative-link rewrite previously configured in pyproject.toml.
+    return re.sub(
+        r"\[(.+?)\]\(((?!https?://)\S+?)\)",
+        r"[\1](https://github.com/openai/openai-python/tree/main/\g<2>)",
+        text,
+    )
+
+
+def get_metadata_hook() -> type[Any]:
+    # Hatchling is available in the isolated build environment, not at runtime.
+    from hatchling.metadata.plugin.interface import MetadataHookInterface
+
+    class ReadmeMetadataHook(MetadataHookInterface):
+        def update(self, metadata: dict[str, Any]) -> None:
+            text = Path(self.root, "README.md").read_text(encoding="utf-8")
+            metadata["readme"] = {"content-type": "text/markdown", "text": render_readme(text)}
+
+    return ReadmeMetadataHook

--- a/tests/test_readme_metadata.py
+++ b/tests/test_readme_metadata.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+from typing import Callable, cast
+from pathlib import Path
+
+import pytest
+
+_render_readme = cast(
+    Callable[[str], str],
+    runpy.run_path(str(Path(__file__).parents[1] / "scripts" / "hatch_metadata.py"))["render_readme"],
+)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("[Guide](CONTRIBUTING.md)", "[Guide](https://github.com/openai/openai-python/tree/main/CONTRIBUTING.md)"),
+        (
+            "[Example](examples/demo.py#usage)",
+            "[Example](https://github.com/openai/openai-python/tree/main/examples/demo.py#usage)",
+        ),
+        ("[Docs](https://example.com/docs)", "[Docs](https://example.com/docs)"),
+        ("[Docs](http://example.com/docs)", "[Docs](http://example.com/docs)"),
+        ("Plain text — no links", "Plain text — no links"),
+    ],
+)
+def test_readme_link_rewriting(text: str, expected: str) -> None:
+    assert _render_readme(text) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,6 @@ exclude-newer-span = "P8D"
 
 [manifest]
 build-constraints = [
-    { name = "hatch-fancy-pypi-readme", specifier = "==25.1.0" },
     { name = "hatchling", specifier = "==1.26.3" },
     { name = "packaging", specifier = "==26.3" },
     { name = "pathspec", specifier = "==1.1.1" },
@@ -730,19 +729,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hatch-fancy-pypi-readme"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hatchling" },
-    { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'group-6-openai-pydantic-v1' and extra == 'group-6-openai-pydantic-v2')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0f/aed57c301f339936eb91cb4d8c1e5088a101081854bd3ec18a889df32365/hatch_fancy_pypi_readme-25.1.0.tar.gz", hash = "sha256:9c58ed3dff90d51f43414ce37009ad1d5b0f08ffc9fc216998a06380f01c0045", size = 29701, upload-time = "2025-05-01T10:34:42.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/b4/ad71e051b34f1935783de37beffee16e343ff2514b204dc515f9e939d4af/hatch_fancy_pypi_readme-25.1.0-py3-none-any.whl", hash = "sha256:ce0134c40d63d874ac48f48ccc678b8f3b62b8e50e9318520d2bffc752eedaf3", size = 10046, upload-time = "2025-05-01T10:34:41.204Z" },
-]
-
-[[package]]
 name = "hatchling"
 version = "1.26.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1363,7 +1349,6 @@ voice-helpers = [
 
 [package.dev-dependencies]
 build = [
-    { name = "hatch-fancy-pypi-readme" },
     { name = "hatchling" },
     { name = "packaging" },
     { name = "pathspec" },
@@ -1415,7 +1400,6 @@ provides-extras = ["aiohttp", "realtime", "datalib", "voice-helpers", "bedrock"]
 
 [package.metadata.requires-dev]
 build = [
-    { name = "hatch-fancy-pypi-readme", specifier = "==25.1.0" },
     { name = "hatchling", specifier = "==1.26.3" },
     { name = "packaging", specifier = "==26.3" },
     { name = "pathspec", specifier = "==1.1.1" },


### PR DESCRIPTION
# Summary

This is part of a series to reduce the SDK’s dependency surface where a small, purpose-built alternative is sufficient.

- Replace `hatch-fancy-pypi-readme` with a small repository-owned Hatch metadata hook for our existing relative-link rewrite.
- Preserve the README published in package metadata, including when a wheel is built from the source distribution.
- Reduce the isolated build dependency graph from seven to six distributions across supported Python versions. Runtime and development dependencies are unchanged.

## Stack

- https://github.com/openai/openai-python/pull/3653 (merged)
- https://github.com/openai/openai-python/pull/3654 (merged)
- https://github.com/openai/openai-python/pull/3655 👈 this PR
- https://github.com/openai/openai-python/pull/3656

<!--
BEGIN_COMMIT_OVERRIDE
build: replace the external README metadata hook
END_COMMIT_OVERRIDE
-->
