### PR TITLE
fix: keep Python SDK diagnostics metadata-only

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -62,7 +62,7 @@ from ._types import (
     not_given,
 )
 from ._utils import SensitiveHeadersFilter, is_dict, is_list, asyncify, is_given, lru_cache, is_mapping
-from ._compat import PYDANTIC_V1, model_copy, model_dump
+from ._compat import PYDANTIC_V1, model_copy
 from ._httpx2 import (
     status_exceptions,
     timeout_exceptions,
@@ -519,20 +519,8 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         *,
         retries_taken: int = 0,
     ) -> httpx2.Request:
-        if log.isEnabledFor(logging.DEBUG):
-            log.debug(
-                "Request options: %s",
-                model_dump(
-                    options,
-                    exclude_unset=True,
-                    # Pydantic v1 can't dump every type we support in content, so we exclude it for now.
-                    exclude={
-                        "content",
-                    }
-                    if PYDANTIC_V1
-                    else {},
-                ),
-            )
+        # Request bodies, files, URLs, and custom options can contain private data.
+        log.debug("Building HTTP request: method=%s retries_taken=%i", options.method, retries_taken)
         kwargs: dict[str, Any] = {}
 
         json_data = options.json_data
@@ -1079,7 +1067,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             if options.follow_redirects is not None:
                 kwargs["follow_redirects"] = options.follow_redirects
 
-            log.debug("Sending HTTP Request: %s %s", request.method, request.url)
+            log.debug("Sending HTTP Request: %s", request.method)
 
             response = None
             try:
@@ -1089,7 +1077,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                     **kwargs,
                 )
             except timeout_exceptions() as err:
