### PR TITLE
fix: decode SSE incrementally without limiting event size

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -281,32 +281,18 @@ class ServerSentEvent:
         return f"ServerSentEvent(event={self.event}, data={self.data}, id={self.id}, retry={self.retry})"
 
 
-# Large enough for image/audio payloads, while keeping incomplete events finite.
-_DEFAULT_MAX_SSE_SIZE = 64 * 1024 * 1024
 _SSE_LINE_END = re.compile(b"[\\r\\n]")
 
 
 class _SSELineDecoder:
     """Incrementally split CR, LF, and CRLF without copying growing prefixes."""
 
-    def __init__(self, *, max_line_size: int, max_event_size: int) -> None:
-        self._max_line_size = max_line_size
-        self._max_event_size = max_event_size
+    def __init__(self) -> None:
         self._buffer = bytearray()
-        self._event_size = 0
         self._skip_lf = False
 
     def _append(self, chunk: bytes, start: int, end: int) -> None:
-        size = end - start
-        if len(self._buffer) + size > self._max_line_size:
-            raise ValueError("SSE line exceeded maximum size")
-        self._count(size)
         self._buffer.extend(memoryview(chunk)[start:end])
-
-    def _count(self, size: int) -> None:
-        if self._event_size + size > self._max_event_size:
-            raise ValueError("SSE event exceeded maximum size")
-        self._event_size += size
 
     def feed(self, chunk: bytes) -> Iterator[bytes]:
         start = 0
@@ -318,12 +304,8 @@ class _SSELineDecoder:
                 continue
             self._skip_lf = False
             self._append(chunk, start, end)
-            # Count each logical line ending once, independently of CRLF chunking.
-            self._count(1)
             line = bytes(self._buffer)
             self._buffer.clear()
-            if not line:
-                self._event_size = 0
             self._skip_lf = chunk[end] == 13
             start = end + 1
             yield line
@@ -339,30 +321,14 @@ class _SSELineDecoder:
 
 
 class SSEDecoder:
-    """Decode SSE with bounded lines and events.
-
-    Limits are UTF-8 byte counts. Line endings count as one byte toward the
-    event limit, including the terminating blank line. Comments and ignored
-    fields count too. Larger trusted payloads can use a custom decoder from
-    ``_make_sse_decoder`` with larger positive limits. Oversized input raises
-    ``ValueError`` without including response data.
-    """
+    """Decode SSE incrementally without imposing a line or event size limit."""
 
     _data: list[str]
     _event: str | None
     _retry: int | None
     _last_event_id: str | None
 
-    def __init__(
-        self,
-        *,
-        max_line_size: int = _DEFAULT_MAX_SSE_SIZE,
-        max_event_size: int = _DEFAULT_MAX_SSE_SIZE,
-    ) -> None:
-        if max_line_size <= 0 or max_event_size <= 0:
-            raise ValueError("SSE size limits must be positive")
-        self._max_line_size = max_line_size
-        self._max_event_size = max_event_size
+    def __init__(self) -> None:
         self._reset()
 
     def _reset(self) -> None:
@@ -379,7 +345,7 @@ class SSEDecoder:
 
     def iter_bytes(self, iterator: Iterator[bytes]) -> Iterator[ServerSentEvent]:
         """Given raw binary data, yield every event encountered."""
-        decoder = _SSELineDecoder(max_line_size=self._max_line_size, max_event_size=self._max_event_size)
+        decoder = _SSELineDecoder()
         try:
             for chunk in iterator:
                 yield from self._decode_lines(decoder.feed(chunk))
@@ -389,7 +355,7 @@ class SSEDecoder:
 
     async def aiter_bytes(self, iterator: AsyncIterator[bytes]) -> AsyncIterator[ServerSentEvent]:
         """Given async raw binary data, yield every event encountered."""
-        decoder = _SSELineDecoder(max_line_size=self._max_line_size, max_event_size=self._max_event_size)
+        decoder = _SSELineDecoder()
         try:
             async for chunk in iterator:
                 for sse in self._decode_lines(decoder.feed(chunk)):

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -1,6 +1,7 @@
 # Note: initially copied from https://github.com/florimondmanca/httpx-sse/blob/master/src/httpx_sse/_decoders.py
 from __future__ import annotations
 
+import re
 import json
 import inspect
 from types import TracebackType
