### PR TITLE
chore(api): remove redundant generated test edits

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: 260c1f53-e64c-4d91-86a5-b85a85b57da0
+generation_id: d01088d9-a117-4981-9899-afab176a91ec
 openapi_spec_hash: a99ded1ea34cf528a9cd5f064167f26a
 openapi_transformed_spec_hash: e24c9d9339620c3cce8bbdd80e9ef8ed
 config_hash: 85382dd94c503b5d225adc7636a77c9f
-codegen_sha: 1a5da8d7cca1526c2c1fedc340b19b76dc234ab2
+codegen_sha: 160eee5e853d55c35205907a7b0bdd7151c74cec
 codegen_hash: 0e1cb892e3631438e55b55edd14899551f458be8d073e13d2c191730297562d6
-public_codegen_sha: 2bc1edac041ed7a11d9affc837ad05dd26eeb29d
+public_codegen_sha: 53459fc3cbb96f06dc69478d23b9703346a61c64

--- a/tests/api_resources/audio/test_speech.py
+++ b/tests/api_resources/audio/test_speech.py
@@ -26,7 +26,7 @@ class TestSpeech:
     def test_method_create(self, client: OpenAI, respx2_mock: MockRouter) -> None:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         speech = client.audio.speech.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
         )
@@ -38,7 +38,7 @@ class TestSpeech:
     def test_method_create_with_all_params(self, client: OpenAI, respx2_mock: MockRouter) -> None:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         speech = client.audio.speech.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
             instructions="instructions",
@@ -55,7 +55,7 @@ class TestSpeech:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
 
         response = client.audio.speech.with_raw_response.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
         )
@@ -70,7 +70,7 @@ class TestSpeech:
     def test_streaming_response_create(self, client: OpenAI, respx2_mock: MockRouter) -> None:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         with client.audio.speech.with_streaming_response.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
         ) as response:
@@ -93,7 +93,7 @@ class TestAsyncSpeech:
     async def test_method_create(self, async_client: AsyncOpenAI, respx2_mock: MockRouter) -> None:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         speech = await async_client.audio.speech.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
         )
@@ -105,7 +105,7 @@ class TestAsyncSpeech:
     async def test_method_create_with_all_params(self, async_client: AsyncOpenAI, respx2_mock: MockRouter) -> None:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         speech = await async_client.audio.speech.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
             instructions="instructions",
@@ -122,7 +122,7 @@ class TestAsyncSpeech:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
 
         response = await async_client.audio.speech.with_raw_response.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
         )
@@ -137,7 +137,7 @@ class TestAsyncSpeech:
     async def test_streaming_response_create(self, async_client: AsyncOpenAI, respx2_mock: MockRouter) -> None:
         respx2_mock.post("/audio/speech").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         async with async_client.audio.speech.with_streaming_response.create(
-            input="string",
+            input="input",
             model="tts-1",
             voice="alloy",
         ) as response:

--- a/tests/api_resources/test_batches.py
+++ b/tests/api_resources/test_batches.py
@@ -23,7 +23,7 @@ class TestBatches:
         batch = client.batches.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
         )
         assert_matches_type(Batch, batch, path=["response"])
 
@@ -32,7 +32,7 @@ class TestBatches:
         batch = client.batches.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
             metadata={"foo": "string"},
             output_expires_after={
                 "anchor": "created_at",
@@ -46,7 +46,7 @@ class TestBatches:
         response = client.batches.with_raw_response.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
         )
 
         assert response.is_closed is True
@@ -59,7 +59,7 @@ class TestBatches:
         with client.batches.with_streaming_response.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -72,14 +72,14 @@ class TestBatches:
     @parametrize
     def test_method_retrieve(self, client: OpenAI) -> None:
         batch = client.batches.retrieve(
-            "string",
+            "batch_id",
         )
         assert_matches_type(Batch, batch, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: OpenAI) -> None:
         response = client.batches.with_raw_response.retrieve(
-            "string",
+            "batch_id",
         )
 
         assert response.is_closed is True
