### PR TITLE
[3/n] Use the standard library for platform headers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "pydantic>=1.9.0, <3",
   "typing-extensions>=4.14, <5",
   "anyio>=4.10.0, <5",
-  "distro>=1.7.0, <2",
   "sniffio",
   "jiter>=0.10.0, <1",
 ]

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -34,7 +34,6 @@ from typing import (
 from typing_extensions import Unpack, Literal, override, get_origin
 
 import anyio
-import distro
 import httpx2
 import pydantic
 from httpx2 import URL
@@ -2186,9 +2185,18 @@ def get_platform() -> Platform:
         # system is Linux and platform_name is a string like 'Linux-5.10.81-android12-9-00001-geba40aecb3b7-ab8534902-aarch64-with-libc'
         return "Android"
 
+    if system == "freebsd":
+        return "FreeBSD"
+
+    if system == "openbsd":
+        return "OpenBSD"
+
     if system == "linux":
-        # https://distro.readthedocs.io/en/latest/#distro.id
-        distro_id = distro.id()
+        try:
+            distro_id = platform.freedesktop_os_release().get("ID", "").lower()
+        except OSError:
+            # This diagnostic header does not require an os-release file.
+            distro_id = ""
         if distro_id == "freebsd":
             return "FreeBSD"
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import threading
+from typing import Any, Iterator, cast
+from unittest.mock import Mock
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from openai._base_client import get_platform, platform_headers
+
+
+@pytest.fixture(autouse=True)
+def clear_platform_headers() -> Iterator[None]:
+    # The SDK's lru_cache wrapper preserves the callable's original signature.
+    cast(Any, platform_headers).cache_clear()
+    yield
+    cast(Any, platform_headers).cache_clear()
+
+
+@pytest.mark.parametrize(
+    "system,name,expected",
+    [
+        ("Darwin", "Darwin-iPhone12,1", "iOS"),
+        ("Darwin", "Darwin-iPad7,11", "iOS"),
+        ("Darwin", "macOS", "MacOS"),
+        ("Windows", "Windows-11", "Windows"),
+        ("Linux", "Linux-android12", "Android"),
+        ("FreeBSD", "FreeBSD-14", "FreeBSD"),
+        ("OpenBSD", "OpenBSD-7", "OpenBSD"),
+        ("SunOS", "SunOS-5", "Other:sunos-5"),
+        ("", "", "Unknown"),
+    ],
+)
+def test_non_linux_platforms(monkeypatch: pytest.MonkeyPatch, system: str, name: str, expected: str) -> None:
+    monkeypatch.setattr("openai._base_client.platform.system", lambda: system)
+    monkeypatch.setattr("openai._base_client.platform.platform", lambda: name)
+    os_release = Mock(side_effect=AssertionError("os-release must not be read"))
+    monkeypatch.setattr("openai._base_client.platform.freedesktop_os_release", os_release)
+    assert str(get_platform()) == expected
+    os_release.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "release,expected",
+    [({}, "Linux"), ({"ID": "ubuntu"}, "Linux"), ({"ID": "FREEBSD"}, "FreeBSD"), ({"ID": "openbsd"}, "OpenBSD")],
+)
+def test_linux_os_release(monkeypatch: pytest.MonkeyPatch, release: dict[str, str], expected: str) -> None:
+    monkeypatch.setattr("openai._base_client.platform.system", lambda: "Linux")
+    monkeypatch.setattr("openai._base_client.platform.platform", lambda: "Linux-6")
+    monkeypatch.setattr("openai._base_client.platform.freedesktop_os_release", lambda: release)
+    assert str(get_platform()) == expected
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError(), PermissionError(), OSError()])
+def test_unreadable_os_release(monkeypatch: pytest.MonkeyPatch, error: OSError) -> None:
+    monkeypatch.setattr("openai._base_client.platform.system", lambda: "Linux")
+    monkeypatch.setattr("openai._base_client.platform.platform", lambda: "Linux-6")
+    monkeypatch.setattr("openai._base_client.platform.freedesktop_os_release", Mock(side_effect=error))
+    assert get_platform() == "Linux"
+
+
+def test_platform_lookup_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("openai._base_client.platform.system", Mock(side_effect=OSError()))
+    assert get_platform() == "Unknown"
+
+
+def _linux_request_setup(monkeypatch: pytest.MonkeyPatch, expected: str) -> httpx2.MockTransport:
+    monkeypatch.setattr("openai._base_client.platform.system", lambda: "Linux")
+    monkeypatch.setattr("openai._base_client.platform.platform", lambda: "Linux-6")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        assert request.headers["X-Stainless-OS"] == expected
+        return httpx2.Response(200, json={})
+
+    return httpx2.MockTransport(handler)
+
+
+def test_sync_request_platform_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _linux_request_setup(monkeypatch, "Linux")
+    monkeypatch.setattr("openai._base_client.platform.freedesktop_os_release", Mock(side_effect=FileNotFoundError()))
+    with OpenAI(api_key="test-key", http_client=httpx2.Client(transport=transport, trust_env=False)) as client:
+        assert client.get("/models", cast_to=httpx2.Response).status_code == 200
+
+
+async def test_async_request_platform_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    transport = _linux_request_setup(monkeypatch, "FreeBSD")
+    event_loop_thread = threading.get_ident()
+    calls: list[int] = []
+
+    def os_release() -> dict[str, str]:
+        calls.append(threading.get_ident())
+        return {"ID": "freebsd"}
+
+    monkeypatch.setattr("openai._base_client.platform.freedesktop_os_release", os_release)
+    async with AsyncOpenAI(
+        api_key="test-key", http_client=httpx2.AsyncClient(transport=transport, trust_env=False)
+    ) as client:
+        for _ in range(2):
+            assert (await client.get("/models", cast_to=httpx2.Response)).status_code == 200
+    assert len(calls) == 1
+    assert calls[0] != event_loop_thread