@@ -280,61 +281,123 @@ class ServerSentEvent:
         return f"ServerSentEvent(event={self.event}, data={self.data}, id={self.id}, retry={self.retry})"
 
 
+# Large enough for image/audio payloads, while keeping incomplete events finite.
+_DEFAULT_MAX_SSE_SIZE = 64 * 1024 * 1024
+_SSE_LINE_END = re.compile(b"[\\r\\n]")
+
+
+class _SSELineDecoder:
+    """Incrementally split CR, LF, and CRLF without copying growing prefixes."""
+
+    def __init__(self, *, max_line_size: int, max_event_size: int) -> None:
+        self._max_line_size = max_line_size
+        self._max_event_size = max_event_size
+        self._buffer = bytearray()
+        self._event_size = 0
+        self._skip_lf = False
+
+    def _append(self, chunk: bytes, start: int, end: int) -> None:
+        size = end - start
+        if len(self._buffer) + size > self._max_line_size:
+            raise ValueError("SSE line exceeded maximum size")
+        self._count(size)
+        self._buffer.extend(memoryview(chunk)[start:end])
+
+    def _count(self, size: int) -> None:
+        if self._event_size + size > self._max_event_size:
+            raise ValueError("SSE event exceeded maximum size")
+        self._event_size += size
+
+    def feed(self, chunk: bytes) -> Iterator[bytes]:
+        start = 0
+        for match in _SSE_LINE_END.finditer(chunk):
+            end = match.start()
+            if self._skip_lf and end == start and chunk[end] == 10:
+                self._skip_lf = False
+                start = end + 1
+                continue
+            self._skip_lf = False
+            self._append(chunk, start, end)
+            # Count each logical line ending once, independently of CRLF chunking.
+            self._count(1)
+            line = bytes(self._buffer)
+            self._buffer.clear()
+            if not line:
+                self._event_size = 0
+            self._skip_lf = chunk[end] == 13
+            start = end + 1
+            yield line
+        if start < len(chunk):
+            self._skip_lf = False
+            self._append(chunk, start, len(chunk))
+
+    def finish(self) -> Iterator[bytes]:
+        if self._buffer:
+            line = bytes(self._buffer)
+            self._buffer.clear()
+            yield line
+
+
 class SSEDecoder:
+    """Decode SSE with bounded lines and events.
+
+    Limits are UTF-8 byte counts. Line endings count as one byte toward the
+    event limit, including the terminating blank line. Comments and ignored
+    fields count too. Larger trusted payloads can use a custom decoder from
+    ``_make_sse_decoder`` with larger positive limits. Oversized input raises
+    ``ValueError`` without including response data.
+    """
+
     _data: list[str]
     _event: str | None
     _retry: int | None
     _last_event_id: str | None
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        max_line_size: int = _DEFAULT_MAX_SSE_SIZE,
+        max_event_size: int = _DEFAULT_MAX_SSE_SIZE,
+    ) -> None:
+        if max_line_size <= 0 or max_event_size <= 0:
+            raise ValueError("SSE size limits must be positive")
+        self._max_line_size = max_line_size
+        self._max_event_size = max_event_size
+        self._reset()
+
+    def _reset(self) -> None:
         self._event = None
         self._data = []
         self._last_event_id = None
         self._retry = None
 
-    def iter_bytes(self, iterator: Iterator[bytes]) -> Iterator[ServerSentEvent]:
-        """Given an iterator that yields raw binary data, iterate over it & yield every event encountered"""
-        for chunk in self._iter_chunks(iterator):
-            # Split before decoding so splitlines() only uses \r and \n
-            for raw_line in chunk.splitlines():
-                line = raw_line.decode("utf-8")
-                sse = self.decode(line)
-                if sse:
-                    yield sse
+    def _decode_lines(self, lines: Iterator[bytes]) -> Iterator[ServerSentEvent]:
+        for raw_line in lines:
+            sse = self.decode(raw_line.decode("utf-8"))
+            if sse:
+                yield sse
 
