### PR TITLE
fix(azure): resolve one authentication mode

### DIFF
--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -166,7 +166,8 @@ api_version: str | None = _os.environ.get("OPENAI_API_VERSION")
 
 azure_endpoint: str | None = _os.environ.get("AZURE_OPENAI_ENDPOINT")
 
-azure_ad_token: str | None = _os.environ.get("AZURE_OPENAI_AD_TOKEN")
+# Keep explicit module configuration separate from Azure's environment fallback.
+azure_ad_token: str | None = None
 
 azure_ad_token_provider: _azure.AzureADTokenProvider | None = None
 
@@ -362,13 +363,10 @@ def _load_client() -> OpenAI:  # type: ignore[reportUnusedFunction]
     global _client
 
     if _client is None:
-        global api_type, azure_endpoint, azure_ad_token, api_version
+        global api_type, azure_endpoint, api_version
 
         if azure_endpoint is None:
             azure_endpoint = _os.environ.get("AZURE_OPENAI_ENDPOINT")
-
-        if azure_ad_token is None:
-            azure_ad_token = _os.environ.get("AZURE_OPENAI_AD_TOKEN")
 
         if api_version is None:
             api_version = _os.environ.get("OPENAI_API_VERSION")
@@ -379,11 +377,6 @@ def _load_client() -> OpenAI:  # type: ignore[reportUnusedFunction]
             has_azure_ad = _has_azure_ad_credentials()
 
             if has_openai and (has_azure or has_azure_ad):
-                raise _AmbiguousModuleClientUsageError()
-
-            if (azure_ad_token is not None or azure_ad_token_provider is not None) and _os.environ.get(
-                "AZURE_OPENAI_API_KEY"
-            ) is not None:
                 raise _AmbiguousModuleClientUsageError()
 
             if has_azure or has_azure_ad:

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -445,6 +445,9 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
 
     @override
     def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        if self._api_key_provider is not None:
+            self._refresh_api_key()
+
         headers: dict[str, str | Omit] = {**options.headers} if is_given(options.headers) else {}
 
         options = model_copy(options)
@@ -791,6 +794,9 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
 
     @override
     async def _prepare_options(self, options: FinalRequestOptions) -> FinalRequestOptions:
+        if self._api_key_provider is not None:
+            await self._refresh_api_key()
+
         headers: dict[str, str | Omit] = {**options.headers} if is_given(options.headers) else {}
 
         options = model_copy(options)

--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -63,6 +63,56 @@ class MutuallyExclusiveAuthError(OpenAIError):
         )
 
 
+_AzureApiKeyT = TypeVar("_AzureApiKeyT", bound=Union[str, Callable[..., Any]])
+_AzureTokenProviderT = TypeVar("_AzureTokenProviderT", bound=Callable[..., Any])
+
+
+def _resolve_azure_auth(
+    api_key: _AzureApiKeyT | None,
+    azure_ad_token: str | None,
+    azure_ad_token_provider: _AzureTokenProviderT | None,
+) -> tuple[_AzureApiKeyT | str | None, str | None, _AzureTokenProviderT | None]:
+    # The sentinel is internal state carried by copies, not a second credential.
+    if (
+        sum(
+            (
+                api_key is not None and api_key != API_KEY_SENTINEL,
+                azure_ad_token is not None,
+                azure_ad_token_provider is not None,
+            )
+        )
+        > 1
+    ):
+        raise MutuallyExclusiveAuthError()
+
+    # Explicit credentials select the principal. Only an entirely unspecified
+    # configuration may consult the environment; retain AD-token precedence.
+    resolved_api_key: _AzureApiKeyT | str | None = api_key
+    if api_key is None and azure_ad_token is None and azure_ad_token_provider is None:
+        azure_ad_token = os.environ.get("AZURE_OPENAI_AD_TOKEN")
+        if azure_ad_token is None:
+            resolved_api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+
+    return resolved_api_key, azure_ad_token, azure_ad_token_provider
+
+
+def _copy_azure_auth(
+    api_key: _AzureApiKeyT | None,
+    azure_ad_token: str | None,
+    azure_ad_token_provider: _AzureTokenProviderT | None,
+    *,
+    current_api_key: _AzureApiKeyT | str,
+    current_token: str | None,
+    current_provider: _AzureTokenProviderT | None,
+) -> tuple[_AzureApiKeyT | str, str | None, _AzureTokenProviderT | None]:
+    if api_key is None and azure_ad_token is None and azure_ad_token_provider is None:
+        return current_api_key or API_KEY_SENTINEL, current_token, current_provider
+
+    # Prevent OpenAI.copy() from inheriting the old API key when switching to AD.
+    key, token, provider = _resolve_azure_auth(api_key, azure_ad_token, azure_ad_token_provider)
+    return key or API_KEY_SENTINEL, token, provider
+
+
 class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
     _azure_endpoint: httpx2.URL | None
     _azure_deployment: str | None
