### PR TITLE
refactor(api): share webhook signature verification

### DIFF
--- a/src/openai/lib/_webhooks.py
+++ b/src/openai/lib/_webhooks.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import hmac
+import time
+import base64
+import hashlib
+
+from .._types import HeadersLike
+from .._utils import get_required_header
+from .._exceptions import InvalidWebhookSignatureError
+
+
+def webhook_signature_matches(
+    payload: str | bytes,
+    headers: HeadersLike,
+    *,
+    secret: str,
+    tolerance: int,
+) -> bool:
+    """Validate the replay window and compare the supplied signatures."""
+    signature_header = get_required_header(headers, "webhook-signature")
+    timestamp = get_required_header(headers, "webhook-timestamp")
+    webhook_id = get_required_header(headers, "webhook-id")
+
+    # Validate timestamp to prevent replay attacks
+    try:
+        timestamp_seconds = int(timestamp)
+    except ValueError:
+        raise InvalidWebhookSignatureError("Invalid webhook timestamp format") from None
+
+    now = int(time.time())
+
+    if now - timestamp_seconds > tolerance:
+        raise InvalidWebhookSignatureError("Webhook timestamp is too old") from None
+
+    if timestamp_seconds > now + tolerance:
+        raise InvalidWebhookSignatureError("Webhook timestamp is too new") from None
+
+    # Extract signatures from v1,<base64> format
+    # The signature header can have multiple values, separated by spaces.
+    # Each value is in the format v1,<base64>. We should accept if any match.
+    signatures: list[str] = []
+    for part in signature_header.split():
+        if part.startswith("v1,"):
+            signatures.append(part[3:])
+        else:
+            signatures.append(part)
+
+    # Decode the secret if it starts with whsec_
+    if secret.startswith("whsec_"):
+        decoded_secret = base64.b64decode(secret[6:])
+    else:
+        decoded_secret = secret.encode()
+
+    body = payload.decode("utf-8") if isinstance(payload, bytes) else payload
+
+    # Prepare the signed payload (OpenAI uses webhookId.timestamp.payload format)
+    signed_payload = f"{webhook_id}.{timestamp}.{body}"
+    expected_signature = base64.b64encode(
+        hmac.new(decoded_secret, signed_payload.encode(), hashlib.sha256).digest()
+    ).decode()
+
+    # Accept if any signature matches
+    return any(hmac.compare_digest(expected_signature, sig) for sig in signatures)

--- a/src/openai/resources/webhooks/webhooks.py
+++ b/src/openai/resources/webhooks/webhooks.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-import hmac
 import json
-import time
-import base64
-import hashlib
 from typing import cast
 
 from ..._types import HeadersLike
-from ..._utils import get_required_header
 from ..._models import construct_type
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._exceptions import InvalidWebhookSignatureError
+from ...lib._webhooks import webhook_signature_matches as _webhook_signature_matches
 from ...types.webhooks.unwrap_webhook_event import UnwrapWebhookEvent
 
 __all__ = ["Webhooks", "AsyncWebhooks"]
@@ -66,50 +62,7 @@ class Webhooks(SyncAPIResource):
                 "on the client class, OpenAI(webhook_secret='123'), or passed to this function"
             )
 