-    def _iter_chunks(self, iterator: Iterator[bytes]) -> Iterator[bytes]:
-        """Given an iterator that yields raw binary data, iterate over it and yield individual SSE chunks"""
-        data = b""
-        for chunk in iterator:
-            for line in chunk.splitlines(keepends=True):
-                data += line
-                if data.endswith((b"\r\r", b"\n\n", b"\r\n\r\n")):
-                    yield data
-                    data = b""
-        if data:
-            yield data
+    def iter_bytes(self, iterator: Iterator[bytes]) -> Iterator[ServerSentEvent]:
+        """Given raw binary data, yield every event encountered."""
+        decoder = _SSELineDecoder(max_line_size=self._max_line_size, max_event_size=self._max_event_size)
+        try:
+            for chunk in iterator:
+                yield from self._decode_lines(decoder.feed(chunk))
+            yield from self._decode_lines(decoder.finish())
+        finally:
+            self._reset()
 
     async def aiter_bytes(self, iterator: AsyncIterator[bytes]) -> AsyncIterator[ServerSentEvent]:
-        """Given an iterator that yields raw binary data, iterate over it & yield every event encountered"""
-        async for chunk in self._aiter_chunks(iterator):
-            # Split before decoding so splitlines() only uses \r and \n
-            for raw_line in chunk.splitlines():
-                line = raw_line.decode("utf-8")
-                sse = self.decode(line)
-                if sse:
+        """Given async raw binary data, yield every event encountered."""
+        decoder = _SSELineDecoder(max_line_size=self._max_line_size, max_event_size=self._max_event_size)
+        try:
+            async for chunk in iterator:
+                for sse in self._decode_lines(decoder.feed(chunk)):
                     yield sse
-
-    async def _aiter_chunks(self, iterator: AsyncIterator[bytes]) -> AsyncIterator[bytes]:
-        """Given an iterator that yields raw binary data, iterate over it and yield individual SSE chunks"""
-        data = b""
-        async for chunk in iterator:
-            for line in chunk.splitlines(keepends=True):
-                data += line
-                if data.endswith((b"\r\r", b"\n\n", b"\r\n\r\n")):
-                    yield data
-                    data = b""
-        if data:
-            yield data
+            for sse in self._decode_lines(decoder.finish()):
+                yield sse
+        finally:
+            self._reset()
 
     def decode(self, line: str) -> ServerSentEvent | None:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501

--- a/tests/test_sse_framing.py
+++ b/tests/test_sse_framing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Iterator, AsyncIterator
+from typing import Iterable, Iterator, AsyncIterator
 from typing_extensions import override
 
 import httpx2
@@ -11,12 +11,12 @@ from openai import OpenAI, AsyncOpenAI
 from openai._streaming import Stream, SSEDecoder, AsyncStream, ServerSentEvent, _SSELineDecoder
 
 
-async def _aiter(chunks: list[bytes]) -> AsyncIterator[bytes]:
+async def _aiter(chunks: Iterable[bytes]) -> AsyncIterator[bytes]:
     for chunk in chunks:
         yield chunk
 
 
-async def _decode(decoder: SSEDecoder, chunks: list[bytes], sync: bool) -> list[ServerSentEvent]:
+async def _decode(decoder: SSEDecoder, chunks: Iterable[bytes], sync: bool) -> list[ServerSentEvent]:
     if sync:
         return list(decoder.iter_bytes(iter(chunks)))
     return [event async for event in decoder.aiter_bytes(_aiter(chunks))]
@@ -29,39 +29,43 @@ def _fragment(data: bytes, size: int) -> list[bytes]:
 @pytest.mark.parametrize("sync", [True, False])
 @pytest.mark.parametrize("line", [b":x\n", b"data:x\n", b"ignored:x\n"])
 @pytest.mark.parametrize("fragment_size", [1, 97, 100000])
-async def test_unterminated_event_limit(sync: bool, line: bytes, fragment_size: int) -> None:
-    decoder = SSEDecoder(max_line_size=32, max_event_size=1024)
-    with pytest.raises(ValueError, match="^SSE event exceeded maximum size$"):
-        await _decode(decoder, _fragment(line * 2000, fragment_size), sync)
+async def test_unterminated_event(sync: bool, line: bytes, fragment_size: int) -> None:
+    decoder = SSEDecoder()
+    assert await _decode(decoder, _fragment(line * 2000, fragment_size), sync) == []
     assert decoder._data == []
     assert decoder._last_event_id is None
 
 
 @pytest.mark.parametrize("sync", [True, False])
