### PR TITLE
refactor(api): share embedding response decoding

### DIFF
--- a/src/openai/lib/_parsing/_embeddings.py
+++ b/src/openai/lib/_parsing/_embeddings.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import array
+import base64
+from typing import cast
+
+from ..._types import Omit, NotGiven
+from ..._utils import is_given
+from ..._extras import numpy as np, has_numpy
+from ...types.create_embedding_response import CreateEmbeddingResponse
+
+
+def parse_embedding_response(
+    obj: CreateEmbeddingResponse, *, encoding_format: str | Omit | NotGiven
+) -> CreateEmbeddingResponse:
+    if is_given(encoding_format):
+        # don't modify the response object if a user explicitly asked for a format
+        return obj
+
+    if not obj.data:
+        raise ValueError("No embedding data received")
+
+    for embedding in obj.data:
+        data = cast(object, embedding.embedding)
+        if not isinstance(data, str):
+            continue
+        if not has_numpy():
+            # use array for base64 optimisation
+            embedding.embedding = array.array("f", base64.b64decode(data)).tolist()
+        else:
+            embedding.embedding = np.frombuffer(  # type: ignore[no-untyped-call]
+                base64.b64decode(data), dtype="float32"
+            ).tolist()
+
+    return obj

--- a/src/openai/resources/embeddings.py
+++ b/src/openai/resources/embeddings.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import array
-import base64
-from typing import Union, Iterable, cast
+from typing import Union, Iterable
+from functools import partial
 from typing_extensions import Literal
 
 import httpx2
@@ -14,11 +13,11 @@ from ..types import embedding_create_params
 from .._types import Body, Omit, Query, Headers, NotGiven, SequenceNotStr, omit, not_given
 from .._utils import is_given, maybe_transform
 from .._compat import cached_property
-from .._extras import numpy as np, has_numpy
 from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from .._base_client import make_request_options
 from ..types.embedding_model import EmbeddingModel
+from ..lib._parsing._embeddings import parse_embedding_response as _parse_embedding_response
 from ..types.create_embedding_response import CreateEmbeddingResponse
 
 __all__ = ["Embeddings", "AsyncEmbeddings"]
@@ -111,28 +110,6 @@ class Embeddings(SyncAPIResource):
         if not is_given(encoding_format):
             params["encoding_format"] = "base64"
 
-        def parser(obj: CreateEmbeddingResponse) -> CreateEmbeddingResponse:
-            if is_given(encoding_format):
-                # don't modify the response object if a user explicitly asked for a format
-                return obj
-
-            if not obj.data:
-                raise ValueError("No embedding data received")
-
-            for embedding in obj.data:
-                data = cast(object, embedding.embedding)
-                if not isinstance(data, str):
-                    continue
-                if not has_numpy():
-                    # use array for base64 optimisation
-                    embedding.embedding = array.array("f", base64.b64decode(data)).tolist()
-                else:
-                    embedding.embedding = np.frombuffer(  # type: ignore[no-untyped-call]
-                        base64.b64decode(data), dtype="float32"
-                    ).tolist()
-
-            return obj
-
         return self._post(
             "/embeddings",
             body=maybe_transform(params, embedding_create_params.EmbeddingCreateParams),
@@ -141,7 +118,7 @@ class Embeddings(SyncAPIResource):
                 extra_query=extra_query,
                 extra_body=extra_body,
                 timeout=timeout,
-                post_parser=parser,
+                post_parser=partial(_parse_embedding_response, encoding_format=encoding_format),
                 security={"bearer_auth": True},
             ),
             cast_to=CreateEmbeddingResponse,
@@ -235,28 +212,6 @@ class AsyncEmbeddings(AsyncAPIResource):
         if not is_given(encoding_format):
             params["encoding_format"] = "base64"
 
-        def parser(obj: CreateEmbeddingResponse) -> CreateEmbeddingResponse:
-            if is_given(encoding_format):
-                # don't modify the response object if a user explicitly asked for a format
-                return obj
-
-            if not obj.data:
-                raise ValueError("No embedding data received")
-
-            for embedding in obj.data:
-                data = cast(object, embedding.embedding)
-                if not isinstance(data, str):
-                    continue
-                if not has_numpy():
-                    # use array for base64 optimisation
-                    embedding.embedding = array.array("f", base64.b64decode(data)).tolist()
-                else:
-                    embedding.embedding = np.frombuffer(  # type: ignore[no-untyped-call]
-                        base64.b64decode(data), dtype="float32"
-                    ).tolist()
-
-            return obj
-
         return await self._post(
             "/embeddings",
             body=maybe_transform(params, embedding_create_params.EmbeddingCreateParams),
@@ -265,7 +220,7 @@ class AsyncEmbeddings(AsyncAPIResource):
                 extra_query=extra_query,
                 extra_body=extra_body,
                 timeout=timeout,
-                post_parser=parser,
+                post_parser=partial(_parse_embedding_response, encoding_format=encoding_format),
                 security={"bearer_auth": True},
             ),
             cast_to=CreateEmbeddingResponse,

