### PR TITLE
fix: preserve WebSocket send queue byte accounting during flush

### DIFF
--- a/src/openai/_send_queue.py
+++ b/src/openai/_send_queue.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import typing
 import threading
+from collections import deque
+
+import anyio.to_thread
 
 from ._exceptions import WebSocketQueueFullError
 
@@ -19,6 +22,7 @@ class SendQueue:
         self._bytes: int = 0
         self._max_bytes = max_bytes
         self._lock = threading.Lock()
+        self._flush_done: threading.Event | None = None
 
     def enqueue(self, data: str) -> None:
         """Append *data* to the queue.
@@ -39,44 +43,59 @@ class SendQueue:
         If *send* raises, the failing message and all subsequent messages
         are re-queued and the error is re-raised.
         """
-        with self._lock:
-            pending = list(self._queue)
-            self._queue.clear()
-            self._bytes = 0
+        while isinstance(pending := self._begin_flush(), threading.Event):
+            pending.wait()
 
-        for i, (data, _byte_length) in enumerate(pending):
-            try:
+        try:
+            while pending:
+                data, byte_length = pending[0]
                 send(data)
-            except Exception:
                 with self._lock:
-                    remaining = pending[i:]
-                    self._queue = remaining + self._queue
-                    self._bytes = sum(bl for _, bl in self._queue)
-                raise
+                    pending.popleft()
+                    self._bytes -= byte_length
+        finally:
+            self._end_flush(pending)
 
     async def flush_async(self, send: typing.Callable[[str], typing.Awaitable[object]]) -> None:
         """Async variant of :meth:`flush_sync`."""
-        with self._lock:
-            pending = list(self._queue)
-            self._queue.clear()
-            self._bytes = 0
+        while isinstance(pending := self._begin_flush(), threading.Event):
+            # Waiting in a worker keeps the event loop responsive. Cancellation
+            # cannot strand ownership: the worker only waits, never acquires it.
+            await anyio.to_thread.run_sync(pending.wait, abandon_on_cancel=True)
 
-        for i, (data, _byte_length) in enumerate(pending):
-            try:
+        try:
+            while pending:
+                data, byte_length = pending[0]
                 await send(data)
-            except Exception:
                 with self._lock:
-                    remaining = pending[i:]
-                    self._queue = remaining + self._queue
-                    self._bytes = sum(bl for _, bl in self._queue)
-                raise
+                    pending.popleft()
+                    self._bytes -= byte_length
+        finally:
+            self._end_flush(pending)
+
+    def _begin_flush(self) -> deque[tuple[str, int]] | threading.Event:
+        with self._lock:
+            if self._flush_done is not None:
+                return self._flush_done
+            pending = deque(self._queue)
+            self._queue.clear()
+            self._flush_done = threading.Event()
+            # Pending messages remain charged until their sends succeed.
+            return pending
+
+    def _end_flush(self, pending: deque[tuple[str, int]]) -> None:
+        with self._lock:
+            self._queue = list(pending) + self._queue
+            assert self._flush_done is not None
+            self._flush_done.set()
+            self._flush_done = None
 
     def drain(self) -> list[str]:
         """Remove and return all queued messages."""
         with self._lock:
             items = [data for data, _ in self._queue]
+            self._bytes -= sum(byte_length for _, byte_length in self._queue)
             self._queue.clear()
-            self._bytes = 0
             return items
 
     def __len__(self) -> int:

--- a/tests/test_send_queue.py
+++ b/tests/test_send_queue.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+import threading
+from typing import Callable
+
 import pytest
 
 from openai._exceptions import WebSocketQueueFullError
@@ -124,3 +128,238 @@ class TestSendQueue:
         # "b" (failed) should come before "new" (added during flush)
         remaining = q.drain()
         assert remaining == ["b", "new"]