-@pytest.mark.parametrize("suffix", [b"", b"\n", b"\n\n", b"\r\n\r\n"])
-@pytest.mark.parametrize("fragment_size", [1, 17, 10000])
-async def test_oversized_line(sync: bool, suffix: bytes, fragment_size: int) -> None:
-    decoder = SSEDecoder(max_line_size=64, max_event_size=1024)
-    with pytest.raises(ValueError, match="^SSE line exceeded maximum size$"):
-        await _decode(decoder, _fragment(b"data:" + b"x" * 60 + suffix, fragment_size), sync)
-    assert decoder._data == []
-
-
-@pytest.mark.parametrize("sync", [True, False])
 @pytest.mark.parametrize("ending", [b"\n", b"\r", b"\r\n"])
-async def test_exact_limits_and_every_chunk_boundary(sync: bool, ending: bytes) -> None:
+async def test_every_chunk_boundary(sync: bool, ending: bytes) -> None:
     frame = b"data:ok" + ending + ending
     for split in range(len(frame) + 1):
-        events = await _decode(SSEDecoder(max_line_size=7, max_event_size=9), [frame[:split], b"", frame[split:]], sync)
+        events = await _decode(SSEDecoder(), [frame[:split], b"", frame[split:]], sync)
         assert [event.data for event in events] == ["ok"]
-        with pytest.raises(ValueError, match="SSE event exceeded"):
-            await _decode(SSEDecoder(max_line_size=7, max_event_size=8), [frame[:split], frame[split:]], sync)
 
 
 @pytest.mark.parametrize("sync", [True, False])
-async def test_many_complete_events_reset_limit(sync: bool) -> None:
-    events = await _decode(SSEDecoder(max_line_size=7, max_event_size=9), [b"data:ok\n\n" * 2000], sync)
+async def test_many_complete_events(sync: bool) -> None:
+    events = await _decode(SSEDecoder(), [b"data:ok\n\n" * 2000], sync)
     assert [event.data for event in events] == ["ok"] * 2000
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_event_larger_than_64_mib(sync: bool) -> None:
+    # A fixed regression for the rejected 64 MiB ceiling, not a stress sweep.
+    # Reuse the input chunk and avoid allocating a second full expected payload.
+    def chunks() -> Iterator[bytes]:
+        yield b"data:"
+        chunk = b"x" * (1024 * 1024)
+        for _ in range(64):
+            yield chunk
+        yield b"x\n\n"
+
+    events = await _decode(SSEDecoder(), chunks(), sync)
+    assert len(events) == 1
+    assert len(events[0].data) == 64 * 1024 * 1024 + 1
+    assert events[0].data.count("x") == len(events[0].data)
 
 
 @pytest.mark.parametrize("sync", [True, False])
@@ -82,12 +86,13 @@ async def test_mixed_endings_utf8_and_eof(sync: bool) -> None:
 
 
 @pytest.mark.parametrize("sync", [True, False])
-async def test_comments_are_discarded_incrementally(sync: bool) -> None:
-    decoder = SSEDecoder(max_event_size=100000)
+@pytest.mark.parametrize("line", [b":x\n", b"ignored:x\n"])
+async def test_ignored_lines_are_discarded_incrementally(sync: bool, line: bytes) -> None:
+    decoder = SSEDecoder()
 
     def chunks() -> Iterator[bytes]:
         for _ in range(10000):
-            yield b":x\n"
+            yield line
             assert decoder._data == []
         yield b"data:ok\n"
         assert decoder._data == ["ok"]
@@ -101,37 +106,23 @@ async def test_comments_are_discarded_incrementally(sync: bool) -> None:
     assert [event.data for event in events] == ["ok"]
 
 
-def test_partial_line_uses_bounded_mutable_buffer() -> None:
-    decoder = _SSELineDecoder(max_line_size=4096, max_event_size=8192)
+def test_partial_line_uses_mutable_buffer() -> None:
+    decoder = _SSELineDecoder()
     for _ in range(4096):
         assert list(decoder.feed(b"x")) == []
     assert isinstance(decoder._buffer, bytearray)
     assert len(decoder._buffer) == 4096