-        signature_header = get_required_header(headers, "webhook-signature")
-        timestamp = get_required_header(headers, "webhook-timestamp")
-        webhook_id = get_required_header(headers, "webhook-id")
-
-        # Validate timestamp to prevent replay attacks
-        try:
-            timestamp_seconds = int(timestamp)
-        except ValueError:
-            raise InvalidWebhookSignatureError("Invalid webhook timestamp format") from None
-
-        now = int(time.time())
-
-        if now - timestamp_seconds > tolerance:
-            raise InvalidWebhookSignatureError("Webhook timestamp is too old") from None
-
-        if timestamp_seconds > now + tolerance:
-            raise InvalidWebhookSignatureError("Webhook timestamp is too new") from None
-
-        # Extract signatures from v1,<base64> format
-        # The signature header can have multiple values, separated by spaces.
-        # Each value is in the format v1,<base64>. We should accept if any match.
-        signatures: list[str] = []
-        for part in signature_header.split():
-            if part.startswith("v1,"):
-                signatures.append(part[3:])
-            else:
-                signatures.append(part)
-
-        # Decode the secret if it starts with whsec_
-        if secret.startswith("whsec_"):
-            decoded_secret = base64.b64decode(secret[6:])
-        else:
-            decoded_secret = secret.encode()
-
-        body = payload.decode("utf-8") if isinstance(payload, bytes) else payload
-
-        # Prepare the signed payload (OpenAI uses webhookId.timestamp.payload format)
-        signed_payload = f"{webhook_id}.{timestamp}.{body}"
-        expected_signature = base64.b64encode(
-            hmac.new(decoded_secret, signed_payload.encode(), hashlib.sha256).digest()
-        ).decode()
-
-        # Accept if any signature matches
-        if not any(hmac.compare_digest(expected_signature, sig) for sig in signatures):
+        if not _webhook_signature_matches(payload, headers, secret=secret, tolerance=tolerance):
             raise InvalidWebhookSignatureError(
                 "The given webhook signature does not match the expected signature"
             ) from None
@@ -163,48 +116,5 @@ class AsyncWebhooks(AsyncAPIResource):
                 "on the client class, OpenAI(webhook_secret='123'), or passed to this function"
             ) from None
 
-        signature_header = get_required_header(headers, "webhook-signature")
-        timestamp = get_required_header(headers, "webhook-timestamp")
-        webhook_id = get_required_header(headers, "webhook-id")
-
-        # Validate timestamp to prevent replay attacks
-        try:
-            timestamp_seconds = int(timestamp)
-        except ValueError:
-            raise InvalidWebhookSignatureError("Invalid webhook timestamp format") from None
-
-        now = int(time.time())
-
-        if now - timestamp_seconds > tolerance:
-            raise InvalidWebhookSignatureError("Webhook timestamp is too old") from None
-
-        if timestamp_seconds > now + tolerance:
-            raise InvalidWebhookSignatureError("Webhook timestamp is too new") from None
-
-        # Extract signatures from v1,<base64> format
-        # The signature header can have multiple values, separated by spaces.
-        # Each value is in the format v1,<base64>. We should accept if any match.
-        signatures: list[str] = []
-        for part in signature_header.split():
-            if part.startswith("v1,"):
-                signatures.append(part[3:])
-            else:
-                signatures.append(part)
-
-        # Decode the secret if it starts with whsec_
-        if secret.startswith("whsec_"):
-            decoded_secret = base64.b64decode(secret[6:])
-        else:
-            decoded_secret = secret.encode()
-
-        body = payload.decode("utf-8") if isinstance(payload, bytes) else payload
-
-        # Prepare the signed payload (OpenAI uses webhookId.timestamp.payload format)
-        signed_payload = f"{webhook_id}.{timestamp}.{body}"
-        expected_signature = base64.b64encode(
-            hmac.new(decoded_secret, signed_payload.encode(), hashlib.sha256).digest()
-        ).decode()
-
-        # Accept if any signature matches
-        if not any(hmac.compare_digest(expected_signature, sig) for sig in signatures):
+        if not _webhook_signature_matches(payload, headers, secret=secret, tolerance=tolerance):
             raise InvalidWebhookSignatureError("The given webhook signature does not match the expected signature")

