### PR TITLE
test(api): move fine-tuning positional tests out of generated code

### DIFF
--- a/tests/api_resources/fine_tuning/jobs/test_checkpoints.py
+++ b/tests/api_resources/fine_tuning/jobs/test_checkpoints.py
@@ -21,15 +21,15 @@ class TestCheckpoints:
     @parametrize
     def test_method_list(self, client: OpenAI) -> None:
         checkpoint = client.fine_tuning.jobs.checkpoints.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
         assert_matches_type(SyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
 
     @parametrize
     def test_method_list_with_all_params(self, client: OpenAI) -> None:
         checkpoint = client.fine_tuning.jobs.checkpoints.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-            after="string",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="after",
             limit=0,
         )
         assert_matches_type(SyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
@@ -37,7 +37,7 @@ class TestCheckpoints:
     @parametrize
     def test_raw_response_list(self, client: OpenAI) -> None:
         response = client.fine_tuning.jobs.checkpoints.with_raw_response.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
 
         assert response.is_closed is True
@@ -48,7 +48,7 @@ class TestCheckpoints:
     @parametrize
     def test_streaming_response_list(self, client: OpenAI) -> None:
         with client.fine_tuning.jobs.checkpoints.with_streaming_response.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -62,7 +62,7 @@ class TestCheckpoints:
     def test_path_params_list(self, client: OpenAI) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
             client.fine_tuning.jobs.checkpoints.with_raw_response.list(
-                "",
+                fine_tuning_job_id="",
             )
 
 
@@ -74,15 +74,15 @@ class TestAsyncCheckpoints:
     @parametrize
     async def test_method_list(self, async_client: AsyncOpenAI) -> None:
         checkpoint = await async_client.fine_tuning.jobs.checkpoints.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
         assert_matches_type(AsyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
 
     @parametrize
     async def test_method_list_with_all_params(self, async_client: AsyncOpenAI) -> None:
         checkpoint = await async_client.fine_tuning.jobs.checkpoints.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-            after="string",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="after",
             limit=0,
         )
         assert_matches_type(AsyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
@@ -90,7 +90,7 @@ class TestAsyncCheckpoints:
     @parametrize
     async def test_raw_response_list(self, async_client: AsyncOpenAI) -> None:
         response = await async_client.fine_tuning.jobs.checkpoints.with_raw_response.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
 
         assert response.is_closed is True
@@ -101,7 +101,7 @@ class TestAsyncCheckpoints:
     @parametrize
     async def test_streaming_response_list(self, async_client: AsyncOpenAI) -> None:
         async with async_client.fine_tuning.jobs.checkpoints.with_streaming_response.list(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -115,5 +115,5 @@ class TestAsyncCheckpoints:
     async def test_path_params_list(self, async_client: AsyncOpenAI) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
             await async_client.fine_tuning.jobs.checkpoints.with_raw_response.list(
-                "",
+                fine_tuning_job_id="",
             )

--- a/tests/api_resources/fine_tuning/test_jobs.py
+++ b/tests/api_resources/fine_tuning/test_jobs.py
@@ -165,7 +165,7 @@ class TestJobs:
     @parametrize
     def test_method_list_with_all_params(self, client: OpenAI) -> None:
         job = client.fine_tuning.jobs.list(
-            after="string",
+            after="after",
             limit=0,
             metadata={"foo": "string"},
         )
@@ -232,15 +232,15 @@ class TestJobs:
     @parametrize
     def test_method_list_events(self, client: OpenAI) -> None:
         job = client.fine_tuning.jobs.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
         assert_matches_type(SyncCursorPage[FineTuningJobEvent], job, path=["response"])
 
     @parametrize
     def test_method_list_events_with_all_params(self, client: OpenAI) -> None:
         job = client.fine_tuning.jobs.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-            after="string",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="after",
             limit=0,
         )
         assert_matches_type(SyncCursorPage[FineTuningJobEvent], job, path=["response"])
@@ -248,7 +248,7 @@ class TestJobs:
     @parametrize
     def test_raw_response_list_events(self, client: OpenAI) -> None:
         response = client.fine_tuning.jobs.with_raw_response.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
 
         assert response.is_closed is True
@@ -259,7 +259,7 @@ class TestJobs:
     @parametrize
     def test_streaming_response_list_events(self, client: OpenAI) -> None:
         with client.fine_tuning.jobs.with_streaming_response.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -273,7 +273,7 @@ class TestJobs:
     def test_path_params_list_events(self, client: OpenAI) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
             client.fine_tuning.jobs.with_raw_response.list_events(
-                "",
+                fine_tuning_job_id="",
             )
 
     @parametrize
@@ -502,7 +502,7 @@ class TestAsyncJobs:
     @parametrize
     async def test_method_list_with_all_params(self, async_client: AsyncOpenAI) -> None:
         job = await async_client.fine_tuning.jobs.list(
-            after="string",
+            after="after",
             limit=0,
             metadata={"foo": "string"},
         )
@@ -569,15 +569,15 @@ class TestAsyncJobs:
     @parametrize
     async def test_method_list_events(self, async_client: AsyncOpenAI) -> None:
         job = await async_client.fine_tuning.jobs.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
         assert_matches_type(AsyncCursorPage[FineTuningJobEvent], job, path=["response"])
 
     @parametrize
     async def test_method_list_events_with_all_params(self, async_client: AsyncOpenAI) -> None:
         job = await async_client.fine_tuning.jobs.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
-            after="string",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="after",
             limit=0,
         )
         assert_matches_type(AsyncCursorPage[FineTuningJobEvent], job, path=["response"])
@@ -585,7 +585,7 @@ class TestAsyncJobs:
     @parametrize
     async def test_raw_response_list_events(self, async_client: AsyncOpenAI) -> None:
         response = await async_client.fine_tuning.jobs.with_raw_response.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         )
 
         assert response.is_closed is True
