### PR TITLE
refactor(api): isolate audio response format selection

### DIFF
--- a/src/openai/lib/_parsing/_audio.py
+++ b/src/openai/lib/_parsing/_audio.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from typing_extensions import assert_never
+
+from ..._types import Omit
+from ...types.audio.translation import Translation
+from ...types.audio.transcription import Transcription
+from ...types.audio_response_format import AudioResponseFormat
+from ...types.audio.translation_verbose import TranslationVerbose
+from ...types.audio.transcription_verbose import TranscriptionVerbose
+from ...types.audio.transcription_diarized import TranscriptionDiarized
+
+
+def get_transcription_response_format_type(
+    response_format: AudioResponseFormat | Omit,
+    *,
+    log: logging.Logger,
+) -> type[Transcription | TranscriptionVerbose | TranscriptionDiarized | str]:
+    if isinstance(response_format, Omit) or response_format is None:  # pyright: ignore[reportUnnecessaryComparison]
+        return Transcription
+
+    if response_format == "json":
+        return Transcription
+    elif response_format == "verbose_json":
+        return TranscriptionVerbose
+    elif response_format == "diarized_json":
+        return TranscriptionDiarized
+    elif response_format == "srt" or response_format == "text" or response_format == "vtt":
+        return str
+    elif TYPE_CHECKING:  # type: ignore[unreachable]
+        assert_never(response_format)
+    else:
+        log.warn("Unexpected audio response format: %s", response_format)
+        return Transcription
+
+
+def get_translation_response_format_type(
+    response_format: AudioResponseFormat | Omit,
+    *,
+    log: logging.Logger,
+) -> type[Translation | TranslationVerbose | str]:
+    if isinstance(response_format, Omit) or response_format is None:  # pyright: ignore[reportUnnecessaryComparison]
+        return Translation
+
+    if response_format == "json":
+        return Translation
+    elif response_format == "verbose_json":
+        return TranslationVerbose
+    elif response_format == "srt" or response_format == "text" or response_format == "vtt":
+        return str
+    elif TYPE_CHECKING and response_format != "diarized_json":  # type: ignore[unreachable]
+        assert_never(response_format)
+    else:
+        log.warning("Unexpected audio response format: %s", response_format)
+        return Translation

--- a/src/openai/resources/audio/transcriptions.py
+++ b/src/openai/resources/audio/transcriptions.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List, Union, Mapping, Optional, cast
-from typing_extensions import Literal, overload, assert_never
+from typing import List, Union, Mapping, Optional, cast
+from typing_extensions import Literal, overload
 
 import httpx2
 
@@ -29,6 +29,7 @@ from ..._streaming import Stream, AsyncStream
 from ...types.audio import transcription_create_params
 from ..._base_client import make_request_options
 from ...types.audio_model import AudioModel
+from ...lib._parsing._audio import get_transcription_response_format_type as _get_transcription_response_format_type
 from ...types.audio.transcription import Transcription
 from ...types.audio_response_format import AudioResponseFormat
 from ...types.audio.transcription_include import TranscriptionInclude
@@ -1078,19 +1079,4 @@ class AsyncTranscriptionsWithStreamingResponse:
 def _get_response_format_type(
     response_format: AudioResponseFormat | Omit,
 ) -> type[Transcription | TranscriptionVerbose | TranscriptionDiarized | str]:
-    if isinstance(response_format, Omit) or response_format is None:  # pyright: ignore[reportUnnecessaryComparison]
-        return Transcription
-
-    if response_format == "json":
-        return Transcription
-    elif response_format == "verbose_json":
-        return TranscriptionVerbose
-    elif response_format == "diarized_json":
-        return TranscriptionDiarized
-    elif response_format == "srt" or response_format == "text" or response_format == "vtt":
-        return str
-    elif TYPE_CHECKING:  # type: ignore[unreachable]
-        assert_never(response_format)
-    else:
-        log.warn("Unexpected audio response format: %s", response_format)
-        return Transcription
+    return _get_transcription_response_format_type(response_format, log=log)

--- a/src/openai/resources/audio/translations.py
+++ b/src/openai/resources/audio/translations.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Union, Mapping, cast
-from typing_extensions import Literal, overload, assert_never
+from typing import Union, Mapping, cast
+from typing_extensions import Literal, overload
 
 import httpx2
 
@@ -18,6 +18,7 @@ from ..._response import to_streamed_response_wrapper, async_to_streamed_respons
 from ...types.audio import translation_create_params
 from ..._base_client import make_request_options
 from ...types.audio_model import AudioModel
