### PR TITLE
chore(api): move chat validation tests out of generated code

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: 666f7a8a-a464-4003-94e8-c7b07ccb258a
+generation_id: d01088d9-a117-4981-9899-afab176a91ec
 openapi_spec_hash: a99ded1ea34cf528a9cd5f064167f26a
 openapi_transformed_spec_hash: e24c9d9339620c3cce8bbdd80e9ef8ed
 config_hash: 85382dd94c503b5d225adc7636a77c9f
-codegen_sha: 0f92db3a57f82fb46601bc2b994b0ef256c99387
+codegen_sha: 160eee5e853d55c35205907a7b0bdd7151c74cec
 codegen_hash: 0e1cb892e3631438e55b55edd14899551f458be8d073e13d2c191730297562d6
-public_codegen_sha: 5dae2ae2bcc44c210bb1b1c5239e55deb028bafa
+public_codegen_sha: 53459fc3cbb96f06dc69478d23b9703346a61c64

--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,8 +1,8 @@
 schema_version: 1
-generation_id: d01088d9-a117-4981-9899-afab176a91ec
+generation_id: 666f7a8a-a464-4003-94e8-c7b07ccb258a
 openapi_spec_hash: a99ded1ea34cf528a9cd5f064167f26a
 openapi_transformed_spec_hash: e24c9d9339620c3cce8bbdd80e9ef8ed
 config_hash: 85382dd94c503b5d225adc7636a77c9f
-codegen_sha: 160eee5e853d55c35205907a7b0bdd7151c74cec
+codegen_sha: 0f92db3a57f82fb46601bc2b994b0ef256c99387
 codegen_hash: 0e1cb892e3631438e55b55edd14899551f458be8d073e13d2c191730297562d6
-public_codegen_sha: 53459fc3cbb96f06dc69478d23b9703346a61c64
+public_codegen_sha: 5dae2ae2bcc44c210bb1b1c5239e55deb028bafa

--- a/tests/api_resources/chat/test_completions.py
+++ b/tests/api_resources/chat/test_completions.py
@@ -6,7 +6,6 @@ import os
 from typing import Any, cast
 
 import pytest
-import pydantic
 
 from openai import OpenAI, AsyncOpenAI
 from tests.utils import assert_matches_type
@@ -464,23 +463,6 @@ class TestCompletions:
                 "",
             )
 
-    @parametrize
-    def test_method_create_disallows_pydantic(self, client: OpenAI) -> None:
-        class MyModel(pydantic.BaseModel):
-            a: str
-
-        with pytest.raises(TypeError, match=r"You tried to pass a `BaseModel` class"):
-            client.chat.completions.create(
-                messages=[
-                    {
-                        "content": "string",
-                        "role": "system",
-                    }
-                ],
-                model="gpt-4o",
-                response_format=cast(Any, MyModel),
-            )
-
 
 class TestAsyncCompletions:
     parametrize = pytest.mark.parametrize(
@@ -927,21 +909,4 @@ class TestAsyncCompletions:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `completion_id` but received ''"):
             await async_client.chat.completions.with_raw_response.delete(
                 "",
-            )
-
-    @parametrize
-    async def test_method_create_disallows_pydantic(self, async_client: AsyncOpenAI) -> None:
-        class MyModel(pydantic.BaseModel):
-            a: str
-
-        with pytest.raises(TypeError, match=r"You tried to pass a `BaseModel` class"):
-            await async_client.chat.completions.create(
-                messages=[
-                    {
-                        "content": "string",
-                        "role": "system",
-                    }
-                ],
-                model="gpt-4o",
-                response_format=cast(Any, MyModel),
             )

--- a/tests/lib/chat/test_create_validation.py
+++ b/tests/lib/chat/test_create_validation.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+import pydantic
+
+from openai import OpenAI, AsyncOpenAI
+
+
+class TestCompletions:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @parametrize
+    def test_method_create_disallows_pydantic(self, client: OpenAI) -> None:
+        class MyModel(pydantic.BaseModel):
+            a: str
+
+        with pytest.raises(TypeError, match=r"You tried to pass a `BaseModel` class"):
+            client.chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "system",
+                    }
+                ],
+                model="gpt-4o",
+                response_format=cast(Any, MyModel),
+            )
+
+
+class TestAsyncCompletions:
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
+
+    @parametrize
+    async def test_method_create_disallows_pydantic(self, async_client: AsyncOpenAI) -> None:
+        class MyModel(pydantic.BaseModel):
+            a: str
+
+        with pytest.raises(TypeError, match=r"You tried to pass a `BaseModel` class"):
+            await async_client.chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "system",
+                    }
+                ],
+                model="gpt-4o",
+                response_format=cast(Any, MyModel),
+            )


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the handwritten `chat.completions.create()` validation tests out of the
generated resource-test file. The test methods and their client parameterization
are copied verbatim; the generated file returns to the verified Castiron output.

Coverage now lives in these exact tests:

- [`tests/lib/chat/test_create_validation.py::TestCompletions::test_method_create_disallows_pydantic`](https://github.com/openai/openai-python/blob/f883c09550b4a123094b57659fb6a5b008b54581/tests/lib/chat/test_create_validation.py#L15)
  covers loose and strict synchronous clients.
- [`tests/lib/chat/test_create_validation.py::TestAsyncCompletions::test_method_create_disallows_pydantic`](https://github.com/openai/openai-python/blob/f883c09550b4a123094b57659fb6a5b008b54581/tests/lib/chat/test_create_validation.py#L38)
  covers loose, strict, and aiohttp asynchronous clients.

All five cases still assert the existing `TypeError` and message when a
Pydantic `BaseModel` class is passed as `response_format` to `create()`. No test
coverage, SDK implementation, public API, exception behavior, or client mode is
removed.

## Additional context & links

Validation:

- The custom-code report verifies 42 -> 41 mixed files, one removed
  customization, and no changes to the other customizations.
- AST and source-text comparisons prove both methods and their parameterization
  moved verbatim. Pytest collection confirms the same five cases.
- `./scripts/format` and `./scripts/lint` passed, including Ruff, Pyright, mypy,
  and import checks. Unrelated formatter-only changes to the existing report
  scripts are not included.
- Command: `python -m pytest -q tests/api_resources/chat/test_completions.py tests/lib/chat/test_create_validation.py`
  passed 125 tests under Pydantic v2 and 125 under Pydantic v1.
- After rebasing onto the merged test cleanup in #3697, the exact-source check
  and full lint passed again. Command: `python -m pytest -q tests/lib/chat/test_create_validation.py`
  passed all five cases again in both Pydantic modes.

No schema, configuration, compiler, dependency, fixture, or generated-file
ownership changes are needed. The pure-generated content hash is unchanged.
The existing `.castiron.stats.yml` is preserved byte-for-byte so this test-only
PR does not overlap the separate release's generation metadata.