--- a/tests/lib/test_webhook_signature.py
+++ b/tests/lib/test_webhook_signature.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hmac
+import base64
+import hashlib
+import binascii
+from typing import Iterator, cast
+from unittest import mock
+
+import pytest
+
+import openai
+from openai._exceptions import InvalidWebhookSignatureError
+from openai.lib._webhooks import webhook_signature_matches
+from openai.resources.webhooks.webhooks import Webhooks, AsyncWebhooks
+
+NOW = 1_750_000_000
+PAYLOAD = '{"synthetic": "café"}'
+WEBHOOK_ID = "evt_synthetic"
+RAW_SECRET = "synthetic-webhook-secret"
+PREFIXED_SECRET = "whsec_" + base64.b64encode(RAW_SECRET.encode()).decode()
+
+
+def signed_headers(
+    payload: str | bytes = PAYLOAD,
+    *,
+    timestamp: str = str(NOW),
+    secret: bytes = RAW_SECRET.encode(),
+) -> dict[str, str]:
+    body = payload.encode() if isinstance(payload, str) else payload
+    signed = f"{WEBHOOK_ID}.{timestamp}.".encode() + body
+    signature = base64.b64encode(hmac.new(secret, signed, hashlib.sha256).digest()).decode()
+    return {
+        "webhook-id": WEBHOOK_ID,
+        "webhook-timestamp": timestamp,
+        "webhook-signature": f"v1,{signature}",
+    }
+
+
+@pytest.fixture(autouse=True)
+def frozen_time() -> Iterator[None]:
+    with mock.patch("time.time", return_value=NOW):
+        yield
+
+
+@pytest.fixture(params=["sync", "async"])
+def webhook_resource(request: pytest.FixtureRequest) -> Webhooks | AsyncWebhooks:
+    client = mock.Mock()
+    client.webhook_secret = None
+    if request.param == "sync":
+        return Webhooks(cast(openai.OpenAI, client))
+    return AsyncWebhooks(cast(openai.AsyncOpenAI, client))
+
+
+@pytest.mark.parametrize(
+    ("secret", "key"),
+    [(RAW_SECRET, RAW_SECRET.encode()), (PREFIXED_SECRET, RAW_SECRET.encode()), ("", b"")],
+    ids=["raw", "prefixed", "empty"],
+)
+@pytest.mark.parametrize("payload", [PAYLOAD, PAYLOAD.encode()], ids=["text", "bytes"])
+@pytest.mark.parametrize("signature_form", ["prefixed", "bare", "multiple"])
+def test_signature_forms_and_secret_encodings(
+    webhook_resource: Webhooks | AsyncWebhooks,
+    secret: str,
+    key: bytes,
+    payload: str | bytes,
+    signature_form: str,
+) -> None:
+    headers = signed_headers(payload, secret=key)
+    signature = headers["webhook-signature"][3:]
+    if signature_form == "bare":
+        headers["webhook-signature"] = signature
+    elif signature_form == "multiple":
+        headers["webhook-signature"] = f"v1,invalid\t{signature} v1,also-invalid"
+    headers = {name.upper(): value for name, value in headers.items()}
+
+    assert webhook_signature_matches(payload, headers, secret=secret, tolerance=300)
+    assert webhook_resource.verify_signature(payload, headers, secret=secret) is None
+
+
+@pytest.mark.parametrize(
+    ("delta", "tolerance", "error"),
+    [
+        (0, 0, None),
+        (-300, 300, None),
+        (300, 300, None),
+        (-301, 300, "Webhook timestamp is too old"),
+        (301, 300, "Webhook timestamp is too new"),
+        (-1, 0, "Webhook timestamp is too old"),
+        (1, 0, "Webhook timestamp is too new"),
+        (0, -1, "Webhook timestamp is too old"),
+    ],
+)
+def test_replay_window_boundaries(
+    webhook_resource: Webhooks | AsyncWebhooks,
+    delta: int,
+    tolerance: int,
+    error: str | None,
+) -> None:
+    headers = signed_headers(timestamp=str(NOW + delta))
+    if error is None:
+        webhook_resource.verify_signature(PAYLOAD, headers, secret=RAW_SECRET, tolerance=tolerance)
+    else:
+        with pytest.raises(InvalidWebhookSignatureError, match=error) as caught:
+            webhook_resource.verify_signature(PAYLOAD, headers, secret=RAW_SECRET, tolerance=tolerance)
+        assert caught.value.__cause__ is None
+        assert caught.value.__suppress_context__
+
+
+@pytest.mark.parametrize("timestamp", [f"0{NOW}", f"+{NOW}", f" {NOW} "])
+def test_signature_uses_original_timestamp_text(webhook_resource: Webhooks | AsyncWebhooks, timestamp: str) -> None:
+    webhook_resource.verify_signature(PAYLOAD, signed_headers(timestamp=timestamp), secret=RAW_SECRET)
+
+
+@pytest.mark.parametrize("timestamp", ["", "not-a-timestamp", "1.5"])
+def test_invalid_timestamp_exception(webhook_resource: Webhooks | AsyncWebhooks, timestamp: str) -> None:
+    with pytest.raises(InvalidWebhookSignatureError, match="Invalid webhook timestamp format") as caught:
+        webhook_resource.verify_signature(PAYLOAD, signed_headers(timestamp=timestamp), secret=RAW_SECRET)
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__
+
+
+@pytest.mark.parametrize(
+    ("headers", "missing"),
+    [
+        ({}, "webhook-signature"),
+        ({"webhook-signature": "invalid"}, "webhook-timestamp"),
+        ({"webhook-signature": "invalid", "webhook-timestamp": str(NOW)}, "webhook-id"),
+    ],
+)
+def test_required_header_order(
+    webhook_resource: Webhooks | AsyncWebhooks, headers: dict[str, str], missing: str
+) -> None:
+    with pytest.raises(ValueError, match=f"Could not find {missing} header"):
+        webhook_resource.verify_signature(PAYLOAD, headers, secret=RAW_SECRET)
+
+
+def test_client_secret_fallback_preserves_explicit_empty_secret(
+    webhook_resource: Webhooks | AsyncWebhooks,
+) -> None:
+    webhook_resource._client.webhook_secret = PREFIXED_SECRET
+    webhook_resource.verify_signature(PAYLOAD, signed_headers())
+    webhook_resource.verify_signature(PAYLOAD, signed_headers(secret=b""), secret="")
+
+
+def test_missing_secret_preserves_wrapper_exception_chaining(
+    webhook_resource: Webhooks | AsyncWebhooks,
+) -> None:
+    previous = RuntimeError("synthetic prior failure")
+    try:
+        raise previous
+    except RuntimeError:
+        with pytest.raises(ValueError, match="The webhook secret must either be set") as caught:
+            webhook_resource.verify_signature(PAYLOAD, {})
+
+    assert caught.value.__context__ is previous
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__ is isinstance(webhook_resource, AsyncWebhooks)
+
+
+def test_mismatch_preserves_wrapper_exception_chaining(
+    webhook_resource: Webhooks | AsyncWebhooks,
+) -> None:
+    headers = signed_headers()
+    headers["webhook-signature"] = "v1,synthetic-invalid-signature"
+    previous = RuntimeError("synthetic prior failure")
+    try:
+        raise previous
+    except RuntimeError:
+        with pytest.raises(InvalidWebhookSignatureError, match="does not match the expected signature") as caught:
+            webhook_resource.verify_signature(PAYLOAD, headers, secret=RAW_SECRET)
+
+    assert caught.value.__context__ is previous
+    assert caught.value.__cause__ is None
+    assert caught.value.__suppress_context__ is (not isinstance(webhook_resource, AsyncWebhooks))
+    assert RAW_SECRET not in str(caught.value)
+    assert PAYLOAD not in str(caught.value)
+    assert headers["webhook-signature"] not in str(caught.value)
+
+
+def test_malformed_secret_keeps_base64_error(webhook_resource: Webhooks | AsyncWebhooks) -> None:
+    with pytest.raises(binascii.Error):
+        webhook_resource.verify_signature(PAYLOAD, signed_headers(), secret="whsec_a")
+
+
+def test_invalid_utf8_payload_keeps_decode_error(webhook_resource: Webhooks | AsyncWebhooks) -> None:
+    with pytest.raises(UnicodeDecodeError):
+        webhook_resource.verify_signature(b"\xff", signed_headers(), secret=RAW_SECRET)
+
+
+def test_non_ascii_signature_keeps_compare_error(webhook_resource: Webhooks | AsyncWebhooks) -> None:
+    headers = signed_headers()
+    headers["webhook-signature"] = "v1,é"
+    with pytest.raises(TypeError, match="non-ASCII"):
+        webhook_resource.verify_signature(PAYLOAD, headers, secret=RAW_SECRET)
+
+
+def test_constant_time_comparison_order(webhook_resource: Webhooks | AsyncWebhooks) -> None:
+    headers = signed_headers()
+    expected = headers["webhook-signature"][3:]
+    headers["webhook-signature"] = f"v1,invalid v1,{expected} v1,unused"
+    with mock.patch("openai.lib._webhooks.hmac.compare_digest", wraps=hmac.compare_digest) as compare:
+        webhook_resource.verify_signature(PAYLOAD, headers, secret=RAW_SECRET)
+    assert compare.call_args_list == [mock.call(expected, "invalid"), mock.call(expected, expected)]
+
+
+@pytest.mark.parametrize("signature", ["", "v1,invalid", "invalid v1,also-invalid"])
+def test_helper_returns_false_for_mismatch(signature: str) -> None:
+    headers = signed_headers()
+    headers["webhook-signature"] = signature
+    assert not webhook_signature_matches(PAYLOAD, headers, secret=RAW_SECRET, tolerance=300)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the identical webhook header/timestamp/HMAC verification core into the
SDK-owned `lib/_webhooks.py` module. The public sync and async wrappers retain
their signatures, client-secret fallback, mismatch errors, and their existing
exception-chaining differences. Both `unwrap` methods are unchanged.