+
+
+async def flush_in_background(q: SendQueue, send: Callable[[str], None], asynchronous: bool) -> None:
+    if asynchronous:
+
+        async def async_send(data: str) -> None:
+            await asyncio.to_thread(send, data)
+
+        await q.flush_async(async_send)
+    else:
+        await asyncio.to_thread(q.flush_sync, send)
+
+
+async def wait_for_event(event: threading.Event) -> None:
+    assert await asyncio.to_thread(event.wait, 5), "send did not start"
+
+
+@pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"])
+@pytest.mark.asyncio
+async def test_repeated_failed_flushes_remain_bounded(asynchronous: bool) -> None:
+    q = SendQueue(max_bytes=6)
+    q.enqueue("éé")  # Four UTF-8 bytes.
+    q.enqueue("a")
+
+    for attempt in range(3):
+        entered, release = threading.Event(), threading.Event()
+
+        def send(data: str, entered: threading.Event = entered, release: threading.Event = release) -> None:
+            assert data == "éé"
+            entered.set()
+            assert release.wait(5)
+            raise RuntimeError("fake send failure")
+
+        task = asyncio.create_task(flush_in_background(q, send, asynchronous))
+        try:
+            await wait_for_event(entered)
+            if attempt == 0:
+                q.enqueue("b")
+            with pytest.raises(WebSocketQueueFullError):
+                q.enqueue("c")
+        finally:
+            release.set()
+            with pytest.raises(RuntimeError, match="fake send failure"):
+                await task
+        assert q._bytes == 6
+
+    sent: list[str] = []
+    await flush_in_background(q, sent.append, asynchronous)
+    assert sent == ["éé", "a", "b"]
+    assert q._bytes == 0
+    q.enqueue("123456")
+
+
+@pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"])
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "failure"])
+@pytest.mark.asyncio
+async def test_partial_flush_releases_only_successful_bytes(asynchronous: bool, fail: bool) -> None:
+    q = SendQueue(max_bytes=4)
+    q.enqueue("é")
+    q.enqueue("bb")
+    entered, release = threading.Event(), threading.Event()
+    sent: list[str] = []
+
+    def send(data: str) -> None:
+        if data == "bb":
+            entered.set()
+            assert release.wait(5)
+            if fail:
+                raise RuntimeError("fake send failure")
+        sent.append(data)
+
+    task = asyncio.create_task(flush_in_background(q, send, asynchronous))
+    try:
+        await wait_for_event(entered)
+        assert q._bytes == 2
+        q.enqueue("cc")
+        with pytest.raises(WebSocketQueueFullError):
+            q.enqueue("d")
+    finally:
+        release.set()
+        if fail:
+            with pytest.raises(RuntimeError, match="fake send failure"):
+                await task
+        else:
+            await task
+    assert sent == (["é"] if fail else ["é", "bb"])
+    assert q.drain() == (["bb", "cc"] if fail else ["cc"])
+    assert q._bytes == 0
+
+
+@pytest.mark.parametrize("asynchronous", [False, True], ids=["sync", "async"])
+@pytest.mark.asyncio
+async def test_drain_during_flush_keeps_pending_bytes_charged(asynchronous: bool) -> None:
+    q = SendQueue(max_bytes=4)
+    q.enqueue("aaa")
+    entered, release = threading.Event(), threading.Event()
+
+    def send(_data: str) -> None:
+        entered.set()
+        assert release.wait(5)
+        raise RuntimeError("fake send failure")
+
+    task = asyncio.create_task(flush_in_background(q, send, asynchronous))
+    try:
+        await wait_for_event(entered)
+        q.enqueue("b")
+        assert q.drain() == ["b"]
+        assert q._bytes == 3
+        q.enqueue("c")
+        with pytest.raises(WebSocketQueueFullError):
+            q.enqueue("d")
+    finally:
+        release.set()
+        with pytest.raises(RuntimeError, match="fake send failure"):
+            await task
+    assert q.drain() == ["aaa", "c"]
+    assert q._bytes == 0
+
+
+@pytest.mark.parametrize("first_async", [False, True], ids=["sync-first", "async-first"])
+@pytest.mark.parametrize("second_async", [False, True], ids=["sync-second", "async-second"])
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "failure"])
+@pytest.mark.asyncio
+async def test_overlapping_flushes_preserve_order(first_async: bool, second_async: bool, fail: bool) -> None:
+    q = SendQueue(max_bytes=3)
+    q.enqueue("a")
+    q.enqueue("b")
+    entered, release, second_sent = threading.Event(), threading.Event(), threading.Event()
+    sent: list[str] = []
+
+    def first_send(data: str) -> None:
+        if data == "a":
+            entered.set()
+            assert release.wait(5)
+            if fail:
+                raise RuntimeError("fake send failure")
+        sent.append(data)
+
+    def second_send(data: str) -> None:
+        second_sent.set()
+        sent.append(data)
+
+    first = asyncio.create_task(flush_in_background(q, first_send, first_async))
+    await wait_for_event(entered)
+    q.enqueue("c")
+    second = asyncio.create_task(flush_in_background(q, second_send, second_async))
+    try:
+        # Neither kind of waiter may overtake the active flush.
+        assert not await asyncio.to_thread(second_sent.wait, 0.05)
+    finally:
+        release.set()
+        if fail:
+            with pytest.raises(RuntimeError, match="fake send failure"):
+                await first
+        else:
+            await first
+        await asyncio.wait_for(second, 5)
+    assert sent == ["a", "b", "c"]
+    assert q._bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_flush_restores_unsent_messages() -> None:
+    q = SendQueue(max_bytes=3)
+    q.enqueue("a")
+    q.enqueue("b")
+    entered = asyncio.Event()
+
+    async def send(data: str) -> None:
+        if data == "b":
+            entered.set()
+            await asyncio.Event().wait()
+
+    task = asyncio.create_task(q.flush_async(send))
+    await asyncio.wait_for(entered.wait(), 5)
+    q.enqueue("cc")
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    with pytest.raises(WebSocketQueueFullError):
+        q.enqueue("d")
+    sent: list[str] = []
+    q.flush_sync(sent.append)
+    assert sent == ["b", "cc"]
+    assert q._bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_flush_waiter_does_not_strand_ownership() -> None:
+    q = SendQueue(max_bytes=2)
+    q.enqueue("a")
+    entered, release = asyncio.Event(), asyncio.Event()
+    sent: list[str] = []
+
+    async def first_send(data: str) -> None:
+        entered.set()
+        await release.wait()
+        sent.append(data)
+
+    async def second_send(data: str) -> None:
+        sent.append(data)
+
+    first = asyncio.create_task(q.flush_async(first_send))
+    await asyncio.wait_for(entered.wait(), 5)
+    q.enqueue("b")
+    second = asyncio.create_task(q.flush_async(second_send))
+    await asyncio.sleep(0)
+    second.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await second
+    release.set()
+    await first
+    await asyncio.wait_for(q.flush_async(second_send), 5)
+    assert sent == ["a", "b"]
+    assert q._bytes == 0
+
+
+def test_interrupted_sync_flush_restores_unsent_messages() -> None:
+    q = SendQueue(max_bytes=2)
+    q.enqueue("a")
+    q.enqueue("b")
+
+    def send(data: str) -> None:
+        if data == "b":
+            raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        q.flush_sync(send)
+    q.enqueue("c")
+    with pytest.raises(WebSocketQueueFullError):
+        q.enqueue("d")
+    sent: list[str] = []
+    q.flush_sync(sent.append)
+    assert sent == ["b", "c"]
+    assert q._bytes == 0