-    with pytest.raises(ValueError, match="SSE line exceeded"):
-        list(decoder.feed(b"x" * 10000))
-    assert len(decoder._buffer) == 4096
-
-
-@pytest.mark.parametrize("sync", [True, False])
-async def test_custom_limits_and_validation(sync: bool) -> None:
-    for limits in [{"max_line_size": 0}, {"max_event_size": -1}]:
-        with pytest.raises(ValueError, match="must be positive"):
-            SSEDecoder(**limits)
-    events = await _decode(
-        SSEDecoder(max_line_size=1024, max_event_size=2048), [b"data:" + b"x" * 1000 + b"\n\n"], sync
-    )
-    assert events[0].data == "x" * 1000
+    assert list(decoder.feed(b"\n")) == [b"x" * 4096]
+    assert not decoder._buffer
 
 
 class _SyncBody(httpx2.SyncByteStream):
     closed = False
-    reads = 0
 
     @override
     def __iter__(self) -> Iterator[bytes]:
-        while True:
-            self.reads += 1
-            yield b"data:x\n"
+        yield b"data:partial\n"
+        raise RuntimeError("stream interrupted")
 
     @override
     def close(self) -> None:
@@ -140,41 +131,37 @@ class _SyncBody(httpx2.SyncByteStream):
 
 class _AsyncBody(httpx2.AsyncByteStream):
     closed = False
-    reads = 0
 
     @override
     async def __aiter__(self) -> AsyncIterator[bytes]:
-        while True:
-            self.reads += 1
-            yield b"data:x\n"
+        yield b"data:partial\n"
+        raise RuntimeError("stream interrupted")
 
     @override
     async def aclose(self) -> None:
         self.closed = True
 
 
-def test_sync_limit_closes_response(client: OpenAI) -> None:
+def test_sync_interruption_closes_response(client: OpenAI) -> None:
     body = _SyncBody()
     response = httpx2.Response(200, stream=body, request=httpx2.Request("GET", "https://example.invalid"))
     stream = Stream(cast_to=object, client=client, response=response)
-    stream._decoder = SSEDecoder(max_event_size=21)
-    with pytest.raises(ValueError, match="SSE event exceeded"):
+    stream._decoder = SSEDecoder()
+    with pytest.raises(RuntimeError, match="stream interrupted"):
         next(stream)
     assert response.is_closed and body.closed
-    assert body.reads == 4
     assert stream._decoder._data == []
 
 
-async def test_async_limit_closes_response(async_client: AsyncOpenAI) -> None:
+async def test_async_interruption_closes_response(async_client: AsyncOpenAI) -> None:
     body = _AsyncBody()
     response = httpx2.Response(200, stream=body, request=httpx2.Request("GET", "https://example.invalid"))
     stream = AsyncStream(cast_to=object, client=async_client, response=response)
-    decoder = SSEDecoder(max_event_size=21)
+    decoder = SSEDecoder()
     stream._decoder = decoder
-    with pytest.raises(ValueError, match="SSE event exceeded"):
+    with pytest.raises(RuntimeError, match="stream interrupted"):
         await stream.__anext__()
     assert response.is_closed and body.closed
-    assert body.reads == 4
     assert decoder._data == []
 
 