-                log.debug("Encountered a timeout exception", exc_info=True)
+                log.debug("Encountered a timeout exception: %s", type(err).__name__)
 
                 if remaining_retries > 0:
                     self._sleep_for_retry(
@@ -1106,7 +1094,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                 # Propagate OpenAIErrors as-is, without retrying or wrapping in APIConnectionError
                 raise err
             except Exception as err:
-                log.debug("Encountered Exception", exc_info=True)
+                log.debug("Encountered exception: %s", type(err).__name__)
 
                 if remaining_retries > 0:
                     self._sleep_for_retry(
@@ -1121,19 +1109,16 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                 raise APIConnectionError(request=request) from err
 
             log.debug(
-                'HTTP Response: %s %s "%i %s" %s',
+                "HTTP Response: %s %i",
                 request.method,
-                request.url,
                 response.status_code,
-                response.reason_phrase,
-                response.headers,
             )
             log.debug("request_id: %s", response.headers.get("x-request-id"))
 
             try:
                 response.raise_for_status()
             except status_exceptions() as err:  # thrown on 4xx and 5xx status code
-                log.debug("Encountered an HTTP status error", exc_info=True)
+                log.debug("Encountered an HTTP status error: %i", response.status_code)
 
                 if remaining_retries > 0 and self._should_retry(err.response):
                     err.response.close()
@@ -1175,7 +1160,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             log.debug("%i retries left", remaining_retries)
 
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
-        log.info("Retrying request to %s in %f seconds", options.url, timeout)
+        log.info("Retrying request in %f seconds", timeout)
 
         time.sleep(timeout)
 
@@ -1705,7 +1690,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             if options.follow_redirects is not None:
                 kwargs["follow_redirects"] = options.follow_redirects
 
-            log.debug("Sending HTTP Request: %s %s", request.method, request.url)
+            log.debug("Sending HTTP Request: %s", request.method)
 
             response = None
             try:
@@ -1715,7 +1700,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                     **kwargs,
                 )
             except timeout_exceptions() as err:
-                log.debug("Encountered a timeout exception", exc_info=True)
+                log.debug("Encountered a timeout exception: %s", type(err).__name__)
 
                 if remaining_retries > 0:
                     await self._sleep_for_retry(
@@ -1732,7 +1717,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                 # Propagate OpenAIErrors as-is, without retrying or wrapping in APIConnectionError
                 raise err
             except Exception as err:
-                log.debug("Encountered Exception", exc_info=True)
+                log.debug("Encountered exception: %s", type(err).__name__)
 
                 if remaining_retries > 0:
                     await self._sleep_for_retry(
@@ -1747,19 +1732,16 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                 raise APIConnectionError(request=request) from err
 
             log.debug(
-                'HTTP Response: %s %s "%i %s" %s',
+                "HTTP Response: %s %i",
                 request.method,
-                request.url,
                 response.status_code,
-                response.reason_phrase,
-                response.headers,
             )
             log.debug("request_id: %s", response.headers.get("x-request-id"))
 
             try:
                 response.raise_for_status()
             except status_exceptions() as err:  # thrown on 4xx and 5xx status code
-                log.debug("Encountered an HTTP status error", exc_info=True)
+                log.debug("Encountered an HTTP status error: %i", response.status_code)
 
                 if remaining_retries > 0 and self._should_retry(err.response):
                     await err.response.aclose()
@@ -1801,7 +1783,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             log.debug("%i retries left", remaining_retries)
 
         timeout = self._calculate_retry_timeout(remaining_retries, options, response.headers if response else None)
-        log.info("Retrying request to %s in %f seconds", options.url, timeout)
+        log.info("Retrying request in %f seconds", timeout)
 
         await anyio.sleep(timeout)
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -104,6 +104,7 @@ from ._exceptions import (
     APIResponseValidationError,
 )
 from ._utils._json import openapi_dumps
+from ._utils._logs import get_http_method_for_logging
 from ._legacy_response import LegacyAPIResponse
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -520,7 +521,11 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
         retries_taken: int = 0,
     ) -> httpx2.Request:
         # Request bodies, files, URLs, and custom options can contain private data.
-        log.debug("Building HTTP request: method=%s retries_taken=%i", options.method, retries_taken)
+        log.debug(
+            "Building HTTP request: method=%s retries_taken=%i",
+            get_http_method_for_logging(options.method),
+            retries_taken,
+        )
         kwargs: dict[str, Any] = {}
 
         json_data = options.json_data
@@ -1067,7 +1072,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             if options.follow_redirects is not None:
                 kwargs["follow_redirects"] = options.follow_redirects
 
-            log.debug("Sending HTTP Request: %s", request.method)
+            log.debug("Sending HTTP Request: %s", get_http_method_for_logging(request.method))
 
             response = None
             try:
@@ -1110,7 +1115,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
 
             log.debug(
                 "HTTP Response: %s %i",
-                request.method,
+                get_http_method_for_logging(request.method),
                 response.status_code,
             )
             log.debug("request_id: %s", response.headers.get("x-request-id"))
@@ -1690,7 +1695,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             if options.follow_redirects is not None:
                 kwargs["follow_redirects"] = options.follow_redirects
 
-            log.debug("Sending HTTP Request: %s", request.method)
+            log.debug("Sending HTTP Request: %s", get_http_method_for_logging(request.method))
 
             response = None
             try:
@@ -1733,7 +1738,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
 
             log.debug(
                 "HTTP Response: %s %i",
-                request.method,
+                get_http_method_for_logging(request.method),
                 response.status_code,
             )
             log.debug("request_id: %s", response.headers.get("x-request-id"))

--- a/src/openai/_legacy_response.py
+++ b/src/openai/_legacy_response.py
@@ -314,7 +314,7 @@ class LegacyAPIResponse(Generic[R]):
                 try:
                     data = response.json()
                 except Exception as exc:
-                    log.debug("Could not read JSON from response data due to %s - %s", type(exc), exc)
+                    log.debug("Could not read JSON from response data due to %s", type(exc).__name__)
                 else:
                     return self._client._process_response_data(
                         data=data,

--- a/src/openai/_response.py
+++ b/src/openai/_response.py
@@ -247,7 +247,7 @@ class BaseAPIResponse(Generic[R]):
                 try:
                     data = response.json()
                 except Exception as exc:
-                    log.debug("Could not read JSON from response data due to %s - %s", type(exc), exc)
+                    log.debug("Could not read JSON from response data due to %s", type(exc).__name__)
                 else:
                     return self._client._process_response_data(
                         data=data,

--- a/src/openai/_utils/_logs.py
+++ b/src/openai/_utils/_logs.py
@@ -5,30 +5,36 @@ from typing_extensions import override
 from ._utils import is_dict
 
 logger: logging.Logger = logging.getLogger("openai")
-httpx2_logger: logging.Logger = logging.getLogger("httpx2")
 
 
 SENSITIVE_HEADERS = {"api-key", "authorization", "x-amz-security-token"}
 
 
 def _basic_config() -> None:
-    # e.g. [2023-10-05 14:12:26 - openai._base_client:818 - DEBUG] HTTP Request: POST http://127.0.0.1:4010/foo/bar "200 OK"
+    # e.g. [2023-10-05 14:12:26 - openai._base_client:818 - DEBUG] HTTP Response: POST 200
     logging.basicConfig(
         format="[%(asctime)s - %(name)s:%(lineno)d - %(levelname)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
 
+def get_http_method_for_logging(method: str) -> str:
+    normalized = method.upper()
+    if normalized in {"GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH"}:
+        return normalized
+    return "<custom>"
+
+
 def setup_logging() -> None:
+    # Transport loggers may include complete URLs. Leave their configuration to
+    # the application instead of enabling them with the SDK's logging switch.
     env = os.environ.get("OPENAI_LOG")
     if env == "debug":
         _basic_config()
         logger.setLevel(logging.DEBUG)
-        httpx2_logger.setLevel(logging.DEBUG)
     elif env == "info":
         _basic_config()
         logger.setLevel(logging.INFO)
-        httpx2_logger.setLevel(logging.INFO)
 
 
 class SensitiveHeadersFilter(logging.Filter):

--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -277,7 +277,7 @@ class AsyncRealtimeConnection:
         then you can call `.parse_event(data)`.
         """
         message = await self._connection.recv(decode=False)
-        log.debug(f"Received websocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     async def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
@@ -369,9 +369,9 @@ class AsyncRealtimeConnectionManager:
                     **extra_query,
                 },
             )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         self.__connection = AsyncRealtimeConnection(
             await connect(
@@ -460,7 +460,7 @@ class RealtimeConnection:
         then you can call `.parse_event(data)`.
         """
         message = self._connection.recv(decode=False)
-        log.debug(f"Received websocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
@@ -552,9 +552,9 @@ class RealtimeConnectionManager:
                     **extra_query,
                 },
             )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         self.__connection = RealtimeConnection(
             connect(

--- a/src/openai/resources/beta/responses/responses.py
+++ b/src/openai/resources/beta/responses/responses.py
@@ -4175,7 +4175,7 @@ class AsyncResponsesConnection:
         then you can call `.parse_event(data)`.
         """
         message = await self._connection.recv(decode=False)
-        log.debug(f"Received WebSocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     async def send(self, event: BetaResponsesClientEvent | BetaResponsesClientEventParam) -> None:
@@ -4300,7 +4300,7 @@ class AsyncResponsesConnection:
         try:
             await self._send_queue.flush_async(_send)
         except Exception:
-            log.warning("Failed to flush send queue after reconnect", exc_info=True)
+            log.warning("Failed to flush send queue after reconnect")
 
     def on(
         self, event_type: str, handler: Callable[..., Any] | None = None
@@ -4524,9 +4524,9 @@ class AsyncResponsesConnectionManager:
                 **extra_query,
             },
         )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         return await connect(
             str(url),
@@ -4632,7 +4632,7 @@ class ResponsesConnection:
         then you can call `.parse_event(data)`.
         """
         message = self._connection.recv(decode=False)
-        log.debug(f"Received WebSocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     def send(self, event: BetaResponsesClientEvent | BetaResponsesClientEventParam) -> None:
@@ -4751,7 +4751,7 @@ class ResponsesConnection:
         try:
             self._send_queue.flush_sync(lambda data: self._connection.send(data))
         except Exception:
-            log.warning("Failed to flush send queue after reconnect", exc_info=True)
+            log.warning("Failed to flush send queue after reconnect")
 
     def on(
         self, event_type: str, handler: Callable[..., Any] | None = None
@@ -4969,9 +4969,9 @@ class ResponsesConnectionManager:
                 **extra_query,
             },
         )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         return connect(
             str(url),

--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -340,7 +340,7 @@ class AsyncRealtimeConnection:
         then you can call `.parse_event(data)`.
         """
         message = await self._connection.recv(decode=False)
-        log.debug(f"Received WebSocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     async def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
@@ -464,7 +464,7 @@ class AsyncRealtimeConnection:
         try:
             await self._send_queue.flush_async(_send)
         except Exception:
-            log.warning("Failed to flush send queue after reconnect", exc_info=True)
+            log.warning("Failed to flush send queue after reconnect")
 
     def on(
         self, event_type: str, handler: Callable[..., Any] | None = None
@@ -704,9 +704,9 @@ class AsyncRealtimeConnectionManager:
                     **extra_query,
                 },
             )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         return await connect(
             str(url),
@@ -820,7 +820,7 @@ class RealtimeConnection:
         then you can call `.parse_event(data)`.
         """
         message = self._connection.recv(decode=False)
-        log.debug(f"Received WebSocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
@@ -938,7 +938,7 @@ class RealtimeConnection:
         try:
             self._send_queue.flush_sync(lambda data: self._connection.send(data))
         except Exception:
-            log.warning("Failed to flush send queue after reconnect", exc_info=True)
+            log.warning("Failed to flush send queue after reconnect")
 
     def on(
         self, event_type: str, handler: Callable[..., Any] | None = None
@@ -1172,9 +1172,9 @@ class RealtimeConnectionManager:
                     **extra_query,
                 },
             )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         return connect(
             str(url),

--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -4070,7 +4070,7 @@ class AsyncResponsesConnection:
         then you can call `.parse_event(data)`.
         """
         message = await self._connection.recv(decode=False)
-        log.debug(f"Received WebSocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     async def send(self, event: ResponsesClientEvent | ResponsesClientEventParam) -> None:
@@ -4195,7 +4195,7 @@ class AsyncResponsesConnection:
         try:
             await self._send_queue.flush_async(_send)
         except Exception:
-            log.warning("Failed to flush send queue after reconnect", exc_info=True)
+            log.warning("Failed to flush send queue after reconnect")
 
     def on(
         self, event_type: str, handler: Callable[..., Any] | None = None
@@ -4419,9 +4419,9 @@ class AsyncResponsesConnectionManager:
                 **extra_query,
             },
         )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         return await connect(
             str(url),
@@ -4527,7 +4527,7 @@ class ResponsesConnection:
         then you can call `.parse_event(data)`.
         """
         message = self._connection.recv(decode=False)
-        log.debug(f"Received WebSocket message: %s", message)
+        log.debug("Received WebSocket message: %i bytes", len(message))
         return message
 
     def send(self, event: ResponsesClientEvent | ResponsesClientEventParam) -> None:
@@ -4646,7 +4646,7 @@ class ResponsesConnection:
         try:
             self._send_queue.flush_sync(lambda data: self._connection.send(data))
         except Exception:
-            log.warning("Failed to flush send queue after reconnect", exc_info=True)
+            log.warning("Failed to flush send queue after reconnect")
 
     def on(
         self, event_type: str, handler: Callable[..., Any] | None = None
@@ -4864,9 +4864,9 @@ class ResponsesConnectionManager:
                 **extra_query,
             },
         )
-        log.debug("Connecting to %s", url)
+        log.debug("Connecting to WebSocket API")
         if self.__websocket_connection_options:
-            log.debug("Connection options: %s", self.__websocket_connection_options)
+            log.debug("Custom WebSocket connection options provided")
 
         return connect(
             str(url),

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -324,9 +324,10 @@ async def test_websocket_queue_failure_metadata(
     connection = cls(websocket)
     connection._send_queue.enqueue(FAKE_SECRET)
     with caplog.at_level(logging.DEBUG, logger="openai"):
-        result = connection._flush_send_queue()
         if asynchronous:
-            await result
+            await connection._flush_send_queue()
+        else:
+            connection._flush_send_queue()
     websocket.send.assert_called_once_with(FAKE_SECRET)
     assert assert_safe_logs(caplog) == ["Failed to flush send queue after reconnect"]
 

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+import importlib
+from typing import Any, AsyncIterator
+from unittest.mock import Mock, AsyncMock, patch
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI, APIStatusError, APITimeoutError, APIConnectionError
+from openai._models import FinalRequestOptions
+
+FAKE_SECRET = "fake-private-value-for-logging-tests"
+BASE_URL = "https://example.test/v1"
+
+
+def assert_safe_logs(caplog: pytest.LogCaptureFixture) -> list[str]:
+    records = [record for record in caplog.records if record.name.startswith("openai.")]
+    assert records
+    # Handlers may retain the unformatted arguments or exception, not just text.
+    for record in records:
+        assert FAKE_SECRET not in record.getMessage()
+        assert FAKE_SECRET not in repr(record.args)
+        assert record.exc_info is None
+    return [record.getMessage() for record in records]
+
+
+def request_options(kind: str) -> FinalRequestOptions:
+    common: dict[str, Any] = {
+        "method": "post",
+        "url": "/logging-test?private=" + FAKE_SECRET,
+        "headers": {"Authorization": FAKE_SECRET, "X-Custom": FAKE_SECRET},
+        "params": {"private": FAKE_SECRET},
+        "idempotency_key": FAKE_SECRET,
+    }
+    if kind == "json":
+        common.update(
+            json_data={"input": FAKE_SECRET, "tools": [{"authorization": FAKE_SECRET}]},
+            extra_json={"nested": {"headers": {"X-Custom": FAKE_SECRET}}},
+        )
+    elif kind == "json-bytes":
+        common["json_data"] = FAKE_SECRET.encode()
+    elif kind == "content":
+        common["content"] = FAKE_SECRET.encode()
+    elif kind == "stream":
+        common["content"] = iter([FAKE_SECRET.encode()])
+    elif kind == "multipart":
+        common["json_data"] = {"purpose": FAKE_SECRET}
+        common["files"] = {"file": (FAKE_SECRET + ".txt", io.BytesIO(FAKE_SECRET.encode()))}
+        common["headers"]["Content-Type"] = "multipart/form-data"
+    else:
+        raise AssertionError(kind)
+    return FinalRequestOptions.construct(**common)
+
+
+def echo_request(request: httpx2.Request) -> httpx2.Response:
+    assert FAKE_SECRET.encode() in request.content
+    assert request.headers["X-Custom"] == FAKE_SECRET
+    assert request.url.params["private"] == FAKE_SECRET
+    return httpx2.Response(
+        200,
+        json={"result": FAKE_SECRET},
+        headers={"x-private": FAKE_SECRET, "x-request-id": "req_fake_logging"},
+    )
+
+
+@pytest.mark.parametrize("kind", ["json", "json-bytes", "content", "stream", "multipart"])
+def test_sync_request_metadata(kind: str, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        with OpenAI(
+            api_key="fake-api-key",
+            base_url=BASE_URL,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(echo_request)),
+        ) as client:
+            result = client.request(object, request_options(kind))
+    assert result == {"result": FAKE_SECRET}
+    messages = assert_safe_logs(caplog)
+    assert "Building HTTP request: method=post retries_taken=0" in messages
+    assert "HTTP Response: POST 200" in messages
+    assert "request_id: req_fake_logging" in messages
+
+
+@pytest.mark.parametrize("kind", ["json", "json-bytes", "content", "stream", "multipart"])
+async def test_async_request_metadata(kind: str, caplog: pytest.LogCaptureFixture) -> None:
+    options = request_options(kind)
+    if kind == "stream":
+
+        async def content() -> AsyncIterator[bytes]:
+            yield FAKE_SECRET.encode()
+
+        options.content = content()
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        async with AsyncOpenAI(
+            api_key="fake-api-key",
+            base_url=BASE_URL,
+            http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(echo_request)),
+        ) as client:
+            result = await client.request(object, options)
+    assert result == {"result": FAKE_SECRET}
+    messages = assert_safe_logs(caplog)
+    assert "Building HTTP request: method=post retries_taken=0" in messages
+    assert "HTTP Response: POST 200" in messages
+    assert "request_id: req_fake_logging" in messages
+
+
+def mcp_response(request: httpx2.Request) -> httpx2.Response:
+    body = json.loads(request.content)
+    assert body["input"] == FAKE_SECRET
+    assert body["tools"][0]["authorization"] == FAKE_SECRET
+    assert body["tools"][0]["headers"]["X-Custom"] == FAKE_SECRET
+    return httpx2.Response(200, json={"id": "resp_fake_logging", "object": "response", "output": []})
+
+
+def mcp_tools() -> Any:
+    return [
+        {
+            "type": "mcp",
+            "server_label": "fake",
+            "server_url": "https://example.test/mcp",
+            "authorization": FAKE_SECRET,
+            "headers": {"X-Custom": FAKE_SECRET},
+        }
+    ]
+
+
+def test_sync_public_mcp_request(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        with OpenAI(
+            api_key="fake-api-key",
+            base_url=BASE_URL,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(mcp_response)),
+        ) as client:
+            result = client.responses.create(model="fake-model", input=FAKE_SECRET, tools=mcp_tools())
+    assert result.id == "resp_fake_logging"
+    assert_safe_logs(caplog)
+
+
+async def test_async_public_mcp_request(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        async with AsyncOpenAI(
+            api_key="fake-api-key",
+            base_url=BASE_URL,
+            http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(mcp_response)),
+        ) as client:
+            result = await client.responses.create(model="fake-model", input=FAKE_SECRET, tools=mcp_tools())
+    assert result.id == "resp_fake_logging"
+    assert_safe_logs(caplog)
+
+
+@pytest.mark.parametrize("failure", ["status", "timeout", "connection"])
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_failure_and_retry_metadata(failure: str, asynchronous: bool, caplog: pytest.LogCaptureFixture) -> None:
+    calls = 0
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        nonlocal calls
+        calls += 1
+        if failure == "timeout":
+            raise httpx2.ReadTimeout(FAKE_SECRET, request=request)
+        if failure == "connection":
+            raise RuntimeError(FAKE_SECRET)
+        return httpx2.Response(
+            500, json={"error": {"message": FAKE_SECRET}}, headers={"x-private": FAKE_SECRET, "retry-after-ms": "1"}
+        )
+
+    expected = {"status": APIStatusError, "timeout": APITimeoutError, "connection": APIConnectionError}[failure]
+    kwargs: dict[str, Any] = {"api_key": "fake-api-key", "base_url": BASE_URL, "max_retries": 1}
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        if asynchronous:
+            async with AsyncOpenAI(
+                **kwargs, http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler))
+            ) as async_client:
+                with pytest.raises(expected) as exc:
+                    await async_client.get("/logging-test?private=" + FAKE_SECRET, cast_to=object)
+        else:
+            with OpenAI(**kwargs, http_client=httpx2.Client(transport=httpx2.MockTransport(handler))) as client:
+                with pytest.raises(expected) as exc:
+                    client.get("/logging-test?private=" + FAKE_SECRET, cast_to=object)
+    assert calls == 2
+    if failure == "status":
+        assert isinstance(exc.value, APIStatusError)
+        assert exc.value.body == {"message": FAKE_SECRET}
+    assert any("Retrying request in" in message for message in assert_safe_logs(caplog))
+
+
+WEBSOCKET_MODULES = [
+    "openai.resources.realtime.realtime",
+    "openai.resources.responses.responses",
+    "openai.resources.beta.responses.responses",
+    "openai.resources.beta.realtime.realtime",
+]
+
+
+@pytest.mark.parametrize("module_name", WEBSOCKET_MODULES)
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("parsed", [False, True])
+async def test_websocket_receive_metadata(
+    module_name: str, asynchronous: bool, parsed: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = importlib.import_module(module_name)
+    name = "RealtimeConnection" if ".realtime." in module_name else "ResponsesConnection"
+    cls = getattr(module, ("Async" if asynchronous else "") + name)
+    payload = (
+        json.dumps({"type": "response.output_text.delta", "delta": FAKE_SECRET}).encode()
+        if parsed
+        else b"\x00" + FAKE_SECRET.encode()
+    )
+    websocket = Mock()
+    websocket.recv = AsyncMock(return_value=payload) if asynchronous else Mock(return_value=payload)
+    connection = cls(websocket)
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        result = connection.recv() if parsed else connection.recv_bytes()
+        if asynchronous:
+            result = await result
+    websocket.recv.assert_called_once_with(decode=False)
+    if parsed:
+        assert result.type == "response.output_text.delta"
+        assert result.delta == FAKE_SECRET
+    else:
+        assert result is payload
+    assert assert_safe_logs(caplog) == [f"Received WebSocket message: {len(payload)} bytes"]
+
+
+@pytest.mark.parametrize("module_name", WEBSOCKET_MODULES)
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_websocket_connection_metadata(
+    module_name: str, asynchronous: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = importlib.import_module(module_name)
+    realtime = ".realtime." in module_name
+    name = "Realtime" if realtime else "Responses"
+    cls = getattr(module, ("Async" if asynchronous else "") + name)
+    websocket = Mock()
+    websocket.send = AsyncMock() if asynchronous else Mock()
+    websocket.close = AsyncMock() if asynchronous else Mock()
+    connect = AsyncMock(return_value=websocket) if asynchronous else Mock(return_value=websocket)
+    kwargs: dict[str, Any] = {
+        "extra_query": {"private": FAKE_SECRET},
+        "extra_headers": {"X-Custom": FAKE_SECRET},
+        "websocket_connection_options": {"origin": FAKE_SECRET},
+    }
+    if realtime:
+        kwargs["model"] = "fake-model"
+    with (
+        caplog.at_level(logging.DEBUG, logger="openai"),
+        patch("websockets." + ("asyncio" if asynchronous else "sync") + ".client.connect", connect),
+    ):
+        if asynchronous:
+            async with AsyncOpenAI(
+                api_key="fake-api-key",
+                base_url=BASE_URL,
+                http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(echo_request)),
+            ) as async_client:
+                async with cls(async_client).connect(**kwargs):
+                    pass
+        else:
+            with OpenAI(
+                api_key="fake-api-key",
+                base_url=BASE_URL,
+                http_client=httpx2.Client(transport=httpx2.MockTransport(echo_request)),
+            ) as client:
+                with cls(client).connect(**kwargs):
+                    pass
+    assert FAKE_SECRET in connect.call_args.args[0]
+    assert connect.call_args.kwargs["additional_headers"]["X-Custom"] == FAKE_SECRET
+    assert connect.call_args.kwargs["origin"] == FAKE_SECRET
+    assert "Connecting to WebSocket API" in assert_safe_logs(caplog)
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_response_parser_metadata(legacy: bool, asynchronous: bool, caplog: pytest.LogCaptureFixture) -> None:
+    from openai._models import BaseModel
+    from openai._response import APIResponse, AsyncAPIResponse
+    from openai._legacy_response import LegacyAPIResponse
+
+    raw = httpx2.Response(200, text=FAKE_SECRET)
+    raw.json = Mock(side_effect=ValueError(FAKE_SECRET))
+    kwargs: dict[str, Any] = {
+        "raw": raw,
+        "cast_to": BaseModel,
+        "stream": False,
+        "stream_cls": None,
+        "options": FinalRequestOptions.construct(method="get", url="/logging-test"),
+    }
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        if asynchronous:
+            async with AsyncOpenAI(
+                api_key="fake-api-key", http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(echo_request))
+            ) as async_client:
+                if legacy:
+                    result = LegacyAPIResponse[Any](client=async_client, **kwargs).parse()
+                else:
+                    result = await AsyncAPIResponse[Any](client=async_client, **kwargs).parse()
+        else:
+            with OpenAI(
+                api_key="fake-api-key", http_client=httpx2.Client(transport=httpx2.MockTransport(echo_request))
+            ) as client:
+                if legacy:
+                    result = LegacyAPIResponse[Any](client=client, **kwargs).parse()
+                else:
+                    result = APIResponse[Any](client=client, **kwargs).parse()
+    assert result == FAKE_SECRET
+    assert assert_safe_logs(caplog) == ["Could not read JSON from response data due to ValueError"]
+
+
+@pytest.mark.parametrize("module_name", WEBSOCKET_MODULES[:3])
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_websocket_queue_failure_metadata(
+    module_name: str, asynchronous: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    module = importlib.import_module(module_name)
+    name = "RealtimeConnection" if ".realtime." in module_name else "ResponsesConnection"
+    cls = getattr(module, ("Async" if asynchronous else "") + name)
+    websocket = Mock()
+    websocket.send = (
+        AsyncMock(side_effect=RuntimeError(FAKE_SECRET))
+        if asynchronous
+        else Mock(side_effect=RuntimeError(FAKE_SECRET))
+    )
+    connection = cls(websocket)
+    connection._send_queue.enqueue(FAKE_SECRET)
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        result = connection._flush_send_queue()
+        if asynchronous:
+            await result
+    websocket.send.assert_called_once_with(FAKE_SECRET)
+    assert assert_safe_logs(caplog) == ["Failed to flush send queue after reconnect"]

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -18,7 +18,7 @@ BASE_URL = "https://example.test/v1"
 
 
 def assert_safe_logs(caplog: pytest.LogCaptureFixture) -> list[str]:
-    records = [record for record in caplog.records if record.name.startswith("openai.")]
+    records = [record for record in caplog.records if record.name.startswith("openai.") or record.name == "httpx2"]
     assert records
     # Handlers may retain the unformatted arguments or exception, not just text.
     for record in records:
@@ -78,7 +78,7 @@ def test_sync_request_metadata(kind: str, caplog: pytest.LogCaptureFixture) -> N
             result = client.request(object, request_options(kind))
     assert result == {"result": FAKE_SECRET}
     messages = assert_safe_logs(caplog)
-    assert "Building HTTP request: method=post retries_taken=0" in messages
+    assert "Building HTTP request: method=POST retries_taken=0" in messages
     assert "HTTP Response: POST 200" in messages
     assert "request_id: req_fake_logging" in messages
 
@@ -101,7 +101,7 @@ async def test_async_request_metadata(kind: str, caplog: pytest.LogCaptureFixtur
             result = await client.request(object, options)
     assert result == {"result": FAKE_SECRET}
     messages = assert_safe_logs(caplog)
-    assert "Building HTTP request: method=post retries_taken=0" in messages
+    assert "Building HTTP request: method=POST retries_taken=0" in messages
     assert "HTTP Response: POST 200" in messages
     assert "request_id: req_fake_logging" in messages
 
@@ -329,3 +329,71 @@ async def test_websocket_queue_failure_metadata(
             await result
     websocket.send.assert_called_once_with(FAKE_SECRET)
     assert assert_safe_logs(caplog) == ["Failed to flush send queue after reconnect"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("method", ["post", FAKE_SECRET])
+async def test_custom_method_metadata(method: str, asynchronous: bool, caplog: pytest.LogCaptureFixture) -> None:
+    received: list[str] = []
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        received.append(request.method)
+        return httpx2.Response(200, json={"ok": True})
+
+    options = FinalRequestOptions.construct(method=method, url="/logging-test")
+    with caplog.at_level(logging.DEBUG, logger="openai"):
+        if asynchronous:
+            async with AsyncOpenAI(
+                api_key="fake-api-key",
+                base_url=BASE_URL,
+                http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+            ) as async_client:
+                assert await async_client.request(object, options) == {"ok": True}
+        else:
+            with OpenAI(
+                api_key="fake-api-key",
+                base_url=BASE_URL,
+                http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+            ) as client:
+                assert client.request(object, options) == {"ok": True}
+    assert received == [method.upper()]
+    expected = "POST" if method == "post" else "<custom>"
+    messages = assert_safe_logs(caplog)
+    assert f"Building HTTP request: method={expected} retries_taken=0" in messages
+    assert f"Sending HTTP Request: {expected}" in messages
+    assert f"HTTP Response: {expected} 200" in messages
+    assert FAKE_SECRET.upper() not in "\n".join(messages)
+
+
+@pytest.mark.parametrize("setting", ["debug", "info"])
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_sdk_log_switch_does_not_enable_transport_payloads(
+    setting: str, asynchronous: bool, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from openai._utils._logs import setup_logging
+
+    # Exercise the documented switch with normal application logging defaults.
+    with (
+        caplog.at_level(logging.WARNING),
+        caplog.at_level(logging.NOTSET, logger="httpx2"),
+        caplog.at_level(logging.WARNING, logger="openai"),
+    ):
+        monkeypatch.setattr(caplog.handler, "level", logging.NOTSET)
+        monkeypatch.setenv("OPENAI_LOG", setting)
+        setup_logging()
+        if asynchronous:
+            async with AsyncOpenAI(
+                api_key="fake-api-key",
+                base_url=BASE_URL,
+                http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(echo_request)),
+            ) as async_client:
+                assert await async_client.request(object, request_options("json")) == {"result": FAKE_SECRET}
+        else:
+            with OpenAI(
+                api_key="fake-api-key",
+                base_url=BASE_URL,
+                http_client=httpx2.Client(transport=httpx2.MockTransport(echo_request)),
+            ) as client:
+                assert client.request(object, request_options("json")) == {"result": FAKE_SECRET}
+        assert logging.getLogger("httpx2").level == logging.NOTSET
+    assert not any(FAKE_SECRET in record.getMessage() or FAKE_SECRET in repr(record.args) for record in caplog.records)

--- a/tests/test_utils/test_logging.py
+++ b/tests/test_utils/test_logging.py
@@ -102,14 +102,17 @@ def test_standard_debug_msg(logger_with_filter: logging.Logger, caplog: pytest.L
 
 
 @pytest.mark.parametrize(("setting", "level"), [("debug", logging.DEBUG), ("info", logging.INFO)])
-def test_httpx2_logger_follows_sdk_log_level(setting: str, level: int, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("transport_level", [logging.WARNING, logging.DEBUG])
+def test_sdk_log_level_preserves_transport_configuration(
+    setting: str, level: int, transport_level: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
     sdk_logger = logging.getLogger("openai")
     transport_logger = logging.getLogger("httpx2")
     monkeypatch.setattr(sdk_logger, "level", sdk_logger.level)
-    monkeypatch.setattr(transport_logger, "level", transport_logger.level)
+    monkeypatch.setattr(transport_logger, "level", transport_level)
     monkeypatch.setenv("OPENAI_LOG", setting)
 
     setup_logging()
 
     assert sdk_logger.level == level
-    assert transport_logger.level == level
+    assert transport_logger.level == transport_level


### PR DESCRIPTION
Troubleshooting logs should help identify request failures without retaining the data applications send or receive. This change keeps request, retry, status, and WebSocket size information while limiting SDK diagnostics to metadata. Request delivery, response parsing, and error handling are unchanged.

The SDK logging setting now controls SDK logs without changing application-configured HTTP transport logging.