--- a/tests/test_send_queue_reconnect.py
+++ b/tests/test_send_queue_reconnect.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from openai._exceptions import WebSocketQueueFullError
+from openai._send_queue import SendQueue
+from openai.resources.realtime.realtime import RealtimeConnection, AsyncRealtimeConnection
+from openai.resources.responses.responses import ResponsesConnection, AsyncResponsesConnection
+from openai.resources.beta.responses.responses import (
+    ResponsesConnection as BetaResponsesConnection,
+    AsyncResponsesConnection as AsyncBetaResponsesConnection,
+)
+
+
+@pytest.mark.parametrize("connection_type", [RealtimeConnection, ResponsesConnection, BetaResponsesConnection])
+def test_reconnect_retries_bounded_send_queue(
+    connection_type: type[RealtimeConnection] | type[ResponsesConnection] | type[BetaResponsesConnection],
+) -> None:
+    q = SendQueue(max_bytes=4)
+    q.enqueue("aaa")
+    ws = MagicMock()
+    attempts = 0
+
+    def failing_send(data: str) -> None:
+        nonlocal attempts
+        assert data == "aaa"
+        if attempts == 0:
+            q.enqueue("b")
+        attempts += 1
+        with pytest.raises(WebSocketQueueFullError):
+            q.enqueue("c")
+        raise RuntimeError("fake send failure")
+
+    ws.send.side_effect = failing_send
+    connection = connection_type(
+        ws,
+        send_queue=q,
+        make_ws=MagicMock(return_value=ws),
+        on_reconnecting=lambda _event: None,
+        initial_delay=0,
+        max_retries=1,
+    )
+    for _ in range(3):
+        assert connection._reconnect(RuntimeError("fake disconnect"))
+        assert q._bytes == 4
+    assert attempts == 3
+
+    sent: list[str] = []
+    ws.send.side_effect = sent.append
+    assert connection._reconnect(RuntimeError("fake disconnect"))
+    assert sent == ["aaa", "b"]
+    assert q._bytes == 0
+
+
+@pytest.mark.parametrize(
+    "connection_type", [AsyncRealtimeConnection, AsyncResponsesConnection, AsyncBetaResponsesConnection]
+)
+@pytest.mark.asyncio
+async def test_async_reconnect_retries_bounded_send_queue(
+    connection_type: type[AsyncRealtimeConnection]
+    | type[AsyncResponsesConnection]
+    | type[AsyncBetaResponsesConnection],
+) -> None:
+    q = SendQueue(max_bytes=4)
+    q.enqueue("aaa")
+    ws = MagicMock()
+    attempts = 0
+
+    async def failing_send(data: str) -> None:
+        nonlocal attempts
+        assert data == "aaa"
+        if attempts == 0:
+            q.enqueue("b")
+        attempts += 1
+        with pytest.raises(WebSocketQueueFullError):
+            q.enqueue("c")
+        raise RuntimeError("fake send failure")
+
+    ws.send = AsyncMock(side_effect=failing_send)
+    connection = connection_type(
+        ws,
+        send_queue=q,
+        make_ws=AsyncMock(return_value=ws),
+        on_reconnecting=lambda _event: None,
+        initial_delay=0,
+        max_retries=1,
+    )
+    for _ in range(3):
+        assert await connection._reconnect(RuntimeError("fake disconnect"))
+        assert q._bytes == 4
+    assert attempts == 3
+
+    sent: list[str] = []
+    ws.send.side_effect = sent.append
+    assert await connection._reconnect(RuntimeError("fake disconnect"))
+    assert sent == ["aaa", "b"]
+    assert q._bytes == 0


### PR DESCRIPTION
## Summary

Keep queued and in-flight messages charged to the existing byte limit until each send succeeds. Serialize overlapping flushes, preserve FIFO restoration on errors or cancellation, and keep concurrent drains from releasing pending-message capacity.

The change is confined to the shared SendQueue helper and focused queue/reconnect tests. It preserves ordinary enqueue/backpressure behavior and does not change generated connection APIs, logging, dependencies, or Python support. This PR targets public main independently; no stacking dependency.

## Validation

- 34 focused synchronous/asynchronous queue and mocked reconnect tests passed, covering all six GA/beta Responses and Realtime connection classes.
- Repository-wide Ruff, mypy (1,562 source files), and pinned Pyright passed; changed-file formatting and git diff checks passed.
- Separate read-only Codex review round 1 was clean (no actionable P0–P2 findings), including 20 repeated focused-suite runs.
- Local environment used the exact committed frozen lockfile because the public-main lock freshness check requested an update; no dependency files changed.

## Generation follow-up

SDK CODEOWNER review requested. Carry the shared-helper accounting behavior and regression coverage into the corresponding Castiron source/template so regeneration preserves it; no generated resource patch is needed here.