### PR TITLE
Promote x-ms-served-model header to Response.model for Azure Responses API

### DIFF
--- a/src/openai/lib/azure.py
+++ b/src/openai/lib/azure.py
@@ -76,6 +76,42 @@ async def _async_strip_azure_api_key_on_redirect(request: httpx2.Request) -> Non
     _strip_azure_api_key_on_redirect(request)
 
 
+def _get_served_model_from_headers(headers: httpx2.Headers) -> str | None:
+    # httpx headers are case-insensitive, but be defensive and check lowercased
+    header = headers.get("x-ms-served-model")
+    if header is not None:
+        header = header.strip()
+        if header:
+            return header
+    # Fallback: iterate case-insensitively
+    for key, value in headers.items():
+        if key.lower() == "x-ms-served-model":
+            value = value.strip()
+            if value:
+                return value
+    return None
+
+
+def _should_promote_for_url(url: str | httpx2.URL | None, headers: httpx2.Headers) -> str | None:
+    if url is None:
+        return None
+    url_str = str(url)
+    if "/responses" not in url_str:
+        return None
+    return _get_served_model_from_headers(headers)
+
+
+def _promote_model_on_response(obj: Any, header: str) -> None:
+    try:
+        if hasattr(obj, "model"):
+            # Response and similar
+            object.__setattr__(obj, "model", header)
+        elif hasattr(obj, "response") and hasattr(obj.response, "model"):
+            object.__setattr__(obj.response, "model", header)
+    except Exception:
+        pass
+
+
 class MutuallyExclusiveAuthError(OpenAIError):
     def __init__(self) -> None:
         super().__init__(
@@ -172,6 +208,60 @@ class BaseAzureClient(BaseClient[_HttpxClientT, _DefaultStreamT]):
             return merge_url
 
         return super()._prepare_url(url)
+
+    @override
+    def _process_response(  # type: ignore[override]
+        self,
+        *,
+        cast_to: type[ResponseT],
+        options: FinalRequestOptions,
+        response: httpx2.Response,
+        stream: bool,
+        stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retries_taken: int = 0,
+    ) -> ResponseT:
+        result = super()._process_response(  # type: ignore[misc]
+            cast_to=cast_to,
+            options=options,
+            response=response,
+            stream=stream,
+            stream_cls=stream_cls,
+            retries_taken=retries_taken,
+        )
+
+        header = _should_promote_for_url(options.url, response.headers)
+        if header is None:
+            # Also check the actual request URL in case it was rewritten
+            try:
+                header = _should_promote_for_url(str(response.request.url), response.headers)
+            except Exception:
+                header = None
+        if header is None:
+            return result
+
+        # Non-streaming: result is a Response
+        if not stream:
+            _promote_model_on_response(result, header)
+            return result
+
+        # Streaming: result is a Stream, wrap its iterator to promote each event's response.model
+        try:
+            from openai._streaming import Stream as _Stream
+
+            if isinstance(result, _Stream):
+                orig_stream = result  # type: ignore[assignment]
+                orig_iterator = orig_stream._iterator  # type: ignore[attr-defined]
+
+                def _wrapped_stream():  # type: ignore[no-untyped-def]
+                    for event in orig_iterator:
+                        _promote_model_on_response(event, header)
+                        yield event
+
+                orig_stream._iterator = _wrapped_stream()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+        return result
 
 
 class AzureOpenAI(BaseAzureClient[httpx2.Client, Stream[Any]], OpenAI):
@@ -875,3 +965,54 @@ class AsyncAzureOpenAI(BaseAzureClient[httpx2.AsyncClient, AsyncStream[Any]], As
 
         url = realtime_url.copy_with(params={**query})
         return url, auth_headers
+
+    @override
+    async def _process_response(  # type: ignore[override]
+        self,
+        *,
+        cast_to: type[ResponseT],
+        options: FinalRequestOptions,
+        response: httpx2.Response,
+        stream: bool,
+        stream_cls: type[Stream[Any]] | type[AsyncStream[Any]] | None,
+        retries_taken: int = 0,
+    ) -> ResponseT:
+        result = await super()._process_response(  # type: ignore[misc]
+            cast_to=cast_to,
+            options=options,
+            response=response,
+            stream=stream,
+            stream_cls=stream_cls,
+            retries_taken=retries_taken,
+        )
+
+        header = _should_promote_for_url(options.url, response.headers)
+        if header is None:
+            try:
+                header = _should_promote_for_url(str(response.request.url), response.headers)
+            except Exception:
+                header = None
+        if header is None:
+            return result
+
+        if not stream:
+            _promote_model_on_response(result, header)
+            return result
+
+        try:
+            from openai._streaming import AsyncStream as _AsyncStream
+
+            if isinstance(result, _AsyncStream):
+                orig_stream = result  # type: ignore[assignment]
+                orig_iterator = orig_stream._iterator  # type: ignore[attr-defined]
+
+                async def _wrapped_stream():  # type: ignore[no-untyped-def]
+                    async for event in orig_iterator:
+                        _promote_model_on_response(event, header)
+                        yield event
+
+                orig_stream._iterator = _wrapped_stream()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+
+        return result


### PR DESCRIPTION
## Summary

Azure Responses API returns the deployment alias in `body.model` and the dated snapshot in response header `x-ms-served-model`. OpenAI endpoints and Azure Chat Completions already return the snapshot in `body.model`. Add post-processing in `BaseAzureClient` and `AsyncAzureOpenAI` to promote the header value to `Response.model` for non-streaming and to each `ResponseStreamEvent.response.model` for streaming when the request URL is for `/responses` and the header is present and non-empty.

Fixes #3271

## Changes

* `src/openai/lib/azure.py:79-112` add helpers `_get_served_model_from_headers`, `_should_promote_for_url`, `_promote_model_on_response`.
* `BaseAzureClient._process_response` override for sync `AzureOpenAI` to check the header and mutate `Response.model` for non-streaming, or wrap `Stream` iterator to promote each event's `response.model`.
* `AsyncAzureOpenAI._process_response` override for async `AsyncAzureOpenAI` with `AsyncStream` wrapping.

The header is checked case-insensitively and stripped, and the URL is checked for `/responses` in both `options.url` and the actual `response.request.url` to handle rewrites.

## Testing

* `uv run ruff check src/openai/lib/azure.py` — All checks passed
* `uv run ruff format --check src/openai/lib/azure.py` — already formatted
* `uv run pytest --override-ini="addopts=" -q tests/lib/test_azure.py` — 63 passed
* Manual check: mocked `httpx.Response` with `x-ms-served-model: gpt-5-nano-2025-08-07` and `/responses` URL correctly promotes `Response.model` and streamed events' `response.model`; non-`/responses` URLs and empty headers are not promoted.

## Checklist

* [x] `ruff` check and format
* [x] Existing `test_azure` suite passes
* [x] Change is limited to `src/openai/lib/azure.py` (141 insertions)
* [x] Commit follows Conventional Commits with DCO sign-off