@@ -596,7 +596,7 @@ class TestAsyncJobs:
     @parametrize
     async def test_streaming_response_list_events(self, async_client: AsyncOpenAI) -> None:
         async with async_client.fine_tuning.jobs.with_streaming_response.list_events(
-            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            fine_tuning_job_id="ft-AF1WoRqd3aJAHsqc9NY7iL8F",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -610,7 +610,7 @@ class TestAsyncJobs:
     async def test_path_params_list_events(self, async_client: AsyncOpenAI) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
             await async_client.fine_tuning.jobs.with_raw_response.list_events(
-                "",
+                fine_tuning_job_id="",
             )
 
     @parametrize

--- a/tests/lib/test_fine_tuning_positional_arguments.py
+++ b/tests/lib/test_fine_tuning_positional_arguments.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from tests.utils import assert_matches_type
+from openai.pagination import SyncCursorPage, AsyncCursorPage
+from openai.types.fine_tuning import FineTuningJobEvent
+from openai.types.fine_tuning.jobs import FineTuningJobCheckpoint
+
+
+class TestCheckpoints:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @parametrize
+    def test_method_list(self, client: OpenAI) -> None:
+        checkpoint = client.fine_tuning.jobs.checkpoints.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+        assert_matches_type(SyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+    @parametrize
+    def test_method_list_with_all_params(self, client: OpenAI) -> None:
+        checkpoint = client.fine_tuning.jobs.checkpoints.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="string",
+            limit=0,
+        )
+        assert_matches_type(SyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+    @parametrize
+    def test_raw_response_list(self, client: OpenAI) -> None:
+        response = client.fine_tuning.jobs.checkpoints.with_raw_response.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        checkpoint = response.parse()
+        assert_matches_type(SyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+    @parametrize
+    def test_streaming_response_list(self, client: OpenAI) -> None:
+        with client.fine_tuning.jobs.checkpoints.with_streaming_response.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            checkpoint = response.parse()
+            assert_matches_type(SyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    def test_path_params_list(self, client: OpenAI) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
+            client.fine_tuning.jobs.checkpoints.with_raw_response.list(
+                "",
+            )
+
+
+class TestAsyncCheckpoints:
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
+
+    @parametrize
+    async def test_method_list(self, async_client: AsyncOpenAI) -> None:
+        checkpoint = await async_client.fine_tuning.jobs.checkpoints.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+        assert_matches_type(AsyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+    @parametrize
+    async def test_method_list_with_all_params(self, async_client: AsyncOpenAI) -> None:
+        checkpoint = await async_client.fine_tuning.jobs.checkpoints.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="string",
+            limit=0,
+        )
+        assert_matches_type(AsyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+    @parametrize
+    async def test_raw_response_list(self, async_client: AsyncOpenAI) -> None:
+        response = await async_client.fine_tuning.jobs.checkpoints.with_raw_response.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        checkpoint = response.parse()
+        assert_matches_type(AsyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+    @parametrize
+    async def test_streaming_response_list(self, async_client: AsyncOpenAI) -> None:
+        async with async_client.fine_tuning.jobs.checkpoints.with_streaming_response.list(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            checkpoint = await response.parse()
+            assert_matches_type(AsyncCursorPage[FineTuningJobCheckpoint], checkpoint, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_path_params_list(self, async_client: AsyncOpenAI) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
+            await async_client.fine_tuning.jobs.checkpoints.with_raw_response.list(
+                "",
+            )
+
+
+class TestJobs:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @parametrize
+    def test_method_list_events(self, client: OpenAI) -> None:
+        job = client.fine_tuning.jobs.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+        assert_matches_type(SyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+    @parametrize
+    def test_method_list_events_with_all_params(self, client: OpenAI) -> None:
+        job = client.fine_tuning.jobs.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="string",
+            limit=0,
+        )
+        assert_matches_type(SyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+    @parametrize
+    def test_raw_response_list_events(self, client: OpenAI) -> None:
+        response = client.fine_tuning.jobs.with_raw_response.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        job = response.parse()
+        assert_matches_type(SyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+    @parametrize
+    def test_streaming_response_list_events(self, client: OpenAI) -> None:
+        with client.fine_tuning.jobs.with_streaming_response.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            job = response.parse()
+            assert_matches_type(SyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    def test_path_params_list_events(self, client: OpenAI) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
+            client.fine_tuning.jobs.with_raw_response.list_events(
+                "",
+            )
+
+
+class TestAsyncJobs:
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
+
+    @parametrize
+    async def test_method_list_events(self, async_client: AsyncOpenAI) -> None:
+        job = await async_client.fine_tuning.jobs.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+        assert_matches_type(AsyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+    @parametrize
+    async def test_method_list_events_with_all_params(self, async_client: AsyncOpenAI) -> None:
+        job = await async_client.fine_tuning.jobs.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+            after="string",
+            limit=0,
+        )
+        assert_matches_type(AsyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+    @parametrize
+    async def test_raw_response_list_events(self, async_client: AsyncOpenAI) -> None:
+        response = await async_client.fine_tuning.jobs.with_raw_response.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        job = response.parse()
+        assert_matches_type(AsyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+    @parametrize
+    async def test_streaming_response_list_events(self, async_client: AsyncOpenAI) -> None:
+        async with async_client.fine_tuning.jobs.with_streaming_response.list_events(
+            "ft-AF1WoRqd3aJAHsqc9NY7iL8F",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            job = await response.parse()
+            assert_matches_type(AsyncCursorPage[FineTuningJobEvent], job, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_path_params_list_events(self, async_client: AsyncOpenAI) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `fine_tuning_job_id` but received ''"):
+            await async_client.fine_tuning.jobs.with_raw_response.list_events(
+                "",
+            )


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Keep the fine-tuning positional-argument regression coverage in handwritten
tests, then restore the two generated test files to the recorded public
generated snapshot. The generated examples use `fine_tuning_job_id=` and their
original fake `after` values; the original positional calls remain tested.

Only three test files change. Runtime code, dependencies, the API reference,
compiler inputs, and generation metadata are unchanged.

## Additional context & links

All 20 original methods and their client parameterizations are retained
verbatim in
[`tests/lib/test_fine_tuning_positional_arguments.py`](https://github.com/openai/openai-python/blob/4dd138db112ee8d02c6803e0f0b812c5c9be3dee/tests/lib/test_fine_tuning_positional_arguments.py):

- [`TestCheckpoints`](https://github.com/openai/openai-python/blob/4dd138db112ee8d02c6803e0f0b812c5c9be3dee/tests/lib/test_fine_tuning_positional_arguments.py#L14)
  and [`TestAsyncCheckpoints`](https://github.com/openai/openai-python/blob/4dd138db112ee8d02c6803e0f0b812c5c9be3dee/tests/lib/test_fine_tuning_positional_arguments.py#L65)
  preserve `test_method_list`, `test_method_list_with_all_params`,
  `test_raw_response_list`, `test_streaming_response_list`, and
  `test_path_params_list`.
- [`TestJobs`](https://github.com/openai/openai-python/blob/4dd138db112ee8d02c6803e0f0b812c5c9be3dee/tests/lib/test_fine_tuning_positional_arguments.py#L118)
  and [`TestAsyncJobs`](https://github.com/openai/openai-python/blob/4dd138db112ee8d02c6803e0f0b812c5c9be3dee/tests/lib/test_fine_tuning_positional_arguments.py#L169)
  preserve `test_method_list_events`, `test_method_list_events_with_all_params`,
  `test_raw_response_list_events`, `test_streaming_response_list_events`, and
  `test_path_params_list_events`.

These retain the basic/all-parameter calls, parsed response types, raw/streaming
response headers and close behavior, and empty-ID errors. The original loose,
strict, and async aiohttp modes remain: **50 positional-call cases**, alongside
the restored generated keyword-call examples.

Validation:

- Exact-source/AST proof for every retained method and parameterization; both
  generated files match the public snapshot byte-for-byte.
- Pytest collection preserves all 50 original class/function/client-mode IDs
  after normalizing only the destination path, under both Pydantic versions.
- `python -m pytest -n 0 tests/lib/test_fine_tuning_positional_arguments.py
  tests/api_resources/fine_tuning/jobs/test_checkpoints.py
  tests/api_resources/fine_tuning/test_jobs.py`: **220 passed under Pydantic v2
  and 220 under v1**, against the checked-in API mock.
- `./scripts/format` and `./scripts/lint` pass, including Ruff, Pyright, mypy,
  and import checks. Unrelated reporter-only formatting changes are excluded.
- Verified public custom-code report: **40 → 38 mixed files**, exactly these
  two generated test customizations removed, and all other customizations
  unchanged.
