### PR TITLE
fix: compute custom-code summaries from trusted workflow code

### DIFF
--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -13,9 +13,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  compute:
+    name: Compute trusted custom-code report
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.path == '.github/workflows/castiron-custom-code.yml'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    outputs:
+      number: ${{ steps.report.outputs.number }}
+      artifact-id: ${{ steps.artifact.outputs.artifact-id }}
+    steps:
+      - name: Check out the trusted reporter
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Compute from the current pull request Git objects
+        id: report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GIT_CONFIG_COUNT: '2'
+          GIT_CONFIG_KEY_0: credential.helper
+          GIT_CONFIG_VALUE_0: ''
+          GIT_CONFIG_KEY_1: credential.https://github.com.helper
+          GIT_CONFIG_VALUE_1: '!gh auth git-credential'
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          python3 -I scripts/castiron/custom_code_report.py trusted-report \
+            --repo "$RUNNER_TEMP/castiron-objects.git" \
+            --repository "$REPOSITORY" --run-id "$RUN_ID" --run-attempt "$RUN_ATTEMPT" \
+            --out "$RUNNER_TEMP/castiron-custom-code"
+          if test -f "$RUNNER_TEMP/castiron-custom-code/context.json"; then
+            number=$(jq -er '.pr' "$RUNNER_TEMP/castiron-custom-code/context.json")
+            printf 'number=%s\n' "$number" >> "$GITHUB_OUTPUT"
+            cat "$RUNNER_TEMP/castiron-custom-code/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload the trusted report and patch
+        id: artifact
+        if: steps.report.outputs.number != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: castiron-custom-code-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/castiron-custom-code/
+          if-no-files-found: error
+          retention-days: 7
+
   comment:
     name: Update custom-code comment
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.path == '.github/workflows/castiron-custom-code.yml'
+    needs: compute
+    if: always() && !cancelled() && (needs.compute.result == 'failure' || needs.compute.outputs.number != '')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -29,40 +82,31 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
-      - name: Download the completed run's report
+      - name: Download this workflow's trusted report
+        if: needs.compute.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: castiron-custom-code-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
+          artifact-ids: ${{ needs.compute.outputs.artifact-id }}
+          merge-multiple: true
           path: ${{ runner.temp }}/castiron-custom-code
-
-      - name: Validate report context
-        id: context
-        env:
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
-          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-        run: |
-          number=$(jq -er --arg repository "$REPOSITORY" --argjson run "$RUN_ID" \
-            --argjson attempt "$RUN_ATTEMPT" \
-            'select(.repository == $repository and .run == $run and .attempt == $attempt) | .pr | select(type == "number" and . > 0 and . == floor)' \
-            "$RUNNER_TEMP/castiron-custom-code/context.json")
-          printf 'number=%s\n' "$number" >> "$GITHUB_OUTPUT"
 
       - name: Create or update the single report comment
         id: publish