The helper keeps the same replay-window checks, secret decoding, signed bytes,
signature order, and `hmac.compare_digest` calls. This is a behavior-preserving
extraction, not a change to accepted signatures or verification policy.
Generation metadata, dependencies, workflows, and the API reference are
unchanged.

The verified custom-code report keeps 40 mixed files and changes only the
webhook resource's patch: **+179/-3 → +89/-3**. The other 39 customizations are
unchanged.

## Additional context & links

Please get SDK CODEOWNER review for this verification-boundary change.

The existing 71 cases remain unchanged in
[`tests/lib/test_webhooks.py::TestWebhooks`](https://github.com/openai/openai-python/blob/ece4324da0b96f848b48bdef090a372ff0a1db26/tests/lib/test_webhooks.py#L32)
and
[`tests/lib/test_webhooks.py::TestAsyncWebhooks`](https://github.com/openai/openai-python/blob/ece4324da0b96f848b48bdef090a372ff0a1db26/tests/lib/test_webhooks.py#L170).
The new
[`tests/lib/test_webhook_signature.py`](https://github.com/openai/openai-python/blob/35d955800683b814490c7a583b91611c30df9a71/tests/lib/test_webhook_signature.py)
adds 87 cases for raw/prefixed/empty secrets, text/bytes payloads, replay-window
boundaries, exact timestamp text, header order, malformed inputs, and
constant-time comparison order. In particular,
[`test_missing_secret_preserves_wrapper_exception_chaining`](https://github.com/openai/openai-python/blob/35d955800683b814490c7a583b91611c30df9a71/tests/lib/test_webhook_signature.py#L146)
and
[`test_mismatch_preserves_wrapper_exception_chaining`](https://github.com/openai/openai-python/blob/35d955800683b814490c7a583b91611c30df9a71/tests/lib/test_webhook_signature.py#L161)
pin the existing sync/async differences.

Validation: exact-source/AST preservation check; `./scripts/format`;
`./scripts/lint` (Ruff, Pyright, mypy, import); wheel and sdist builds with the
new helper included; **158 tests passed under Pydantic v2 and 158 under v1**.