+from ...lib._parsing._audio import get_translation_response_format_type as _get_translation_response_format_type
 from ...types.audio.translation import Translation
 from ...types.audio_response_format import AudioResponseFormat
 from ...types.audio.translation_verbose import TranslationVerbose
@@ -370,17 +371,4 @@ class AsyncTranslationsWithStreamingResponse:
 def _get_response_format_type(
     response_format: AudioResponseFormat | Omit,
 ) -> type[Translation | TranslationVerbose | str]:
-    if isinstance(response_format, Omit) or response_format is None:  # pyright: ignore[reportUnnecessaryComparison]
-        return Translation
-
-    if response_format == "json":
-        return Translation
-    elif response_format == "verbose_json":
-        return TranslationVerbose
-    elif response_format == "srt" or response_format == "text" or response_format == "vtt":
-        return str
-    elif TYPE_CHECKING and response_format != "diarized_json":  # type: ignore[unreachable]
-        assert_never(response_format)
-    else:
-        log.warning("Unexpected audio response format: %s", response_format)
-        return Translation
+    return _get_translation_response_format_type(response_format, log=log)

--- a/tests/lib/test_audio_response_format.py
+++ b/tests/lib/test_audio_response_format.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+from unittest.mock import Mock
+from typing_extensions import Literal
+
+import httpx2
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from tests.respx2 import MockRouter
+from openai._types import Omit, omit, not_given
+from openai.types.audio import (
+    Translation,
+    Transcription,
+    TranslationVerbose,
+    TranscriptionVerbose,
+    TranscriptionDiarized,
+    TranscriptionTextDeltaEvent,
+)
+from openai.resources.audio import translations, transcriptions
+from openai.types.audio_response_format import AudioResponseFormat
+
+AudioResource = Literal["transcriptions", "translations"]
+ResponseMode = Literal["normal", "raw", "streaming"]
+FORMAT_CASES = [
+    pytest.param("transcriptions", omit, Transcription, id="transcription-default"),
+    pytest.param("transcriptions", "json", Transcription, id="transcription-json"),
+    pytest.param("transcriptions", "verbose_json", TranscriptionVerbose, id="transcription-verbose"),
+    pytest.param("transcriptions", "diarized_json", TranscriptionDiarized, id="transcription-diarized"),
+    pytest.param("transcriptions", "text", str, id="transcription-text"),
+    pytest.param("transcriptions", "srt", str, id="transcription-srt"),
+    pytest.param("transcriptions", "vtt", str, id="transcription-vtt"),
+    pytest.param("translations", omit, Translation, id="translation-default"),
+    pytest.param("translations", "json", Translation, id="translation-json"),
+    pytest.param("translations", "verbose_json", TranslationVerbose, id="translation-verbose"),
+    pytest.param("translations", "text", str, id="translation-text"),
+    pytest.param("translations", "srt", str, id="translation-srt"),
+    pytest.param("translations", "vtt", str, id="translation-vtt"),
+]
+
+
+def select_response_type(resource: AudioResource, response_format: object) -> type[object]:
+    if resource == "transcriptions":
+        return transcriptions._get_response_format_type(cast(Any, response_format))
+    return translations._get_response_format_type(cast(Any, response_format))
+
+
+@pytest.mark.parametrize("resource,response_format,expected_type", FORMAT_CASES)
+def test_supported_formats_keep_exact_response_classes(
+    resource: AudioResource, response_format: AudioResponseFormat | Omit, expected_type: type[object]
+) -> None:
+    assert select_response_type(resource, response_format) is expected_type
+
+
+@pytest.mark.parametrize(
+    "resource,expected_type",
+    [("transcriptions", Transcription), ("translations", Translation)],
+)
+@pytest.mark.parametrize("response_format", [None, Omit()], ids=["none", "new-omit"])
+def test_default_compatibility_values(
+    resource: AudioResource, response_format: object, expected_type: type[object]
+) -> None:
+    assert select_response_type(resource, response_format) is expected_type
+
+
+@pytest.mark.parametrize(
+    "resource,response_format,expected_type",
+    [
+        ("transcriptions", "future-format", Transcription),
+        ("transcriptions", not_given, Transcription),
+        ("translations", "future-format", Translation),
+        ("translations", not_given, Translation),
+        ("translations", "diarized_json", Translation),
+    ],
+)
+def test_fallback_keeps_resource_logger_and_method(
+    resource: AudioResource, response_format: object, expected_type: type[object], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    logger = Mock(spec=logging.Logger)
+    module = transcriptions if resource == "transcriptions" else translations
+    monkeypatch.setattr(module, "log", logger)
+
+    assert select_response_type(resource, response_format) is expected_type
+
+    if resource == "transcriptions":
+        logger.warn.assert_called_once_with("Unexpected audio response format: %s", response_format)
+        logger.warning.assert_not_called()
+    else:
+        logger.warning.assert_called_once_with("Unexpected audio response format: %s", response_format)
+        logger.warn.assert_not_called()
+
+
+def test_fallback_keeps_historical_logger_name_and_warning(caplog: pytest.LogCaptureFixture) -> None:
+    logger = logging.getLogger("openai.audio.transcriptions")
+    assert transcriptions.log is logger
+    assert translations.log is logger
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        assert select_response_type("transcriptions", "future-format") is Transcription
+    assert select_response_type("translations", "future-format") is Translation
+
+    records = [record for record in caplog.records if record.name == logger.name]
+    assert [(record.levelno, record.getMessage()) for record in records] == [
+        (logging.WARNING, "Unexpected audio response format: future-format"),
+        (logging.WARNING, "Unexpected audio response format: future-format"),
+    ]
+
+
+def make_response(expected_type: type[object]) -> httpx2.Response:
+    if expected_type is str:
+        return httpx2.Response(200, text="test transcript")
+    return httpx2.Response(
+        200,
+        json={
+            "text": "test transcript",
+            "duration": 1.0,
+            "language": "english",
+            "segments": [],
+            "task": "transcribe",
+        },
+    )
+
+
+def assert_request_and_response(
+    request: httpx2.Request,
+    response: object,
+    response_format: AudioResponseFormat | Omit,
+    expected_type: type[object],
+) -> None:
+    assert type(response) is expected_type
+    assert request.headers["content-type"].startswith("multipart/form-data; boundary=")
+    if isinstance(response_format, Omit):
+        assert b'name="response_format"' not in request.content
+    else:
+        assert f'name="response_format"\r\n\r\n{response_format}\r\n'.encode() in request.content
+
+
+@pytest.mark.respx2()
+@pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+@pytest.mark.parametrize("resource,response_format,expected_type", FORMAT_CASES)
+@pytest.mark.parametrize("mode", ["normal", "raw", "streaming"])
+def test_sync_create_uses_selected_response_class(
+    client: OpenAI,
+    respx2_mock: MockRouter,
+    resource: AudioResource,
+    response_format: AudioResponseFormat | Omit,
+    expected_type: type[object],
+    mode: ResponseMode,
+) -> None:
+    route = respx2_mock.post(f"{str(client.base_url).rstrip('/')}/audio/{resource}").mock(
+        return_value=make_response(expected_type)
+    )
+    audio = cast(Any, client.audio.transcriptions if resource == "transcriptions" else client.audio.translations)
+    kwargs: dict[str, Any] = {"file": b"fake audio", "model": "whisper-1", "response_format": response_format}
+
+    if mode == "normal":
+        response = audio.create(**kwargs)
+    elif mode == "raw":
+        response = audio.with_raw_response.create(**kwargs).parse()
+    else:
+        with audio.with_streaming_response.create(**kwargs) as raw_response:
+            response = raw_response.parse()
+
+    assert route.call_count == 1
+    assert_request_and_response(route.calls.last.request, response, response_format, expected_type)
+
+
+@pytest.mark.respx2()
+@pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+@pytest.mark.parametrize("resource,response_format,expected_type", FORMAT_CASES)
+@pytest.mark.parametrize("mode", ["normal", "raw", "streaming"])
+async def test_async_create_uses_selected_response_class(
+    async_client: AsyncOpenAI,
+    respx2_mock: MockRouter,
+    resource: AudioResource,
+    response_format: AudioResponseFormat | Omit,
+    expected_type: type[object],
+    mode: ResponseMode,
+) -> None:
+    route = respx2_mock.post(f"{str(async_client.base_url).rstrip('/')}/audio/{resource}").mock(
+        return_value=make_response(expected_type)
+    )
+    audio = cast(
+        Any, async_client.audio.transcriptions if resource == "transcriptions" else async_client.audio.translations
+    )
+    kwargs: dict[str, Any] = {"file": b"fake audio", "model": "whisper-1", "response_format": response_format}
+
+    if mode == "normal":
+        response = await audio.create(**kwargs)
+    elif mode == "raw":
+        response = (await audio.with_raw_response.create(**kwargs)).parse()
+    else:
+        async with audio.with_streaming_response.create(**kwargs) as raw_response:
+            response = await raw_response.parse()
+
+    assert route.call_count == 1
+    assert_request_and_response(route.calls.last.request, response, response_format, expected_type)
+
+
+STREAM_BODY = 'event: transcript.text.delta\ndata: {"type":"transcript.text.delta","delta":"hello"}\n\ndata: [DONE]\n\n'
+
+
+@pytest.mark.respx2()
+def test_sync_transcription_stream_still_yields_events(client: OpenAI, respx2_mock: MockRouter) -> None:
+    respx2_mock.post(f"{str(client.base_url).rstrip('/')}/audio/transcriptions").mock(
+        return_value=httpx2.Response(200, content=STREAM_BODY, headers={"content-type": "text/event-stream"})
+    )
+
+    with client.audio.transcriptions.create(
+        file=b"fake audio", model="gpt-4o-transcribe", response_format="json", stream=True
+    ) as stream:
+        events = list(stream)
+
+    assert len(events) == 1
+    assert isinstance(events[0], TranscriptionTextDeltaEvent)
+    assert events[0].delta == "hello"
+
+
+@pytest.mark.respx2()
+async def test_async_transcription_stream_still_yields_events(
+    async_client: AsyncOpenAI, respx2_mock: MockRouter
+) -> None:
+    respx2_mock.post(f"{str(async_client.base_url).rstrip('/')}/audio/transcriptions").mock(
+        return_value=httpx2.Response(200, content=STREAM_BODY, headers={"content-type": "text/event-stream"})
+    )
+
+    async with await async_client.audio.transcriptions.create(
+        file=b"fake audio", model="gpt-4o-transcribe", response_format="json", stream=True
+    ) as stream:
+        events = [event async for event in stream]
+
+    assert len(events) == 1
+    assert isinstance(events[0], TranscriptionTextDeltaEvent)
+    assert events[0].delta == "hello"


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the transcription and translation response-format selectors into the
SDK-owned `lib/_parsing/_audio.py` module. Keep the existing private resource
functions as thin wrappers, including their signatures and module loggers.
The selection branches are unchanged, including `None`/omitted handling,
diarized transcription, text formats, and the existing fallback warnings.

Every resource class is unchanged: public overloads, return annotations,
request fields and order, decorators, and sync/async response wrappers stay
intact. No compiler, schema, dependency, or generation-metadata changes are
included.

## Additional context & links

New handwritten coverage is in `tests/lib/test_audio_response_format.py`:

- `test_supported_formats_keep_exact_response_classes` and
  `test_default_compatibility_values` check the exact response classes.
- `test_fallback_keeps_resource_logger_and_method` and
  `test_fallback_keeps_historical_logger_name_and_warning` preserve the
  fallback class, logger, warning text, and existing `warn`/`warning` behavior.
- `test_sync_create_uses_selected_response_class` and
  `test_async_create_uses_selected_response_class` cover every supported format
  through normal, raw, and streaming responses in strict and loose modes.
- `test_sync_transcription_stream_still_yields_events` and
  `test_async_transcription_stream_still_yields_events` retain event-stream
  behavior. The existing overload checks remain in
  `tests/lib/test_audio.py::test_translation_create_overloads_in_sync` and
  `tests/lib/test_audio.py::test_transcription_create_overloads_in_sync`.

Validation:

- Command: `python -m pytest -n 0 tests/lib/test_audio_response_format.py tests/lib/test_audio.py tests/api_resources/audio/test_transcriptions.py tests/api_resources/audio/test_translations.py`
  passed 245 tests under Pydantic v2 and 245 under Pydantic v1.
- `./scripts/format` and `./scripts/lint` passed, including Ruff, Pyright,
  mypy, and import checks. Unrelated formatter-only reporter edits are excluded.
- `./scripts/build` passed; the wheel and source distribution both contain
  the new private helper.
- The public custom-code report verifies 41 mixed files, with only the two
  audio customizations changed and 39 others unchanged. Transcriptions shrink
  from +160/-53 to +145/-52; translations shrink from +155/-39 to +143/-39.
  `.castiron.stats.yml` is unchanged.

Command to reproduce the report from this branch:

```sh
$ python3 scripts/castiron/custom_code_report.py report \
    --base 8edd9ae411f9d0a5385447a4697c9f7042868213 \
    --head 676b9e7300e5743b6177e7188df0d6d63c3d977c \
    --fetch --require-head-hash --public \
    --out /tmp/castiron-audio-format-selection
```