+        if: needs.compute.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ steps.context.outputs.number }}
+          PR_NUMBER: ${{ needs.compute.outputs.number }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          ARTIFACT_RUN_ID: ${{ github.run_id }}
+          ARTIFACT_RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
           python3 -I scripts/castiron/custom_code_report.py comment \
             --report "$RUNNER_TEMP/castiron-custom-code/report.json" \
             --repository "$REPOSITORY" --pr "$PR_NUMBER" --run-id "$RUN_ID" \
-            --run-attempt "$RUN_ATTEMPT"
+            --run-attempt "$RUN_ATTEMPT" \
+            --artifact-run-id "$ARTIFACT_RUN_ID" --artifact-run-attempt "$ARTIFACT_RUN_ATTEMPT"
 
       - name: Publish a trusted failure status
         if: always() && !cancelled() && steps.publish.outcome != 'success'

--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       number: ${{ steps.report.outputs.number }}
       artifact-id: ${{ steps.artifact.outputs.artifact-id }}
+      artifact-run-attempt: ${{ github.run_attempt }}
     steps:
       - name: Check out the trusted reporter
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -100,7 +101,7 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           ARTIFACT_RUN_ID: ${{ github.run_id }}
-          ARTIFACT_RUN_ATTEMPT: ${{ github.run_attempt }}
+          ARTIFACT_RUN_ATTEMPT: ${{ needs.compute.outputs.artifact-run-attempt }}
         run: |
           python3 -I scripts/castiron/custom_code_report.py comment \
             --report "$RUNNER_TEMP/castiron-custom-code/report.json" \

--- a/.github/workflows/castiron-custom-code.yml
+++ b/.github/workflows/castiron-custom-code.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REPORTER_SHA256: 73ecd6290e9803b0d0a93af4ca4dccdbf8648cbd5c0cce51ea65fce28c7da79f
+  REPORTER_SHA256: ac48ca88e9f7ad57195038157e99f055c0cd3dac8de856e4d102dca807766d4a
 
 jobs:
   report:

--- a/scripts/castiron/README.md
+++ b/scripts/castiron/README.md
@@ -16,8 +16,12 @@ Its hash format is documented in the reporter. Only `.github/actions/` and
 `.github/workflows/` are excluded from the content hash.
 
 The read-only pull-request workflow runs on every branch, including drafts and
-forks. A separate `workflow_run` publisher reads its report as untrusted data and
-uses only code from the trusted default branch to update the PR comment. The
+forks. A separate read-only `workflow_run` job computes the authoritative report from
+current, GitHub-associated base/head Git objects using the trusted workflow
+revision. It fetches those objects into a new bare repository and never checks
+out or executes PR code. The comment-writing job consumes only the artifact
+from that trusted job, rechecks freshness, and links to its report and patch.
+PR-produced reports are advisory run output, not the published assessment. The
 publisher becomes active once its workflow is on the default branch. No branch
 allowlist or repository variable is needed. Never execute PR-controlled code with
 write credentials. Changing either workflow may require one-time AM permission.

--- a/scripts/castiron/custom_code_report.py
+++ b/scripts/castiron/custom_code_report.py
@@ -767,7 +767,14 @@ def api(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
 
 
 def publish_comment(
-    report: dict[str, Any], repository: str, number: int, run_id: int, run_attempt: int
+    report: dict[str, Any],
+    repository: str,
+    number: int,
+    run_id: int,
+    run_attempt: int,
+    *,
+    artifact_run_id: int = 0,
+    artifact_run_attempt: int = 0,
 ) -> str:
     if not REPOSITORY.fullmatch(repository) or min(number, run_id, run_attempt) <= 0:
         raise ReportError("invalid GitHub publication target")
@@ -794,12 +801,14 @@ def publish_comment(
         raise ReportError("workflow run does not match report PR/head")
     if run["run_attempt"] != run_attempt:
         return "Skipped stale report"
+    artifact_run_id = artifact_run_id or run_id
+    artifact_run_attempt = artifact_run_attempt or run_attempt
     body = render_report(
         report,
-        f"https://github.com/{repository}/actions/runs/{run_id}",
+        f"https://github.com/{repository}/actions/runs/{artifact_run_id}",
         repository=repository,
-        run_id=run_id,
-        run_attempt=run_attempt,
+        run_id=artifact_run_id,
+        run_attempt=artifact_run_attempt,
     )
     body += f"\n<!-- castiron:run:v1:{run_id}:{run_attempt} -->\n"
     found = None
@@ -834,6 +843,88 @@ def publish_comment(
     return str(result["html_url"])
 
 
+def write_report(
+    repo: Path,
+    base: str,
+    head: str,
+    out: Path,
+    *,
+    fetch: bool,
+    require_head_hash: bool,
+    public: bool,
+) -> dict[str, Any]:
+    out.mkdir(parents=True, exist_ok=True)
+    try:
+        report, patch = build_report(
+            repo, base, head, fetch=fetch, require_head_hash=require_head_hash, public=public
+        )
+    except (ReportError, UnicodeError, KeyError, ValueError) as exc:
+        report = {
+            "schema_version": 1,
+            "status": "error",
+            "target_base_sha": require_sha(base),
+            "head_sha": require_sha(head),
+            "error": str(exc),
+        }
+        patch = b""
+    (out / "report.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    (out / "custom-code.patch").write_bytes(patch)
+    summary = render_report(report)
+    (out / "summary.md").write_text(summary)
+    sys.stdout.write(summary)
+    return report
+
+
+def trusted_report(
+    repo: Path, repository: str, run_id: int, run_attempt: int, out: Path
+) -> None:
+    """Recompute from GitHub-associated Git objects, never from PR-produced artifacts."""
+    if not REPOSITORY.fullmatch(repository) or min(run_id, run_attempt) <= 0:
+        raise ReportError("invalid GitHub report target")
+    root = f"repos/{repository}"
+    run = api("GET", f"{root}/actions/runs/{run_id}")
+    if (
+        run["event"] != "pull_request"
+        or run.get("path", "").split("@", 1)[0] != ".github/workflows/castiron-custom-code.yml"
+        or run["status"] != "completed"
+    ):
+        raise ReportError("unexpected source workflow run")
+    if run["run_attempt"] != run_attempt:
+        return
+    head = require_sha(run["head_sha"])
+    associated = run["pull_requests"] or api("GET", f"{root}/commits/{head}/pulls?per_page=100")
+    current: list[tuple[int, str]] = []
+    for number in sorted({int(pr["number"]) for pr in associated}):
+        if number <= 0:
+            raise ReportError("invalid associated pull request")
+        pull = api("GET", f"{root}/pulls/{number}")
+        if (
+            pull["state"] == "open"
+            and pull["head"]["sha"] == head
+            and pull["base"]["repo"]["full_name"] == repository
+        ):
+            current.append((number, require_sha(pull["base"]["sha"])))
+    if not current:
+        return
+    if len(current) != 1:
+        raise ReportError("workflow run has multiple current pull requests")
+    number, base = current[0]
+    public = not api("GET", root)["private"]
+    # This must be a new, bare repository: no PR worktree, hooks, configuration,
+    # submodules, or Python imports can affect the trusted reporter.
+    repo.mkdir()
+    git(repo, "init", "--quiet", "--bare")
+    git(repo, "remote", "add", "origin", f"https://github.com/{repository}.git")
+    git(repo, "fetch", "--quiet", "--no-tags", "origin", base, head)
+    write_report(repo, base, head, out, fetch=True, require_head_hash=True, public=public)
+    (out / "context.json").write_text(
+        json.dumps(
+            {"pr": number, "repository": repository, "run": run_id, "attempt": run_attempt}
+        )
+        + "\n"
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
@@ -848,6 +939,12 @@ def main() -> int:
     reporting.add_argument("--fetch", action="store_true")
     reporting.add_argument("--require-head-hash", action="store_true")
     reporting.add_argument("--public", action="store_true")
+    trusted = commands.add_parser("trusted-report")
+    trusted.add_argument("--repo", type=Path, required=True)
+    trusted.add_argument("--repository", required=True)
+    trusted.add_argument("--run-id", type=int, required=True)
+    trusted.add_argument("--run-attempt", type=int, required=True)
+    trusted.add_argument("--out", type=Path, required=True)
     preparing = commands.add_parser("prepare-public")
     preparing.add_argument("--source-repo", type=Path, required=True)
     preparing.add_argument("--source-base", required=True)
@@ -861,6 +958,8 @@ def main() -> int:
     commenting.add_argument("--pr", type=int, required=True)
     commenting.add_argument("--run-id", type=int, required=True)
     commenting.add_argument("--run-attempt", type=int, required=True)
+    commenting.add_argument("--artifact-run-id", type=int, default=0)
+    commenting.add_argument("--artifact-run-attempt", type=int, default=0)
     args = parser.parse_args()
     try:
         if args.command == "hash":
@@ -879,41 +978,34 @@ def main() -> int:
                 )
                 + "\n"
             )
+        elif args.command == "trusted-report":
+            trusted_report(args.repo, args.repository, args.run_id, args.run_attempt, args.out)
         elif args.command == "comment":
             if args.report.stat().st_size > 5_000_000:
                 raise ReportError("report artifact is too large")
             report = json.loads(args.report.read_text())
             sys.stdout.write(
-                publish_comment(report, args.repository, args.pr, args.run_id, args.run_attempt)
+                publish_comment(
+                    report,
+                    args.repository,
+                    args.pr,
+                    args.run_id,
+                    args.run_attempt,
+                    artifact_run_id=args.artifact_run_id,
+                    artifact_run_attempt=args.artifact_run_attempt,
+                )
                 + "\n"
             )
         else:
-            args.out.mkdir(parents=True, exist_ok=True)
-            try:
-                report, patch = build_report(
-                    args.repo,
-                    args.base,
-                    args.head,
-                    fetch=args.fetch,
-                    require_head_hash=args.require_head_hash,
-                    public=args.public,
-                )
-            except (ReportError, UnicodeError, KeyError, ValueError) as exc:
-                report = {
-                    "schema_version": 1,
-                    "status": "error",
-                    "target_base_sha": require_sha(args.base),
-                    "head_sha": require_sha(args.head),
-                    "error": str(exc),
-                }
-                patch = b""
-            (args.out / "report.json").write_text(
-                json.dumps(report, indent=2, sort_keys=True) + "\n"
+            report = write_report(
+                args.repo,
+                args.base,
+                args.head,
+                args.out,
+                fetch=args.fetch,
+                require_head_hash=args.require_head_hash,
+                public=args.public,
             )
-            (args.out / "custom-code.patch").write_bytes(patch)
-            summary = render_report(report)
-            (args.out / "summary.md").write_text(summary)
-            sys.stdout.write(summary)
             return 0 if report["status"] == "ok" else 1
     except (ReportError, OSError, subprocess.TimeoutExpired) as exc:
         sys.stderr.write(f"Castiron custom-code report: {exc}\n")

--- a/scripts/castiron/test_custom_code_report.py
+++ b/scripts/castiron/test_custom_code_report.py
@@ -345,6 +345,71 @@ async function check(stale, exists, priorRun, expected) {
         ).hexdigest()
         self.assertIn(f"REPORTER_SHA256: {digest}", producer)
 
+    def test_comment_only_rerun_links_to_the_compute_artifact_attempt(self) -> None:
+        workflow = (
+            Path(__file__).resolve().parents[2]
+            / ".github/workflows/castiron-custom-code-comment.yml"
+        ).read_text()
+        compute, comment = workflow.split("\n  comment:\n", 1)
+
+        def field(section: str, prefix: str) -> str:
+            return next(
+                line.removeprefix(prefix)
+                for line in section.splitlines()
+                if line.startswith(prefix)
+            )
+
+        def resolve(value: str, context: dict[str, str]) -> str:
+            for key, replacement in context.items():
+                value = value.replace("${{ " + key + " }}", replacement)
+            self.assertNotIn("${{", value)
+            return value
+
+        # A successful compute job's outputs survive a comment-only rerun.
+        compute_context = {"github.run_id": "9", "github.run_attempt": "3"}
+        uploaded_name = resolve(field(compute, "          name: "), compute_context)
+        saved_attempt = resolve(field(compute, "      artifact-run-attempt: "), compute_context)
+        comment_context = {
+            "github.run_id": "9",
+            "github.run_attempt": "4",
+            "needs.compute.outputs.artifact-run-attempt": saved_attempt,
+        }
+        artifact_attempt = resolve(
+            field(comment, "          ARTIFACT_RUN_ATTEMPT: "), comment_context
+        )
+        self.assertEqual(uploaded_name, "castiron-custom-code-9-3")
+        self.assertEqual(artifact_attempt, "3")
+
+        _, base = self.baseline()
+        result, _ = report.build_report(self.repo, base, base)
+        pull = {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
+        run = {
+            "event": "pull_request",
+            "path": ".github/workflows/castiron-custom-code.yml",
+            "head_sha": base,
+            "run_attempt": 1,
+            "pull_requests": [{"number": 1}],
+        }
+        with mock.patch.object(
+            report, "api", side_effect=[pull, run, [], pull, {"html_url": "published"}]
+        ) as api:
+            self.assertEqual(
+                report.publish_comment(
+                    result,
+                    "openai/example",
+                    1,
+                    2,
+                    1,
+                    artifact_run_id=9,
+                    artifact_run_attempt=int(artifact_attempt),
+                ),
+                "published",
+            )
+        body = api.call_args.args[2]["body"]
+        self.assertIn(f"--name {uploaded_name}", body)
+        self.assertNotIn("--name castiron-custom-code-9-4", body)
+        self.assertIn("castiron:run:v1:2:1", body)
+
     def test_trusted_report_recomputes_pr_output_in_a_bare_repository(self) -> None:
         generated, _ = self.baseline()
         content_hash = report.hash_codegen_commit(self.repo, generated)

--- a/scripts/castiron/test_custom_code_report.py
+++ b/scripts/castiron/test_custom_code_report.py
@@ -12,6 +12,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from typing import Any
 from unittest import mock
 
 import custom_code_report as report
@@ -328,6 +329,195 @@ async function check(stale, exists, priorRun, expected) {
         self.assertNotIn("ref: ${{ github.event.pull_request.head.sha }}", publisher)
         self.assertIn("persist-credentials: false", publisher)
         self.assertIn("--report", publisher)
+        compute, comment = publisher.split("\n  comment:\n", 1)
+        self.assertNotIn("pull-requests: write", compute)
+        self.assertIn("pull-requests: read", compute)
+        self.assertIn(" trusted-report ", compute)
+        self.assertNotIn("download-artifact@", compute)
+        self.assertNotIn("unittest", compute)
+        self.assertIn("needs: compute", comment)
+        self.assertIn("artifact-ids: ${{ needs.compute.outputs.artifact-id }}", comment)
+        self.assertNotIn("run-id: ${{ github.event.workflow_run.id }}", comment)
+        self.assertNotIn("git fetch", comment)
+        self.assertIn("--artifact-run-id", comment)
+        digest = hashlib.sha256(
+            (workflows.parents[1] / "scripts/castiron/custom_code_report.py").read_bytes()
+        ).hexdigest()
+        self.assertIn(f"REPORTER_SHA256: {digest}", producer)
+
+    def test_trusted_report_recomputes_pr_output_in_a_bare_repository(self) -> None:
+        generated, _ = self.baseline()
+        content_hash = report.hash_codegen_commit(self.repo, generated)
+        snapshot = report.create_public_snapshot(
+            self.repo,
+            self.git("rev-parse", f"{generated}^{{tree}}"),
+            GENERATION,
+            content_hash,
+            "codegen/public-test",
+            None,
+        )
+        self.git("branch", "codegen/public-test", snapshot)
+        stats = (self.repo / ".castiron.stats.yml").read_text()
+        self.write(".castiron.stats.yml", stats + f"public_codegen_sha: {snapshot}\n")
+        base = self.commit()
+        legitimate, _ = report.build_report(self.repo, base, base, require_head_hash=True)
+        self.write("generated.py", "generated\n# custom\n")
+        # Neither a replacement reporter nor its claimed result may be executed
+        # or read by the trusted job.
+        self.write(
+            "scripts/castiron/custom_code_report.py", "raise RuntimeError('PR code ran')\n"
+        )
+        self.write("report.json", json.dumps(legitimate))
+        head = self.commit()
+        broken_stats = (
+            (self.repo / ".castiron.stats.yml").read_text().replace(content_hash, "0" * 64)
+        )
+        self.write(".castiron.stats.yml", broken_stats)
+        broken = self.commit()
+        remote = self.repo / "public.git"
+        self.git("clone", "--bare", str(self.repo), str(remote))
+        real_git = report.git
+
+        def local_git(repo: Path, *args: str, input_bytes: bytes | None = None) -> bytes:
+            if args[:3] == ("remote", "add", "origin"):
+                self.assertEqual(args[3], "https://github.com/openai/example.git")
+                args = (*args[:3], str(remote))
+            self.assertNotIn("checkout", args)
+            return real_git(repo, *args, input_bytes=input_bytes)
+
+        for label, revision in (("genuine", base), ("custom", head), ("broken", broken)):
+            with self.subTest(label=label):
+                calls: list[tuple[str, str]] = []
+                bodies: list[str] = []
+                pull = {
+                    "state": "open",
+                    "head": {"sha": revision},
+                    "base": {"sha": base, "repo": {"full_name": "openai/example"}},
+                }
+                run: dict[str, Any] = {
+                    "event": "pull_request",
+                    "status": "completed",
+                    "path": ".github/workflows/castiron-custom-code.yml",
+                    "head_sha": revision,
+                    "run_attempt": 1,
+                    "pull_requests": [],
+                }
+                forged: dict[str, Any] = {**legitimate, "head_sha": revision, "files": []}
+                self.assertIn("Generated baselines verified", report.render_report(forged))
+                producer = self.repo / f"producer-{label}"
+                producer.mkdir()
+                (producer / "report.json").write_text(json.dumps(forged))
+
+                def fake_api(
+                    method: str, path: str, payload: dict[str, Any] | None = None
+                ) -> Any:
+                    calls.append((method, path))
+                    if method == "GET":
+                        responses: dict[str, Any] = {
+                            "repos/openai/example": {"private": False},
+                            "repos/openai/example/actions/runs/2": run,
+                            f"repos/openai/example/commits/{revision}/pulls?per_page=100": [
+                                {"number": 1}
+                            ],
+                            "repos/openai/example/pulls/1": pull,
+                            "repos/openai/example/issues/1/comments?per_page=100&page=1": [],
+                        }
+                        if path in responses:
+                            return responses[path]
+                    if (
+                        method == "POST"
+                        and path == "repos/openai/example/issues/1/comments"
+                        and payload
+                    ):
+                        bodies.append(payload["body"])
+                        return {
+                            "html_url": "https://github.com/openai/example/pull/1#issuecomment-1"
+                        }
+                    raise AssertionError(f"unexpected API call: {method} {path}")
+
+                objects = self.repo / f"objects-{label}.git"
+                out = self.repo / f"trusted-{label}"
+                with (
+                    mock.patch.object(report, "api", side_effect=fake_api),
+                    mock.patch.object(report, "git", side_effect=local_git),
+                ):
+                    report.trusted_report(objects, "openai/example", 2, 1, out)
+                    self.assertTrue(all(method == "GET" for method, _ in calls))
+                    self.assertEqual(
+                        real_git(objects, "rev-parse", "--is-bare-repository"), b"true\n"
+                    )
+                    self.assertFalse((objects / "scripts").exists())
+                    actual = json.loads((out / "report.json").read_text())
+                    report.publish_comment(
+                        actual,
+                        "openai/example",
+                        1,
+                        2,
+                        1,
+                        artifact_run_id=9,
+                        artifact_run_attempt=3,
+                    )
+                self.assertEqual(len(bodies), 1)
+                body = bodies[0]
+                self.assertIn("castiron:run:v1:2:1", body)
+                self.assertIn("/actions/runs/9", body)
+                if label == "broken":
+                    self.assertIn("Report unavailable", body)
+                    self.assertNotIn("Generated baselines verified", body)
+                elif label == "custom":
+                    self.assertIn("1 newly customized", body)
+                    self.assertIn("generated.py", body)
+                    self.assertIn(b"+# custom", (out / "custom-code.patch").read_bytes())
+                    self.assertNotIn("No new custom-code files detected", body)
+                else:
+                    self.assertIn("No new custom-code files detected", body)
+                    self.assertIn("Generated baselines verified", body)
+                    self.assertIn("--name castiron-custom-code-9-3", body)
+
+    def test_trusted_report_rejects_invalid_or_stale_association_before_fetch(self) -> None:
+        run = {
+            "event": "pull_request",
+            "status": "completed",
+            "path": ".github/workflows/castiron-custom-code.yml",
+            "head_sha": "a" * 40,
+            "run_attempt": 1,
+            "pull_requests": [{"number": 1}],
+        }
+        pull = {
+            "state": "open",
+            "head": {"sha": "a" * 40},
+            "base": {"sha": "b" * 40, "repo": {"full_name": "openai/example"}},
+        }
+        cases: list[tuple[list[Any], bool]] = [
+            ([{**run, "path": "other.yml"}], True),
+            ([{**run, "status": "in_progress"}], True),
+            ([{**run, "run_attempt": 2}], False),
+            ([run, {**pull, "state": "closed"}], False),
+            ([run, {**pull, "head": {"sha": "c" * 40}}], False),
+            (
+                [run, {**pull, "base": {"sha": "b" * 40, "repo": {"full_name": "other/repo"}}}],
+                False,
+            ),
+            ([{**run, "pull_requests": []}, []], False),
+            ([{**run, "pull_requests": [{"number": 1}, {"number": 2}]}, pull, pull], True),
+        ]
+        for responses, raises in cases:
+            with (
+                self.subTest(responses=responses),
+                mock.patch.object(report, "api", side_effect=responses),
+                mock.patch.object(report, "git") as git,
+            ):
+                if raises:
+                    with self.assertRaises(report.ReportError):
+                        report.trusted_report(
+                            self.repo / "objects", "openai/example", 2, 1, self.repo / "out"
+                        )
+                else:
+                    report.trusted_report(
+                        self.repo / "objects", "openai/example", 2, 1, self.repo / "out"
+                    )
+                git.assert_not_called()
+                self.assertFalse((self.repo / "out").exists())
 
     def test_removals_include_changed_baselines_but_not_handwritten_only_files(self) -> None:
         _, base = self.baseline()


### PR DESCRIPTION
## Summary

Compute custom-code summaries from trusted workflow code in a separate read-only job. Publish its freshly generated report and patch through the existing comment job, retaining current-PR and run freshness checks.

## Validation

- Focused Castiron unittest suite: 19 tests passed (one optional compiler test skipped).
- Focused Ruff, Pyright, mypy, and Python compilation checks passed.
- Workflow YAML, shell syntax, action-pin, and offline local-Git regression checks passed.

The workflow change becomes active after it reaches the default branch. SDK CODEOWNER review is requested.