--- a/uv.lock
+++ b/uv.lock
@@ -548,15 +548,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1316,7 +1307,6 @@ version = "3.3.0" # x-release-please-version
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "distro" },
     { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic", version = "1.10.26", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-6-openai-pydantic-v1'" },
@@ -1383,7 +1373,6 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.14.3" },
     { name = "anyio", specifier = ">=4.10.0,<5" },
     { name = "botocore", marker = "extra == 'bedrock'", specifier = ">=1.40.0,<2" },
-    { name = "distro", specifier = ">=1.7.0,<2" },
     { name = "httpx2", specifier = ">=2.7.0,<3" },
     { name = "jiter", specifier = ">=0.10.0,<1" },
     { name = "numpy", marker = "extra == 'datalib'", specifier = ">=1" },


### PR DESCRIPTION
# Summary

This is part of a series to reduce the SDK’s dependency surface where a small, purpose-built alternative is sufficient.

- Replace `distro` with Python’s standard OS-release lookup for the diagnostic platform header.
- Preserve mobile detection, recognize FreeBSD and OpenBSD directly, and fall back to `Linux` if OS-release information is unavailable.
- Matching `distro`’s exact behavior is explicitly a non-goal. This header only needs to be close enough for our analytics purposes; we prefer removing the dependency over reproducing its full distribution-detection and fallback behavior.
- Remove one runtime dependency: the default graph goes from 15 to 14 distributions, and the all-extras graph from 37 to 36. No remaining dependency versions change.

## Stack

- https://github.com/openai/openai-python/pull/3653 (merged)
- https://github.com/openai/openai-python/pull/3654 (merged)
- https://github.com/openai/openai-python/pull/3655 (merged)
- https://github.com/openai/openai-python/pull/3656 👈 this PR

<!--
BEGIN_COMMIT_OVERRIDE
refactor(deps): use the standard library for platform detection
END_COMMIT_OVERRIDE
-->