@@ -90,7 +90,7 @@ class TestBatches:
     @parametrize
     def test_streaming_response_retrieve(self, client: OpenAI) -> None:
         with client.batches.with_streaming_response.retrieve(
-            "string",
+            "batch_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -115,7 +115,7 @@ class TestBatches:
     @parametrize
     def test_method_list_with_all_params(self, client: OpenAI) -> None:
         batch = client.batches.list(
-            after="string",
+            after="after",
             limit=0,
         )
         assert_matches_type(SyncCursorPage[Batch], batch, path=["response"])
@@ -143,14 +143,14 @@ class TestBatches:
     @parametrize
     def test_method_cancel(self, client: OpenAI) -> None:
         batch = client.batches.cancel(
-            "string",
+            "batch_id",
         )
         assert_matches_type(Batch, batch, path=["response"])
 
     @parametrize
     def test_raw_response_cancel(self, client: OpenAI) -> None:
         response = client.batches.with_raw_response.cancel(
-            "string",
+            "batch_id",
         )
 
         assert response.is_closed is True
@@ -161,7 +161,7 @@ class TestBatches:
     @parametrize
     def test_streaming_response_cancel(self, client: OpenAI) -> None:
         with client.batches.with_streaming_response.cancel(
-            "string",
+            "batch_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -189,7 +189,7 @@ class TestAsyncBatches:
         batch = await async_client.batches.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
         )
         assert_matches_type(Batch, batch, path=["response"])
 
@@ -198,7 +198,7 @@ class TestAsyncBatches:
         batch = await async_client.batches.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
             metadata={"foo": "string"},
             output_expires_after={
                 "anchor": "created_at",
@@ -212,7 +212,7 @@ class TestAsyncBatches:
         response = await async_client.batches.with_raw_response.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
         )
 
         assert response.is_closed is True
@@ -225,7 +225,7 @@ class TestAsyncBatches:
         async with async_client.batches.with_streaming_response.create(
             completion_window="24h",
             endpoint="/v1/responses",
-            input_file_id="string",
+            input_file_id="input_file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -238,14 +238,14 @@ class TestAsyncBatches:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncOpenAI) -> None:
         batch = await async_client.batches.retrieve(
-            "string",
+            "batch_id",
         )
         assert_matches_type(Batch, batch, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncOpenAI) -> None:
         response = await async_client.batches.with_raw_response.retrieve(
-            "string",
+            "batch_id",
         )
 
         assert response.is_closed is True
@@ -256,7 +256,7 @@ class TestAsyncBatches:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncOpenAI) -> None:
         async with async_client.batches.with_streaming_response.retrieve(
-            "string",
+            "batch_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -281,7 +281,7 @@ class TestAsyncBatches:
     @parametrize
     async def test_method_list_with_all_params(self, async_client: AsyncOpenAI) -> None:
         batch = await async_client.batches.list(
-            after="string",
+            after="after",
             limit=0,
         )
         assert_matches_type(AsyncCursorPage[Batch], batch, path=["response"])
@@ -309,14 +309,14 @@ class TestAsyncBatches:
     @parametrize
     async def test_method_cancel(self, async_client: AsyncOpenAI) -> None:
         batch = await async_client.batches.cancel(
-            "string",
+            "batch_id",
         )
         assert_matches_type(Batch, batch, path=["response"])
 
     @parametrize
     async def test_raw_response_cancel(self, async_client: AsyncOpenAI) -> None:
         response = await async_client.batches.with_raw_response.cancel(
-            "string",
+            "batch_id",
         )
 
         assert response.is_closed is True
@@ -327,7 +327,7 @@ class TestAsyncBatches:
     @parametrize
     async def test_streaming_response_cancel(self, async_client: AsyncOpenAI) -> None:
         async with async_client.batches.with_streaming_response.cancel(
-            "string",
+            "batch_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"

--- a/tests/api_resources/test_files.py
+++ b/tests/api_resources/test_files.py
@@ -72,14 +72,14 @@ class TestFiles:
     @parametrize
     def test_method_retrieve(self, client: OpenAI) -> None:
         file = client.files.retrieve(
-            "string",
+            "file_id",
         )
         assert_matches_type(FileObject, file, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: OpenAI) -> None:
         response = client.files.with_raw_response.retrieve(
-            "string",
+            "file_id",
         )
 
         assert response.is_closed is True
@@ -90,7 +90,7 @@ class TestFiles:
     @parametrize
     def test_streaming_response_retrieve(self, client: OpenAI) -> None:
         with client.files.with_streaming_response.retrieve(
-            "string",
+            "file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -145,14 +145,14 @@ class TestFiles:
     @parametrize
     def test_method_delete(self, client: OpenAI) -> None:
         file = client.files.delete(
-            "string",
+            "file_id",
         )
         assert_matches_type(FileDeleted, file, path=["response"])
 
     @parametrize
     def test_raw_response_delete(self, client: OpenAI) -> None:
         response = client.files.with_raw_response.delete(
-            "string",
+            "file_id",
         )
 
         assert response.is_closed is True
@@ -163,7 +163,7 @@ class TestFiles:
     @parametrize
     def test_streaming_response_delete(self, client: OpenAI) -> None:
         with client.files.with_streaming_response.delete(
-            "string",
+            "file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -183,9 +183,9 @@ class TestFiles:
     @parametrize
     @pytest.mark.respx2(base_url=base_url)
     def test_method_content(self, client: OpenAI, respx2_mock: MockRouter) -> None:
-        respx2_mock.get("/files/string/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
+        respx2_mock.get("/files/file_id/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         file = client.files.content(
-            "string",
+            "file_id",
         )
         assert isinstance(file, _legacy_response.HttpxBinaryResponseContent)
         assert file.json() == {"foo": "bar"}
@@ -193,10 +193,10 @@ class TestFiles:
     @parametrize
     @pytest.mark.respx2(base_url=base_url)
     def test_raw_response_content(self, client: OpenAI, respx2_mock: MockRouter) -> None:
-        respx2_mock.get("/files/string/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
+        respx2_mock.get("/files/file_id/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
 
         response = client.files.with_raw_response.content(
-            "string",
+            "file_id",
         )
 
         assert response.is_closed is True
@@ -207,9 +207,9 @@ class TestFiles:
     @parametrize
     @pytest.mark.respx2(base_url=base_url)
     def test_streaming_response_content(self, client: OpenAI, respx2_mock: MockRouter) -> None:
-        respx2_mock.get("/files/string/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
+        respx2_mock.get("/files/file_id/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         with client.files.with_streaming_response.content(
-            "string",
+            "file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -231,7 +231,7 @@ class TestFiles:
     def test_method_retrieve_content(self, client: OpenAI) -> None:
         with pytest.warns(DeprecationWarning):
             file = client.files.retrieve_content(
-                "string",
+                "file_id",
             )
 
         assert_matches_type(str, file, path=["response"])
@@ -240,7 +240,7 @@ class TestFiles:
     def test_raw_response_retrieve_content(self, client: OpenAI) -> None:
         with pytest.warns(DeprecationWarning):
             response = client.files.with_raw_response.retrieve_content(
-                "string",
+                "file_id",
             )
 
         assert response.is_closed is True
@@ -252,7 +252,7 @@ class TestFiles:
     def test_streaming_response_retrieve_content(self, client: OpenAI) -> None:
         with pytest.warns(DeprecationWarning):
             with client.files.with_streaming_response.retrieve_content(
-                "string",
+                "file_id",
             ) as response:
                 assert not response.is_closed
                 assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -325,14 +325,14 @@ class TestAsyncFiles:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncOpenAI) -> None:
         file = await async_client.files.retrieve(
-            "string",
+            "file_id",
         )
         assert_matches_type(FileObject, file, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncOpenAI) -> None:
         response = await async_client.files.with_raw_response.retrieve(
-            "string",
+            "file_id",
         )
 
         assert response.is_closed is True
@@ -343,7 +343,7 @@ class TestAsyncFiles:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncOpenAI) -> None:
         async with async_client.files.with_streaming_response.retrieve(
-            "string",
+            "file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -398,14 +398,14 @@ class TestAsyncFiles:
     @parametrize
     async def test_method_delete(self, async_client: AsyncOpenAI) -> None:
         file = await async_client.files.delete(
-            "string",
+            "file_id",
         )
         assert_matches_type(FileDeleted, file, path=["response"])
 
     @parametrize
     async def test_raw_response_delete(self, async_client: AsyncOpenAI) -> None:
         response = await async_client.files.with_raw_response.delete(
-            "string",
+            "file_id",
         )
 
         assert response.is_closed is True
@@ -416,7 +416,7 @@ class TestAsyncFiles:
     @parametrize
     async def test_streaming_response_delete(self, async_client: AsyncOpenAI) -> None:
         async with async_client.files.with_streaming_response.delete(
-            "string",
+            "file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -436,9 +436,9 @@ class TestAsyncFiles:
     @parametrize
     @pytest.mark.respx2(base_url=base_url)
     async def test_method_content(self, async_client: AsyncOpenAI, respx2_mock: MockRouter) -> None:
-        respx2_mock.get("/files/string/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
+        respx2_mock.get("/files/file_id/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         file = await async_client.files.content(
-            "string",
+            "file_id",
         )
         assert isinstance(file, _legacy_response.HttpxBinaryResponseContent)
         assert file.json() == {"foo": "bar"}
@@ -446,10 +446,10 @@ class TestAsyncFiles:
     @parametrize
     @pytest.mark.respx2(base_url=base_url)
     async def test_raw_response_content(self, async_client: AsyncOpenAI, respx2_mock: MockRouter) -> None:
-        respx2_mock.get("/files/string/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
+        respx2_mock.get("/files/file_id/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
 
         response = await async_client.files.with_raw_response.content(
-            "string",
+            "file_id",
         )
 
         assert response.is_closed is True
@@ -460,9 +460,9 @@ class TestAsyncFiles:
     @parametrize
     @pytest.mark.respx2(base_url=base_url)
     async def test_streaming_response_content(self, async_client: AsyncOpenAI, respx2_mock: MockRouter) -> None:
-        respx2_mock.get("/files/string/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
+        respx2_mock.get("/files/file_id/content").mock(return_value=httpx2.Response(200, json={"foo": "bar"}))
         async with async_client.files.with_streaming_response.content(
-            "string",
+            "file_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -484,7 +484,7 @@ class TestAsyncFiles:
     async def test_method_retrieve_content(self, async_client: AsyncOpenAI) -> None:
         with pytest.warns(DeprecationWarning):
             file = await async_client.files.retrieve_content(
-                "string",
+                "file_id",
             )
 
         assert_matches_type(str, file, path=["response"])
@@ -493,7 +493,7 @@ class TestAsyncFiles:
     async def test_raw_response_retrieve_content(self, async_client: AsyncOpenAI) -> None:
         with pytest.warns(DeprecationWarning):
             response = await async_client.files.with_raw_response.retrieve_content(
-                "string",
+                "file_id",
             )
 
         assert response.is_closed is True
@@ -505,7 +505,7 @@ class TestAsyncFiles:
     async def test_streaming_response_retrieve_content(self, async_client: AsyncOpenAI) -> None:
         with pytest.warns(DeprecationWarning):
             async with async_client.files.with_streaming_response.retrieve_content(
-                "string",
+                "file_id",
             ) as response:
                 assert not response.is_closed
                 assert response.http_request.headers.get("X-Stainless-Lang") == "python"

--- a/tests/api_resources/test_responses.py
+++ b/tests/api_resources/test_responses.py
@@ -9,7 +9,6 @@ import pytest
 
 from openai import OpenAI, AsyncOpenAI
 from tests.utils import assert_matches_type
-from openai._utils import assert_signatures_in_sync
 from openai.types.responses import (
     Response,
     CompactedResponse,
@@ -450,17 +449,6 @@ class TestResponses:
             assert_matches_type(CompactedResponse, response, path=["response"])
 
         assert cast(Any, http_response.is_closed) is True
-
-
-@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
-def test_parse_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
-    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
-
-    assert_signatures_in_sync(
-        checking_client.responses.create,
-        checking_client.responses.parse,
-        exclude_params={"stream", "tools"},
-    )
 
 
 class TestAsyncResponses:

--- a/tests/lib/responses/test_responses.py
+++ b/tests/lib/responses/test_responses.py
@@ -84,6 +84,17 @@ def test_stream_method_definition_in_sync(sync: bool, client: OpenAI, async_clie
 
 
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_parse_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
+
+    assert_signatures_in_sync(
+        checking_client.responses.create,
+        checking_client.responses.parse,
+        exclude_params={"stream", "tools"},
+    )
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 def test_parse_method_definition_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
     checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Restore the generated sample values in the Speech, Batches, and Files resource
tests, including the matching fake file-content URLs. Move the Responses
`parse` signature check unchanged from the generated test file into the
handwritten Responses tests.

Coverage is preserved in these exact tests:

- [tests/lib/responses/test_responses.py::test_parse_method_in_sync](https://github.com/openai/openai-python/blob/f1349ad105372d314f7e60ca407210073c1cb73d/tests/lib/responses/test_responses.py#L87) is the
  original test, moved verbatim. It compares `responses.create` with
  `responses.parse`, excludes `stream` and `tools`, and runs for both sync and
  async clients.
- [tests/lib/responses/test_responses.py::test_parse_method_definition_in_sync](https://github.com/openai/openai-python/blob/f1349ad105372d314f7e60ca407210073c1cb73d/tests/lib/responses/test_responses.py#L98)
  remains unchanged. It checks the same two methods while excluding only
  `tools`, so it also checks the `stream` parameter.

No SDK implementation, public API, or test coverage is removed.

All four generated resource-test files become byte-identical to the verified
generated output. This continues
[openai-python#3696](https://github.com/openai/openai-python/pull/3696);
no schema, configuration, compiler, dependency, fixture, or ownership-rule
changes are needed.

## Additional context & links

Validation:

- The custom-code report verifies 46 -> 42 mixed files: four removed
  customizations, with no new custom-code files or changes to the others.
- An AST comparison verifies exactly 60 expected fake-value substitutions,
  the verbatim move of the original signature test, and the unchanged stricter
  handwritten test.
- `./scripts/format` and `./scripts/lint` passed, including Ruff, Pyright, mypy,
  and import checks. Unrelated formatter-only changes to the existing report
  scripts are not included.
- The following suites passed under both Pydantic v2 and v1: 367 passed and
  7 skipped in each environment.

```sh
python -m pytest -q \
  tests/api_resources/audio/test_speech.py \
  tests/api_resources/test_batches.py \
  tests/api_resources/test_files.py \
  tests/api_resources/test_responses.py \
  tests/lib/responses/test_responses.py::test_parse_method_in_sync \
  tests/lib/responses/test_responses.py::test_parse_method_definition_in_sync
```

The cleanup survives a fresh Castiron generation using the existing API and
configuration inputs. The old and new pure-generated content hashes match.

From a checkout of the public PR, reproduce the report with:

```sh
python3 scripts/castiron/custom_code_report.py report \
  --base 5ac1e03e1ae8f08acf6213b3e44772734dbb8e59 \
  --head "$(git rev-parse HEAD)" --fetch --require-head-hash --public \
  --out /tmp/castiron-generated-test-cleanup
```