--- a/tests/test_sse_limits.py
+++ b/tests/test_sse_limits.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Iterator, AsyncIterator
+from typing_extensions import override
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from openai._streaming import Stream, SSEDecoder, AsyncStream, ServerSentEvent, _SSELineDecoder
+
+
+async def _aiter(chunks: list[bytes]) -> AsyncIterator[bytes]:
+    for chunk in chunks:
+        yield chunk
+
+
+async def _decode(decoder: SSEDecoder, chunks: list[bytes], sync: bool) -> list[ServerSentEvent]:
+    if sync:
+        return list(decoder.iter_bytes(iter(chunks)))
+    return [event async for event in decoder.aiter_bytes(_aiter(chunks))]
+
+
+def _fragment(data: bytes, size: int) -> list[bytes]:
+    return [data[i : i + size] for i in range(0, len(data), size)]
+
+
+@pytest.mark.parametrize("sync", [True, False])
+@pytest.mark.parametrize("line", [b":x\n", b"data:x\n", b"ignored:x\n"])
+@pytest.mark.parametrize("fragment_size", [1, 97, 100000])
+async def test_unterminated_event_limit(sync: bool, line: bytes, fragment_size: int) -> None:
+    decoder = SSEDecoder(max_line_size=32, max_event_size=1024)
+    with pytest.raises(ValueError, match="^SSE event exceeded maximum size$"):
+        await _decode(decoder, _fragment(line * 2000, fragment_size), sync)
+    assert decoder._data == []
+    assert decoder._last_event_id is None
+
+
+@pytest.mark.parametrize("sync", [True, False])
+@pytest.mark.parametrize("suffix", [b"", b"\n", b"\n\n", b"\r\n\r\n"])
+@pytest.mark.parametrize("fragment_size", [1, 17, 10000])
+async def test_oversized_line(sync: bool, suffix: bytes, fragment_size: int) -> None:
+    decoder = SSEDecoder(max_line_size=64, max_event_size=1024)
+    with pytest.raises(ValueError, match="^SSE line exceeded maximum size$"):
+        await _decode(decoder, _fragment(b"data:" + b"x" * 60 + suffix, fragment_size), sync)
+    assert decoder._data == []
+
+
+@pytest.mark.parametrize("sync", [True, False])
+@pytest.mark.parametrize("ending", [b"\n", b"\r", b"\r\n"])
+async def test_exact_limits_and_every_chunk_boundary(sync: bool, ending: bytes) -> None:
+    frame = b"data:ok" + ending + ending
+    for split in range(len(frame) + 1):
+        events = await _decode(SSEDecoder(max_line_size=7, max_event_size=9), [frame[:split], b"", frame[split:]], sync)
+        assert [event.data for event in events] == ["ok"]
+        with pytest.raises(ValueError, match="SSE event exceeded"):
+            await _decode(SSEDecoder(max_line_size=7, max_event_size=8), [frame[:split], frame[split:]], sync)
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_many_complete_events_reset_limit(sync: bool) -> None:
+    events = await _decode(SSEDecoder(max_line_size=7, max_event_size=9), [b"data:ok\n\n" * 2000], sync)
+    assert [event.data for event in events] == ["ok"] * 2000
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_large_legitimate_events(sync: bool) -> None:
+    value = "x" * (2 * 1024 * 1024) + "известни\u2028"
+    frame = ("data:" + value + "\r\n\r\n").encode()
+    events = await _decode(SSEDecoder(), _fragment(frame, 4093), sync)
+    assert [event.data for event in events] == [value]
+    events = await _decode(SSEDecoder(), [b"data:x\n" * 10000 + b"\n"], sync)
+    assert [event.data for event in events] == ["\n".join(["x"] * 10000)]
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_mixed_endings_utf8_and_eof(sync: bool) -> None:
+    frame = "id:one\r\ndata:известни\r\n\ndata:two\n\rdata:unfinished".encode()
+    events = await _decode(SSEDecoder(), _fragment(frame, 1), sync)
+    assert [(event.data, event.id) for event in events] == [("известни", "one"), ("two", "one")]
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_comments_are_discarded_incrementally(sync: bool) -> None:
+    decoder = SSEDecoder(max_event_size=100000)
+
+    def chunks() -> Iterator[bytes]:
+        for _ in range(10000):
+            yield b":x\n"
+            assert decoder._data == []
+        yield b"data:ok\n"
+        assert decoder._data == ["ok"]
+        yield b"\n"
+
+    async def achunks() -> AsyncIterator[bytes]:
+        for chunk in chunks():
+            yield chunk
+
+    events = list(decoder.iter_bytes(chunks())) if sync else [e async for e in decoder.aiter_bytes(achunks())]
+    assert [event.data for event in events] == ["ok"]
+
+
+def test_partial_line_uses_bounded_mutable_buffer() -> None:
+    decoder = _SSELineDecoder(max_line_size=4096, max_event_size=8192)
+    for _ in range(4096):
+        assert list(decoder.feed(b"x")) == []
+    assert isinstance(decoder._buffer, bytearray)
+    assert len(decoder._buffer) == 4096
+    with pytest.raises(ValueError, match="SSE line exceeded"):
+        list(decoder.feed(b"x" * 10000))
+    assert len(decoder._buffer) == 4096
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_custom_limits_and_validation(sync: bool) -> None:
+    for limits in [{"max_line_size": 0}, {"max_event_size": -1}]:
+        with pytest.raises(ValueError, match="must be positive"):
+            SSEDecoder(**limits)
+    events = await _decode(
+        SSEDecoder(max_line_size=1024, max_event_size=2048), [b"data:" + b"x" * 1000 + b"\n\n"], sync
+    )
+    assert events[0].data == "x" * 1000
+
+
+class _SyncBody(httpx2.SyncByteStream):
+    closed = False
+    reads = 0
+
+    @override
+    def __iter__(self) -> Iterator[bytes]:
+        while True:
+            self.reads += 1
+            yield b"data:x\n"
+
+    @override
+    def close(self) -> None:
+        self.closed = True
+
+
+class _AsyncBody(httpx2.AsyncByteStream):
+    closed = False
+    reads = 0
+
+    @override
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        while True:
+            self.reads += 1
+            yield b"data:x\n"
+
+    @override
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def test_sync_limit_closes_response(client: OpenAI) -> None:
+    body = _SyncBody()
+    response = httpx2.Response(200, stream=body, request=httpx2.Request("GET", "https://example.invalid"))
+    stream = Stream(cast_to=object, client=client, response=response)
+    stream._decoder = SSEDecoder(max_event_size=21)
+    with pytest.raises(ValueError, match="SSE event exceeded"):
+        next(stream)
+    assert response.is_closed and body.closed
+    assert body.reads == 4
+    assert stream._decoder._data == []
+
+
+async def test_async_limit_closes_response(async_client: AsyncOpenAI) -> None:
+    body = _AsyncBody()
+    response = httpx2.Response(200, stream=body, request=httpx2.Request("GET", "https://example.invalid"))
+    stream = AsyncStream(cast_to=object, client=async_client, response=response)
+    decoder = SSEDecoder(max_event_size=21)
+    stream._decoder = decoder
+    with pytest.raises(ValueError, match="SSE event exceeded"):
+        await stream.__anext__()
+    assert response.is_closed and body.closed
+    assert body.reads == 4
+    assert decoder._data == []
+
+
+async def test_cancellation_clears_partial_event_and_closes_response(async_client: AsyncOpenAI) -> None:
+    started = asyncio.Event()
+
+    class PausedBody(_AsyncBody):
+        @override
+        async def __aiter__(self) -> AsyncIterator[bytes]:
+            yield b"data:partial\n"
+            started.set()
+            await asyncio.Event().wait()
+
+    body = PausedBody()
+    response = httpx2.Response(200, stream=body, request=httpx2.Request("GET", "https://example.invalid"))
+    stream = AsyncStream(cast_to=object, client=async_client, response=response)
+    decoder = SSEDecoder()
+    stream._decoder = decoder
+    task = asyncio.create_task(stream.__anext__())
+    await started.wait()
+    assert decoder._data == ["partial"]
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert response.is_closed and body.closed
+    assert decoder._data == []
+
+
+@pytest.mark.parametrize("sync", [True, False])
+async def test_context_exit_after_event(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    if sync:
+        response = httpx2.Response(200, content=iter([b"data:{}\n\n", b"data:partial"]))
+        with Stream(cast_to=object, client=client, response=response) as stream:
+            assert next(stream) == {}
+    else:
+        response = httpx2.Response(200, content=_aiter([b"data:{}\n\n", b"data:partial"]))
+        async with AsyncStream(cast_to=object, client=async_client, response=response) as astream:
+            assert await astream.__anext__() == {}
+    assert response.is_closed


### PR DESCRIPTION
## Summary

- Share an amortized-linear incremental SSE line framer between synchronous and asynchronous decoding.
- Process complete lines as they arrive so comments and ignored fields are discarded before the event finishes.
- Preserve historical unlimited line/event sizes, CR/LF/CRLF framing, UTF-8 chunking, and response cleanup. No new size-limit API, dependencies, exported client APIs, or `[DONE]` drain changes.

This removes quadratic prefix copying and unnecessary whole-frame retention. It does not impose a memory bound on arbitrarily large data events or unfinished lines.

## Validation

- 62 focused streaming/framing tests passed, including synchronous and asynchronous events larger than 64 MiB, fragmented and unterminated input, all newline forms, transport interruption, and cancellation.
- Ruff, targeted Mypy, targeted Pyright, and `git diff --check` passed.
- Final separate local review (round 3 of 3) was clean at `d3667578e1a4e8da9d1962bfd403d98f4a0f945c`; its exhaustive short-input CR/LF fragmentation matrix also passed.

Independent PR against public main. Please confirm this handwritten shared-runtime patch is preserved in the next Castiron Python candidate; no schema or generation-metadata change is needed.