### PR TITLE
test(api): move vector-store signature tests out of generated code

### DIFF
--- a/tests/api_resources/vector_stores/test_file_batches.py
+++ b/tests/api_resources/vector_stores/test_file_batches.py
@@ -9,7 +9,6 @@ import pytest
 
 from openai import OpenAI, AsyncOpenAI
 from tests.utils import assert_matches_type
-from openai._utils import assert_signatures_in_sync
 from openai.pagination import SyncCursorPage, AsyncCursorPage
 from openai.types.vector_stores import (
     VectorStoreFile,
@@ -451,14 +450,3 @@ class TestAsyncFileBatches:
                 batch_id="",
                 vector_store_id="vector_store_id",
             )
-
-
-@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
-def test_create_and_poll_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
-    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
-
-    # ensure helpers do not drift from generated spec
-    assert_signatures_in_sync(
-        checking_client.vector_stores.file_batches.create,
-        checking_client.vector_stores.file_batches.create_and_poll,
-    )

--- a/tests/api_resources/vector_stores/test_files.py
+++ b/tests/api_resources/vector_stores/test_files.py
@@ -9,7 +9,6 @@ import pytest
 
 from openai import OpenAI, AsyncOpenAI
 from tests.utils import assert_matches_type
-from openai._utils import assert_signatures_in_sync
 from openai.pagination import SyncPage, AsyncPage, SyncCursorPage, AsyncCursorPage
 from openai.types.vector_stores import (
     VectorStoreFile,
@@ -626,24 +625,3 @@ class TestAsyncFiles:
                 file_id="",
                 vector_store_id="vs_abc123",
             )
-
-
-@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
-def test_create_and_poll_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
-    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
-
-    assert_signatures_in_sync(
-        checking_client.vector_stores.files.create,
-        checking_client.vector_stores.files.create_and_poll,
-    )
-
-
-@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
-def test_upload_and_poll_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
-    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
-
-    assert_signatures_in_sync(
-        checking_client.vector_stores.files.create,
-        checking_client.vector_stores.files.upload_and_poll,
-        exclude_params={"file_id", "extra_headers", "extra_query", "extra_body", "timeout"},
-    )

--- a/tests/lib/test_vector_store_file_batches.py
+++ b/tests/lib/test_vector_store_file_batches.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from openai._utils import assert_signatures_in_sync
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_create_and_poll_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
+
+    # ensure helpers do not drift from generated spec
+    assert_signatures_in_sync(
+        checking_client.vector_stores.file_batches.create,
+        checking_client.vector_stores.file_batches.create_and_poll,
+    )

--- a/tests/lib/test_vector_store_files.py
+++ b/tests/lib/test_vector_store_files.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from openai._utils import assert_signatures_in_sync
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_create_and_poll_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
+
+    assert_signatures_in_sync(
+        checking_client.vector_stores.files.create,
+        checking_client.vector_stores.files.create_and_poll,
+    )
+
+
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+def test_upload_and_poll_method_in_sync(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    checking_client: OpenAI | AsyncOpenAI = client if sync else async_client
+
+    assert_signatures_in_sync(
+        checking_client.vector_stores.files.create,
+        checking_client.vector_stores.files.upload_and_poll,
+        exclude_params={"file_id", "extra_headers", "extra_query", "extra_body", "timeout"},
+    )


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the three handwritten vector-store helper-signature tests into handwritten
test modules, then restore the two API-resource test files to the recorded
public generated snapshot. Keep each original function, decorator, comparison,
and excluded-parameter set unchanged.

Only four test files change. No polling, upload, runtime, dependency, API
reference, compiler, or generation-metadata changes.

## Additional context & links

The exact retained coverage is:

- [`tests/lib/test_vector_store_file_batches.py::test_create_and_poll_method_in_sync`](https://github.com/openai/openai-python/blob/8eaeaad036a156bbd4155c6a426acffa06d13cfd/tests/lib/test_vector_store_file_batches.py#L10)
  keeps batch `create_and_poll` aligned with `create`.
- [`tests/lib/test_vector_store_files.py::test_create_and_poll_method_in_sync`](https://github.com/openai/openai-python/blob/8eaeaad036a156bbd4155c6a426acffa06d13cfd/tests/lib/test_vector_store_files.py#L10)
  keeps file `create_and_poll` aligned with `create`.
- [`tests/lib/test_vector_store_files.py::test_upload_and_poll_method_in_sync`](https://github.com/openai/openai-python/blob/8eaeaad036a156bbd4155c6a426acffa06d13cfd/tests/lib/test_vector_store_files.py#L20)
  keeps `upload_and_poll` aligned with `create`, retaining exactly the existing
  exclusions: `file_id`, `extra_headers`, `extra_query`, `extra_body`, and
  `timeout`.

Each still runs for both sync and async clients: all **six original cases** are
preserved. The generated API tests remain intact.

Validation:

- Exact-source/AST proof, including decorators and exclusions; both generated
  files match the public snapshot byte-for-byte.
- Both Pydantic collection checks preserve all six original test IDs after
  mapping only the file paths.
- The two handwritten modules plus both affected API-resource suites pass
  **226 tests under Pydantic v2 and 226 under v1**, against the checked-in API
  mock.
- `./scripts/format` and `./scripts/lint` pass, including Ruff, Pyright, mypy,
  and import checks. Unrelated reporter-only formatting changes are excluded.
- Verified public custom-code report: **40 → 38 mixed files**, exactly these
  two customizations removed and every other customization unchanged.