--- a/tests/lib/test_embeddings.py
+++ b/tests/lib/test_embeddings.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import json
+import array
+import base64
+import binascii
+from typing import Any, cast
+from typing_extensions import Literal
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from tests.respx2 import MockRouter
+from openai._types import Omit, NotGiven, omit, not_given
+from openai._models import construct_type_unchecked
+from openai.lib._parsing import _embeddings as embeddings_parser
+from openai.types.create_embedding_response import CreateEmbeddingResponse
+
+VALUES = [0.125, -2.5, 3.75]
+ENCODED = base64.b64encode(array.array("f", VALUES).tobytes()).decode("ascii")
+EncodingFormat = Literal["float", "base64"] | Omit
+ResponseMode = Literal["normal", "raw", "streaming"]
+
+
+def response_body(*vectors: object) -> dict[str, object]:
+    return {
+        "data": [{"embedding": vector, "index": index, "object": "embedding"} for index, vector in enumerate(vectors)],
+        "model": "text-embedding-3-small",
+        "object": "list",
+        "usage": {"prompt_tokens": 1, "total_tokens": 1},
+    }
+
+
+def make_response(*vectors: object) -> CreateEmbeddingResponse:
+    return construct_type_unchecked(type_=CreateEmbeddingResponse, value=response_body(*vectors))
+
+
+@pytest.fixture(params=[False, True], ids=["stdlib", "numpy"])
+def decoder(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    use_numpy = cast(bool, request.param)
+    if use_numpy:
+        pytest.importorskip("numpy")
+    monkeypatch.setattr(embeddings_parser, "has_numpy", lambda: use_numpy)
+
+
+@pytest.mark.usefixtures("decoder")
+@pytest.mark.parametrize("encoding_format", [omit, not_given], ids=["omit", "not-given"])
+def test_decode_preserves_response_and_non_string_vectors(encoding_format: Omit | NotGiven) -> None:
+    response = make_response(ENCODED, [4.0, 5.0], ENCODED)
+    data = response.data
+    unchanged_vector = data[1].embedding
+    usage = response.usage
+
+    parsed = embeddings_parser.parse_embedding_response(response, encoding_format=encoding_format)
+
+    assert parsed is response
+    assert parsed.data is data
+    assert parsed.data[0].embedding == VALUES
+    assert parsed.data[1].embedding is unchanged_vector
+    assert parsed.data[2].embedding == VALUES
+    assert parsed.usage is usage
+    assert parsed.model == "text-embedding-3-small"
+
+
+@pytest.mark.parametrize("encoding_format", ["float", "base64", None])
+@pytest.mark.parametrize("vectors", [(ENCODED,), ("abc",), ()], ids=["encoded", "invalid", "empty"])
+def test_explicit_format_is_untouched(
+    encoding_format: object, vectors: tuple[object, ...], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def unexpected_decoder() -> bool:
+        raise AssertionError("an explicit format must not inspect the decoder")
+
+    monkeypatch.setattr(embeddings_parser, "has_numpy", unexpected_decoder)
+    response = make_response(*vectors)
+    data = response.data
+    original = [cast(object, item.embedding) for item in data]
+
+    assert embeddings_parser.parse_embedding_response(response, encoding_format=cast(Any, encoding_format)) is response
+    assert response.data is data
+    assert [cast(object, item.embedding) for item in data] == original
+
+
+@pytest.mark.parametrize("encoding_format", [omit, not_given], ids=["omit", "not-given"])
+@pytest.mark.parametrize("data", [[], None], ids=["empty", "null"])
+def test_missing_data_keeps_existing_error(encoding_format: Omit | NotGiven, data: object) -> None:
+    body = response_body()
+    body["data"] = data
+    response = construct_type_unchecked(type_=CreateEmbeddingResponse, value=body)
+
+    with pytest.raises(ValueError, match=r"^No embedding data received$"):
+        embeddings_parser.parse_embedding_response(response, encoding_format=encoding_format)
+
+
+@pytest.mark.usefixtures("decoder")
+@pytest.mark.parametrize(
+    "encoded,error",
+    [("abc", binascii.Error), (base64.b64encode(b"abc").decode("ascii"), ValueError)],
+    ids=["invalid-base64", "invalid-float-buffer"],
+)
+def test_invalid_data_preserves_decoder_errors(encoded: str, error: type[Exception]) -> None:
+    response = make_response(encoded)
+
+    with pytest.raises(error):
+        embeddings_parser.parse_embedding_response(response, encoding_format=omit)
+
+
+def assert_request_and_response(
+    request: httpx2.Request, response: CreateEmbeddingResponse, encoding_format: EncodingFormat
+) -> None:
+    expected_format = encoding_format if isinstance(encoding_format, str) else "base64"
+    body = json.loads(request.content)
+    assert body == {
+        "input": "test input",
+        "model": "text-embedding-3-small",
+        "user": "fake-user",
+        "dimensions": 3,
+        "encoding_format": expected_format,
+    }
+    expected_vector = ENCODED if encoding_format == "base64" else VALUES
+    assert cast(object, response.data[0].embedding) == expected_vector
+
+
+@pytest.mark.respx2()
+@pytest.mark.usefixtures("decoder")
+@pytest.mark.parametrize("client", [False], indirect=True)
+@pytest.mark.parametrize("encoding_format", [omit, "float", "base64"], ids=["default", "float", "base64"])
+@pytest.mark.parametrize("mode", ["normal", "raw", "streaming"])
+def test_sync_create_uses_decoder(
+    client: OpenAI, respx2_mock: MockRouter, encoding_format: EncodingFormat, mode: ResponseMode
+) -> None:
+    vector = VALUES if encoding_format == "float" else ENCODED
+    route = respx2_mock.post(f"{str(client.base_url).rstrip('/')}/embeddings").mock(
+        return_value=httpx2.Response(200, json=response_body(vector))
+    )
+    kwargs: dict[str, Any] = {
+        "input": "test input",
+        "model": "text-embedding-3-small",
+        "user": "fake-user",
+        "dimensions": 3,
+        "encoding_format": encoding_format,
+    }
+
+    if mode == "normal":
+        response = client.embeddings.create(**kwargs)
+    elif mode == "raw":
+        response = client.embeddings.with_raw_response.create(**kwargs).parse()
+    else:
+        with client.embeddings.with_streaming_response.create(**kwargs) as raw_response:
+            response = raw_response.parse()
+
+    assert route.call_count == 1
+    assert_request_and_response(route.calls.last.request, response, encoding_format)
+
+
+@pytest.mark.respx2()
+@pytest.mark.usefixtures("decoder")
+@pytest.mark.parametrize("async_client", [False], indirect=True)
+@pytest.mark.parametrize("encoding_format", [omit, "float", "base64"], ids=["default", "float", "base64"])
+@pytest.mark.parametrize("mode", ["normal", "raw", "streaming"])
+async def test_async_create_uses_decoder(
+    async_client: AsyncOpenAI, respx2_mock: MockRouter, encoding_format: EncodingFormat, mode: ResponseMode
+) -> None:
+    vector = VALUES if encoding_format == "float" else ENCODED
+    route = respx2_mock.post(f"{str(async_client.base_url).rstrip('/')}/embeddings").mock(
+        return_value=httpx2.Response(200, json=response_body(vector))
+    )
+    kwargs: dict[str, Any] = {
+        "input": "test input",
+        "model": "text-embedding-3-small",
+        "user": "fake-user",
+        "dimensions": 3,
+        "encoding_format": encoding_format,
+    }
+
+    if mode == "normal":
+        response = await async_client.embeddings.create(**kwargs)
+    elif mode == "raw":
+        response = (await async_client.embeddings.with_raw_response.create(**kwargs)).parse()
+    else:
+        async with async_client.embeddings.with_streaming_response.create(**kwargs) as raw_response:
+            response = await raw_response.parse()
+
+    assert route.call_count == 1
+    assert_request_and_response(route.calls.last.request, response, encoding_format)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the duplicated embeddings response decoder into the SDK-owned
`lib/_parsing/_embeddings.py` module. Both resource methods use the existing
`post_parser` hook. The decoder logic is unchanged: omitted encoding requests
base64 and decodes it in place; explicit formats pass through; empty data keeps
the existing `ValueError`; NumPy and stdlib decoding keep their existing errors.

Public signatures, exports, request fields and order, sync/async behavior, and
raw/streaming response wrappers are unchanged. No compiler, schema, dependency,
or generation-metadata changes are included.

## Additional context & links

New handwritten coverage is in `tests/lib/test_embeddings.py`:

- `test_decode_preserves_response_and_non_string_vectors` checks in-place
  decoding, both omitted-value sentinels, and untouched non-string vectors.
- `test_explicit_format_is_untouched`,
  `test_missing_data_keeps_existing_error`, and
  `test_invalid_data_preserves_decoder_errors` cover passthrough and failures.
- `test_sync_create_uses_decoder` and `test_async_create_uses_decoder` cover
  normal, raw, and streaming responses with both decoder implementations.

Validation:

- Command: `python -m pytest -q -n 4 tests/api_resources/test_embeddings.py tests/lib/test_embeddings.py`
  passed 77 tests under Pydantic v2 and 77 under Pydantic v1.
- `./scripts/format` and `./scripts/lint` passed, including Ruff, Pyright, mypy,
  and import checks. Unrelated formatter-only reporter edits are excluded.
- `./scripts/build` passed; the wheel and source distribution both contain the
  new private helper.
- The public custom-code report verifies 41 mixed files, only the embeddings
  customization changed, and 40 other customizations unchanged. The embeddings
  patch shrinks from +73/-22 to +27/-21. `.castiron.stats.yml` is unchanged.

Command to reproduce the report from this branch:

```sh
$ python3 scripts/castiron/custom_code_report.py report \
    --base 8edd9ae411f9d0a5385447a4697c9f7042868213 \
    --head 38cf9c9ccb2c4e007ada4672424733845e0c29e9 \
    --fetch --require-head-hash --public \
    --out /tmp/castiron-embedding-decoder
```