@@ -203,6 +253,10 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         - `api_version` from `OPENAI_API_VERSION`
         - `azure_endpoint` from `AZURE_OPENAI_ENDPOINT`
 
+        Pass at most one of `api_key`, `azure_ad_token`, or `azure_ad_token_provider`.
+        An explicit credential takes precedence over Azure credential environment variables.
+        With no explicit credential, `AZURE_OPENAI_AD_TOKEN` takes precedence over `AZURE_OPENAI_API_KEY`.
+
         Args:
             azure_endpoint: Your Azure endpoint, including the resource, e.g. `https://example-resource.azure.openai.com/`
 
@@ -216,11 +270,9 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         if is_x509_workload_identity(workload_identity):
             raise OpenAIError("X.509 workload identity is not supported by Azure clients")
 
-        if api_key is None:
-            api_key = os.environ.get("AZURE_OPENAI_API_KEY")
-
-        if azure_ad_token is None:
-            azure_ad_token = os.environ.get("AZURE_OPENAI_AD_TOKEN")
+        api_key, azure_ad_token, azure_ad_token_provider = _resolve_azure_auth(
+            api_key, azure_ad_token, azure_ad_token_provider
+        )
 
         if _enforce_credentials and api_key is None and azure_ad_token is None and azure_ad_token_provider is None:
             raise OpenAIError(
@@ -321,6 +373,15 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
         if is_x509_workload_identity(workload_identity):
             raise OpenAIError("X.509 workload identity is not supported by Azure clients")
 
+        api_key, azure_ad_token, azure_ad_token_provider = _copy_azure_auth(
+            api_key,
+            azure_ad_token,
+            azure_ad_token_provider,
+            current_api_key=self._api_key_provider or self.api_key,
+            current_token=self._azure_ad_token,
+            current_provider=self._azure_ad_token_provider,
+        )
+
         return super().copy(
             api_key=api_key,
             admin_api_key=admin_api_key,
@@ -340,8 +401,8 @@ class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
             _enforce_credentials=_enforce_credentials,
             _extra_kwargs={
                 "api_version": api_version or self._api_version,
-                "azure_ad_token": azure_ad_token or self._azure_ad_token,
-                "azure_ad_token_provider": azure_ad_token_provider or self._azure_ad_token_provider,
+                "azure_ad_token": azure_ad_token,
+                "azure_ad_token_provider": azure_ad_token_provider,
                 **_extra_kwargs,
             },
         )
@@ -536,6 +597,10 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         - `api_version` from `OPENAI_API_VERSION`
         - `azure_endpoint` from `AZURE_OPENAI_ENDPOINT`
 
+        Pass at most one of `api_key`, `azure_ad_token`, or `azure_ad_token_provider`.
+        An explicit credential takes precedence over Azure credential environment variables.
+        With no explicit credential, `AZURE_OPENAI_AD_TOKEN` takes precedence over `AZURE_OPENAI_API_KEY`.
+
         Args:
             azure_endpoint: Your Azure endpoint, including the resource, e.g. `https://example-resource.azure.openai.com/`
 
@@ -549,11 +614,9 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         if is_x509_workload_identity(workload_identity):
             raise OpenAIError("X.509 workload identity is not supported by Azure clients")
 
-        if api_key is None:
-            api_key = os.environ.get("AZURE_OPENAI_API_KEY")
-
-        if azure_ad_token is None:
-            azure_ad_token = os.environ.get("AZURE_OPENAI_AD_TOKEN")
+        api_key, azure_ad_token, azure_ad_token_provider = _resolve_azure_auth(
+            api_key, azure_ad_token, azure_ad_token_provider
+        )
 
         if _enforce_credentials and api_key is None and azure_ad_token is None and azure_ad_token_provider is None:
             raise OpenAIError(
@@ -654,6 +717,15 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
         if is_x509_workload_identity(workload_identity):
             raise OpenAIError("X.509 workload identity is not supported by Azure clients")
 
+        api_key, azure_ad_token, azure_ad_token_provider = _copy_azure_auth(
+            api_key,
+            azure_ad_token,
+            azure_ad_token_provider,
+            current_api_key=self._api_key_provider or self.api_key,
+            current_token=self._azure_ad_token,
+            current_provider=self._azure_ad_token_provider,
+        )
+
         return super().copy(
             api_key=api_key,
             admin_api_key=admin_api_key,
@@ -673,8 +745,8 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
             _enforce_credentials=_enforce_credentials,
             _extra_kwargs={
                 "api_version": api_version or self._api_version,
-                "azure_ad_token": azure_ad_token or self._azure_ad_token,
-                "azure_ad_token_provider": azure_ad_token_provider or self._azure_ad_token_provider,
+                "azure_ad_token": azure_ad_token,
+                "azure_ad_token_provider": azure_ad_token_provider,
                 **_extra_kwargs,
             },
         )

--- a/tests/lib/test_azure_auth.py
+++ b/tests/lib/test_azure_auth.py
@@ -260,10 +260,11 @@ async def test_callable_api_key_refresh_and_copy(asynchronous: bool, monkeypatch
 
         # Replacing a refreshed callable key must discard both its cached value
         # and provider. Switching back must retain the callable, not that cache.
+        calls_before_ad_request = calls
         ad_client = copied.with_options(azure_ad_token="fake-selected")
         await resolve(ad_client.models.list())
         assert auth(requests[-1].headers) == expected_auth("azure_ad_token")
-        assert calls == 5
+        assert calls == calls_before_ad_request
         restored = ad_client.with_options(api_key=provider)
         await resolve(restored.models.list())
         assert auth(requests[-1].headers) == expected_auth("api_key", "fake-key-6")

--- a/tests/lib/test_azure_auth.py
+++ b/tests/lib/test_azure_auth.py
@@ -200,3 +200,72 @@ async def test_internal_sentinel_is_not_a_conflicting_credential(asynchronous: b
         assert auth(requests[0].headers) == expected_auth("azure_ad_token")
     finally:
         await resolve(client.close())
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_callable_api_key_refresh_and_copy(asynchronous: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[httpx2.Request] = []
+    calls = 0
+
+    def key() -> str:
+        nonlocal calls
+        calls += 1
+        return f"fake-key-{calls}"
+
+    async def async_key() -> str:
+        return key()
+
+    def send(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(
+            500 if len(requests) == 1 else 200,
+            json={"data": []},
+            headers={"retry-after-ms": "1"},
+        )
+
+    cls: Any = AsyncAzureOpenAI if asynchronous else AzureOpenAI
+    transport = httpx2.MockTransport(send)
+    http_client = httpx2.AsyncClient(transport=transport) if asynchronous else httpx2.Client(transport=transport)
+    provider = async_key if asynchronous else key
+    client = cls(
+        azure_endpoint="https://azure.test",
+        api_version="2024-02-01",
+        http_client=http_client,
+        api_key=provider,
+        max_retries=1,
+    )
+    try:
+        # Retry, a copy after refresh, and a realtime connection all refresh.
+        await resolve(client.models.list())
+        copied = client.copy()
+        await resolve(copied.models.list())
+        websocket_headers: list[dict[str, str]] = []
+
+        def connect(*_args: Any, **kwargs: Any) -> Any:
+            websocket_headers.append(auth(kwargs["additional_headers"]))
+            return None
+
+        async def async_connect(*args: Any, **kwargs: Any) -> Any:
+            return connect(*args, **kwargs)
+
+        monkeypatch.setattr("websockets.sync.client.connect", connect)
+        monkeypatch.setattr("websockets.asyncio.client.connect", async_connect)
+        for resource in (copied.realtime, copied.beta.realtime):
+            await resolve(resource.connect(model="test-model").enter())
+        assert websocket_headers == [expected_auth("api_key", f"fake-key-{i}") for i in (4, 5)]
+        assert [auth(request.headers) for request in requests] == [
+            expected_auth("api_key", f"fake-key-{i}") for i in (1, 2, 3)
+        ]
+        assert calls == 5
+
+        # Replacing a refreshed callable key must discard both its cached value
+        # and provider. Switching back must retain the callable, not that cache.
+        ad_client = copied.with_options(azure_ad_token="fake-selected")
+        await resolve(ad_client.models.list())
+        assert auth(requests[-1].headers) == expected_auth("azure_ad_token")
+        assert calls == 5
+        restored = ad_client.with_options(api_key=provider)
+        await resolve(restored.models.list())
+        assert auth(requests[-1].headers) == expected_auth("api_key", "fake-key-6")
+    finally:
+        await resolve(client.close())

--- a/tests/lib/test_azure_auth.py
+++ b/tests/lib/test_azure_auth.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import httpx2
+import pytest
+
+from openai import AzureOpenAI, OpenAIError, AsyncAzureOpenAI
+from openai.lib.azure import API_KEY_SENTINEL, MutuallyExclusiveAuthError
+
+
+@pytest.fixture(autouse=True)
+def azure_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-ambient-key")
+    monkeypatch.setenv("AZURE_OPENAI_AD_TOKEN", "fake-ambient-token")
+    monkeypatch.setenv("OPENAI_API_KEY", "fake-unrelated-openai-key")
+
+
+def make_client(asynchronous: bool, requests: list[httpx2.Request], **kwargs: Any) -> Any:
+    def send(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, json={"data": []})
+
+    transport = httpx2.MockTransport(send)
+    http_client = httpx2.AsyncClient(transport=transport) if asynchronous else httpx2.Client(transport=transport)
+    cls: Any = AsyncAzureOpenAI if asynchronous else AzureOpenAI
+    return cls(
+        azure_endpoint="https://azure.test",
+        api_version="2024-02-01",
+        http_client=http_client,
+        **kwargs,
+    )
+
+
+async def resolve(value: Any) -> Any:
+    return await value if inspect.isawaitable(value) else value
+
+
+def auth(headers: Any) -> dict[str, str]:
+    return {key.lower(): value for key, value in headers.items() if key.lower() in {"authorization", "api-key"}}
+
+
+def credentials(mode: str, value: str = "fake-selected") -> dict[str, Any]:
+    if mode == "api_key":
+        return {"api_key": value}
+    if mode == "azure_ad_token":
+        return {"azure_ad_token": value}
+    return {"azure_ad_token_provider": lambda: value}
+
+
+def expected_auth(mode: str, value: str = "fake-selected") -> dict[str, str]:
+    return {"api-key": value} if mode == "api_key" else {"authorization": f"Bearer {value}"}
+
+
+MODES = ["api_key", "azure_ad_token", "azure_ad_token_provider"]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("mode", MODES)
+@pytest.mark.parametrize("ambient_token", [False, True])
+async def test_explicit_mode_wins(
+    asynchronous: bool, mode: str, ambient_token: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if not ambient_token:
+        monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN")
+    requests: list[httpx2.Request] = []
+    client = make_client(asynchronous, requests, **credentials(mode))
+    try:
+        for selected in (client, client.copy(), client.with_options(timeout=20)):
+            await resolve(selected.models.list())
+            _, headers = await resolve(selected._configure_realtime("test-model", {}))
+            assert auth(headers) == expected_auth(mode)
+        assert [auth(request.headers) for request in requests] == [expected_auth(mode)] * 3
+    finally:
+        await resolve(client.close())
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("mode", ["none", "key", "token", "both"])
+async def test_environment_fallback(asynchronous: bool, mode: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    if mode not in {"key", "both"}:
+        monkeypatch.delenv("AZURE_OPENAI_API_KEY")
+    if mode not in {"token", "both"}:
+        monkeypatch.delenv("AZURE_OPENAI_AD_TOKEN")
+    if mode == "none":
+        cls: Any = AsyncAzureOpenAI if asynchronous else AzureOpenAI
+        with pytest.raises(OpenAIError, match="Missing credentials"):
+            cls(azure_endpoint="https://azure.test", api_version="2024-02-01")
+        return
+
+    expected = (
+        expected_auth("api_key", "fake-ambient-key")
+        if mode == "key"
+        else expected_auth("azure_ad_token", "fake-ambient-token")
+    )
+    requests: list[httpx2.Request] = []
+    client = make_client(asynchronous, requests)
+    try:
+        # Copies retain the resolved credential, even after environment changes.
+        monkeypatch.setenv("AZURE_OPENAI_API_KEY", "fake-new-key")
+        monkeypatch.setenv("AZURE_OPENAI_AD_TOKEN", "fake-new-token")
+        for selected in (client, client.copy(), client.with_options()):
+            await resolve(selected.models.list())
+            _, headers = await resolve(selected._configure_realtime("test-model", {}))
+            assert auth(headers) == expected
+        assert [auth(request.headers) for request in requests] == [expected] * 3
+    finally:
+        await resolve(client.close())
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("source", MODES)
+@pytest.mark.parametrize("target", MODES)
+@pytest.mark.parametrize("method", ["copy", "with_options"])
+async def test_copy_replaces_auth_mode(asynchronous: bool, source: str, target: str, method: str) -> None:
+    requests: list[httpx2.Request] = []
+    client = make_client(asynchronous, requests, **credentials(source, "fake-original"))
+    try:
+        copied = getattr(client, method)(**credentials(target))
+        await resolve(copied.models.list())
+        _, headers = await resolve(copied._configure_realtime("test-model", {}))
+        assert auth(headers) == expected_auth(target)
+        await resolve(client.models.list())
+        assert [auth(request.headers) for request in requests] == [
+            expected_auth(target),
+            expected_auth(source, "fake-original"),
+        ]
+    finally:
+        await resolve(client.close())
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("modes", [(MODES[0], MODES[1]), (MODES[0], MODES[2]), (MODES[1], MODES[2]), tuple(MODES)])
+async def test_conflicting_explicit_credentials(asynchronous: bool, modes: tuple[str, ...]) -> None:
+    kwargs = {key: value for mode in modes for key, value in credentials(mode).items()}
+    cls: Any = AsyncAzureOpenAI if asynchronous else AzureOpenAI
+    with pytest.raises(MutuallyExclusiveAuthError):
+        cls(azure_endpoint="https://azure.test", api_version="2024-02-01", **kwargs)
+    client = make_client(asynchronous, [], api_key="fake-original")
+    try:
+        for method in (client.copy, client.with_options):
+            with pytest.raises(MutuallyExclusiveAuthError):
+                method(**kwargs)
+    finally:
+        await resolve(client.close())
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("awaitable_provider", [False, True])
+async def test_provider_refresh_on_retry(asynchronous: bool, awaitable_provider: bool) -> None:
+    if awaitable_provider and not asynchronous:
+        pytest.skip("Synchronous clients require synchronous providers")
+    requests: list[httpx2.Request] = []
+    calls = 0
+
+    def token() -> str:
+        nonlocal calls
+        calls += 1
+        return f"fake-token-{calls}"
+
+    async def async_token() -> str:
+        return token()
+
+    def send(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(500 if len(requests) == 1 else 200, json={"data": []}, headers={"retry-after-ms": "1"})
+
+    cls: Any = AsyncAzureOpenAI if asynchronous else AzureOpenAI
+    transport = httpx2.MockTransport(send)
+    http_client = httpx2.AsyncClient(transport=transport) if asynchronous else httpx2.Client(transport=transport)
+    client = cls(
+        azure_endpoint="https://azure.test",
+        api_version="2024-02-01",
+        http_client=http_client,
+        azure_ad_token_provider=async_token if awaitable_provider else token,
+        max_retries=1,
+    )
+    try:
+        await resolve(client.with_options().models.list())
+        assert [auth(request.headers) for request in requests] == [
+            expected_auth("azure_ad_token", "fake-token-1"),
+            expected_auth("azure_ad_token", "fake-token-2"),
+        ]
+        _, headers = await resolve(client._configure_realtime("test-model", {}))
+        assert auth(headers) == expected_auth("azure_ad_token", "fake-token-3")
+        assert calls == 3
+    finally:
+        await resolve(client.close())
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_internal_sentinel_is_not_a_conflicting_credential(asynchronous: bool) -> None:
+    requests: list[httpx2.Request] = []
+    client = make_client(
+        asynchronous, requests, api_key=API_KEY_SENTINEL, azure_ad_token_provider=lambda: "fake-selected"
+    )
+    try:
+        await resolve(client.models.list())
+        assert auth(requests[0].headers) == expected_auth("azure_ad_token")
+    finally:
+        await resolve(client.close())

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -236,7 +236,7 @@ def test_azure_module_rejects_conflicting_explicit_auth(forced: bool) -> None:
         openai.api_key = "fake-explicit-key"
         openai.azure_ad_token_provider = lambda: "fake-explicit-token"
         with pytest.raises(MutuallyExclusiveAuthError):
-            openai.models._client  # noqa: B018
+            _ = openai.models._client
 
 
 def test_azure_module_import_does_not_make_ambient_token_explicit() -> None:
@@ -271,7 +271,7 @@ def test_azure_module_preserves_provider_ambiguity() -> None:
         _os.environ["OPENAI_API_KEY"] = "fake-openai-key"
         _os.environ["AZURE_OPENAI_AD_TOKEN"] = "fake-azure-token"
         with pytest.raises(openai.OpenAIError, match="Ambiguous use of module client"):
-            openai.models._client  # noqa: B018
+            _ = openai.models._client
 
 
 def test_bedrock_token_and_region_env() -> None:

--- a/tests/test_module_client.py
+++ b/tests/test_module_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import os as _os
+import sys
+import subprocess
 
 import httpx2
 import pytest
@@ -101,7 +103,7 @@ def test_http_client_option() -> None:
 import contextlib
 from typing import Iterator
 
-from openai.lib.azure import AzureOpenAI
+from openai.lib.azure import AzureOpenAI, MutuallyExclusiveAuthError
 from openai.lib.bedrock import BedrockOpenAI
 
 
@@ -185,6 +187,91 @@ def test_azure_azure_ad_token_provider_version_and_endpoint_env() -> None:
         assert isinstance(client, AzureOpenAI)
         assert client._azure_ad_token_provider is not None
         assert client._azure_ad_token_provider() == "token"
+
+
+@pytest.mark.parametrize("forced", [False, True])
+@pytest.mark.parametrize("mode", ["api_key", "azure_ad_token", "azure_ad_token_provider", "environment"])
+def test_azure_module_explicit_auth_precedence(forced: bool, mode: str) -> None:
+    requests: list[httpx2.Request] = []
+
+    def send(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        return httpx2.Response(200, json={"data": []})
+
+    with fresh_env():
+        openai.api_type = "azure" if forced else None
+        _os.environ["AZURE_OPENAI_API_KEY"] = "fake-ambient-key"
+        _os.environ["AZURE_OPENAI_AD_TOKEN"] = "fake-ambient-token"
+        _os.environ["OPENAI_API_VERSION"] = "2024-02-01"
+        _os.environ["AZURE_OPENAI_ENDPOINT"] = "https://azure.test"
+        if mode == "api_key":
+            openai.api_key = "fake-selected"
+        elif mode == "azure_ad_token":
+            openai.azure_ad_token = "fake-selected"
+        elif mode == "azure_ad_token_provider":
+            openai.azure_ad_token_provider = lambda: "fake-selected"
+
+        with httpx2.Client(transport=httpx2.MockTransport(send), trust_env=False) as http_client:
+            openai.http_client = http_client
+            openai.models.list()
+            client = openai.models._client
+            assert isinstance(client, AzureOpenAI)
+            _, realtime_headers = client._configure_realtime("test-model", {})
+
+        expected = (
+            {"api-key": "fake-selected"}
+            if mode == "api_key"
+            else {"authorization": "Bearer fake-ambient-token" if mode == "environment" else "Bearer fake-selected"}
+        )
+        for headers in (requests[0].headers, realtime_headers):
+            assert {k.lower(): v for k, v in headers.items() if k.lower() in {"authorization", "api-key"}} == expected
+
+
+@pytest.mark.parametrize("forced", [False, True])
+def test_azure_module_rejects_conflicting_explicit_auth(forced: bool) -> None:
+    with fresh_env():
+        openai.api_type = "azure" if forced else None
+        openai.azure_endpoint = "https://azure.test"
+        openai.api_version = "2024-02-01"
+        openai.api_key = "fake-explicit-key"
+        openai.azure_ad_token_provider = lambda: "fake-explicit-token"
+        with pytest.raises(MutuallyExclusiveAuthError):
+            openai.models._client  # noqa: B018
+
+
+def test_azure_module_import_does_not_make_ambient_token_explicit() -> None:
+    # Exercise import-time environment handling in a fresh interpreter.
+    subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import os\n"
+            "from unittest.mock import patch\n"
+            "with patch.dict(os.environ, {\n"
+            "    'AZURE_OPENAI_AD_TOKEN': 'fake-ambient-token',\n"
+            "    'OPENAI_API_TYPE': 'azure',\n"
+            "    'OPENAI_API_VERSION': '2024-02-01',\n"
+            "    'AZURE_OPENAI_ENDPOINT': 'https://azure.test',\n"
+            "}, clear=True):\n"
+            "    import openai\n"
+            "    assert openai.azure_ad_token is None\n"
+            "    openai.api_key = 'fake-explicit-key'\n"
+            "    client = openai.models._client\n"
+            "    assert client._azure_ad_token is None\n"
+            "    assert client.api_key == 'fake-explicit-key'\n"
+            "    client.close()\n",
+        ],
+        check=True,
+    )
+
+
+def test_azure_module_preserves_provider_ambiguity() -> None:
+    with fresh_env():
+        openai.api_type = None
+        _os.environ["OPENAI_API_KEY"] = "fake-openai-key"
+        _os.environ["AZURE_OPENAI_AD_TOKEN"] = "fake-azure-token"
+        with pytest.raises(openai.OpenAIError, match="Ambiguous use of module client"):
+            openai.models._client  # noqa: B018
 
 
 def test_bedrock_token_and_region_env() -> None:


### PR DESCRIPTION
## Summary

- Resolve one Azure authentication mode consistently for synchronous and asynchronous clients. Explicit credentials take precedence over credential environment variables; conflicting explicit modes raise the existing `MutuallyExclusiveAuthError`.
- Preserve environment-only AD-token precedence, client-copy behavior, and callable API-key refresh.
- Keep module-level explicit Azure configuration separate from environment fallback, including import-time configuration and automatic Azure selection.
- Add focused regressions for explicit and ambient credential selection, client copies, HTTP and Realtime configuration, and callable keys.

No dependency or exported client API changes. This is independent of the Azure redirect-transport changes in #3684.
