### PR TITLE
chore(api): remove redundant generated formatting

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: 14743cd4-a53e-4fed-ba72-d5e23592153e
+generation_id: 260c1f53-e64c-4d91-86a5-b85a85b57da0
 openapi_spec_hash: a99ded1ea34cf528a9cd5f064167f26a
 openapi_transformed_spec_hash: e24c9d9339620c3cce8bbdd80e9ef8ed
 config_hash: 85382dd94c503b5d225adc7636a77c9f
-codegen_sha: 66cd6dedd5d1b60732d891f911deb07347a8f068
+codegen_sha: 1a5da8d7cca1526c2c1fedc340b19b76dc234ab2
 codegen_hash: 0e1cb892e3631438e55b55edd14899551f458be8d073e13d2c191730297562d6
-public_codegen_sha: 6356986f823c01fd602da9f64ef414c01db4619c
+public_codegen_sha: 2bc1edac041ed7a11d9affc837ad05dd26eeb29d

--- a/src/openai/resources/beta/threads/messages.py
+++ b/src/openai/resources/beta/threads/messages.py
@@ -15,10 +15,7 @@ from ...._compat import cached_property
 from ...._resource import SyncAPIResource, AsyncAPIResource
 from ...._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from ....pagination import SyncCursorPage, AsyncCursorPage
-from ...._base_client import (
-    AsyncPaginator,
-    make_request_options,
-)
+from ...._base_client import AsyncPaginator, make_request_options
 from ....types.beta.threads import message_list_params, message_create_params, message_update_params
 from ....types.beta.threads.message import Message
 from ....types.shared_params.metadata import Metadata

--- a/src/openai/resources/completions.py
+++ b/src/openai/resources/completions.py
@@ -15,9 +15,7 @@ from .._compat import cached_property
 from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from .._streaming import Stream, AsyncStream
-from .._base_client import (
-    make_request_options,
-)
+from .._base_client import make_request_options
 from ..types.completion import Completion
 from ..types.chat.chat_completion_stream_options_param import ChatCompletionStreamOptionsParam
 

--- a/src/openai/resources/fine_tuning/jobs/checkpoints.py
+++ b/src/openai/resources/fine_tuning/jobs/checkpoints.py
@@ -11,10 +11,7 @@ from ...._compat import cached_property
 from ...._resource import SyncAPIResource, AsyncAPIResource
 from ...._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from ....pagination import SyncCursorPage, AsyncCursorPage
-from ...._base_client import (
-    AsyncPaginator,
-    make_request_options,
-)
+from ...._base_client import AsyncPaginator, make_request_options
 from ....types.fine_tuning.jobs import checkpoint_list_params
 from ....types.fine_tuning.jobs.fine_tuning_job_checkpoint import FineTuningJobCheckpoint
 

--- a/src/openai/resources/fine_tuning/jobs/jobs.py
+++ b/src/openai/resources/fine_tuning/jobs/jobs.py
@@ -22,10 +22,7 @@ from .checkpoints import (
 from ...._resource import SyncAPIResource, AsyncAPIResource
 from ...._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from ....pagination import SyncCursorPage, AsyncCursorPage
-from ...._base_client import (
-    AsyncPaginator,
-    make_request_options,
-)
+from ...._base_client import AsyncPaginator, make_request_options
 from ....types.fine_tuning import job_list_params, job_create_params, job_list_events_params
 from ....types.shared_params.metadata import Metadata
 from ....types.fine_tuning.fine_tuning_job import FineTuningJob

--- a/src/openai/resources/models.py
+++ b/src/openai/resources/models.py
@@ -12,10 +12,7 @@ from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from ..pagination import SyncPage, AsyncPage
 from ..types.model import Model
-from .._base_client import (
-    AsyncPaginator,
-    make_request_options,
-)
+from .._base_client import AsyncPaginator, make_request_options
 from ..types.model_deleted import ModelDeleted
 
 __all__ = ["Models", "AsyncModels"]

--- a/src/openai/types/beta/threads/message_content.py
+++ b/src/openai/types/beta/threads/message_content.py
@@ -11,7 +11,6 @@ from .image_file_content_block import ImageFileContentBlock
 
 __all__ = ["MessageContent"]
 
-
 MessageContent: TypeAlias = Annotated[
     Union[ImageFileContentBlock, ImageURLContentBlock, TextContentBlock, RefusalContentBlock],
     PropertyInfo(discriminator="type"),


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Remove redundant import wrapping in five generated resources and one extra
blank line in `MessageContent`. All six files become byte-identical to the
verified Castiron output, with unchanged Python ASTs.

The verified local custom-code report drops from 52 to 46 mixed files. No
runtime behavior, public signatures, imports, exports, dependencies, API
schema, or compiler behavior changes.

## Additional context & links

The cleanup survives a fresh Castiron generation using the existing API and
configuration inputs. The old and new pure-generated content hashes match.
No Stainless fixture or generated-file ownership rule changes.

Validation:

- Pinned Ruff formatting and lint checks passed for all six files.
- `./scripts/format` preserved the cleanup; unrelated formatter-only changes
  to the existing report scripts were not included.
- `./scripts/lint` passed, including Pyright, mypy, and import checks.
- The affected Threads Messages, Completions, Fine-tuning Jobs/Checkpoints,
  and Models resource suites passed: 380 tests under Pydantic v2 and 380
  under Pydantic v1, using the local mock server.
- The custom-code reporter verified the generated baseline and removed
  exactly these six customizations.

No compiler companion is needed. This is a behavior-preserving SDK cleanup.
