### PR TITLE
fix(realtime): preserve Unicode characters in realtime calls session serialization

### DIFF
--- a/src/openai/lib/_realtime.py
+++ b/src/openai/lib/_realtime.py
@@ -43,7 +43,7 @@ class _Calls(Calls):
         session_payload = maybe_transform(session, RealtimeSessionCreateRequestParam)
         files = [
             ("sdp", (None, sdp.encode("utf-8"), "application/sdp")),
-            ("session", (None, json.dumps(session_payload).encode("utf-8"), "application/json")),
+            ("session", (None, json.dumps(session_payload, ensure_ascii=False).encode("utf-8"), "application/json")),
         ]
         return self._post(
             "/realtime/calls",
@@ -80,7 +80,7 @@ class _AsyncCalls(AsyncCalls):
         session_payload = await async_maybe_transform(session, RealtimeSessionCreateRequestParam)
         files = [
             ("sdp", (None, sdp.encode("utf-8"), "application/sdp")),
-            ("session", (None, json.dumps(session_payload).encode("utf-8"), "application/json")),
+            ("session", (None, json.dumps(session_payload, ensure_ascii=False).encode("utf-8"), "application/json")),
         ]
         return await self._post(
             "/realtime/calls",

--- a/tests/test_realtime_calls_unicode.py
+++ b/tests/test_realtime_calls_unicode.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import httpx2
+import pytest
+
+import openai._legacy_response as _legacy_response
+from openai import OpenAI, AsyncOpenAI
+from tests.respx2 import MockRouter
+
+
+class TestRealtimeCallsUnicode:
+    @pytest.mark.respx2(base_url="http://127.0.0.1:4010")
+    def test_realtime_create_unicode_session_not_escaped(self, client: OpenAI, respx2_mock: MockRouter) -> None:
+        captured_requests: list[httpx2.Request] = []
+
+        def side_effect(request: httpx2.Request) -> httpx2.Response:
+            captured_requests.append(request)
+            return httpx2.Response(200, json={"id": "call_123"})
+
+        respx2_mock.post("/realtime/calls").mock(side_effect=side_effect)
+
+        unicode_instructions = "Привет мир! 你好世界 こんにちは"
+        call = client.realtime.calls.create(
+            sdp="v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n",
+            session={
+                "type": "realtime",
+                "instructions": unicode_instructions,
+            },
+        )
+        assert isinstance(call, _legacy_response.HttpxBinaryResponseContent)
+        assert len(captured_requests) == 1
+
+        body_bytes = captured_requests[0].content
+        # Ensure the Unicode string is present directly as UTF-8 bytes, not \uXXXX escaped
+        assert unicode_instructions.encode("utf-8") in body_bytes
+        # Ensure it's not escaped
+        assert b"\\u041f\\u0440\\u0438" not in body_bytes
+
+    @pytest.mark.asyncio
+    @pytest.mark.respx2(base_url="http://127.0.0.1:4010")
+    async def test_async_realtime_create_unicode_session_not_escaped(
+        self, async_client: AsyncOpenAI, respx2_mock: MockRouter
+    ) -> None:
+        captured_requests: list[httpx2.Request] = []
+
+        def side_effect(request: httpx2.Request) -> httpx2.Response:
+            captured_requests.append(request)
+            return httpx2.Response(200, json={"id": "call_123"})
+
+        respx2_mock.post("/realtime/calls").mock(side_effect=side_effect)
+
+        unicode_instructions = "Привет мир! 你好世界 こんにちは"
+        call = await async_client.realtime.calls.create(
+            sdp="v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n",
+            session={
+                "type": "realtime",
+                "instructions": unicode_instructions,
+            },
+        )
+        assert isinstance(call, _legacy_response.HttpxBinaryResponseContent)
+        assert len(captured_requests) == 1
+
+        body_bytes = captured_requests[0].content
+        # Ensure the Unicode string is present directly as UTF-8 bytes, not \uXXXX escaped
+        assert unicode_instructions.encode("utf-8") in body_bytes
+        assert b"\\u041f\\u0440\\u0438" not in body_bytes


### PR DESCRIPTION
## Summary

This PR ensures non-ASCII Unicode characters (such as Cyrillic, Chinese, Japanese, Arabic, etc.) in the session payload for `realtime.calls.create` (sync & async) are not converted to `\uXXXX` escape sequences during serialization.

## Problem

When passing instructions, names, or other parameters containing non-ASCII characters to `client.realtime.calls.create(..., session=...)`, Python's `json.dumps()` defaults to `ensure_ascii=True`, converting characters like `Привет` into `\u041f\u0440\u0438\u0432\u0435\u0442`. This significantly bloats the payload size and leads to excess token consumption upstream.

## Solution

- Added `ensure_ascii=False` to `json.dumps()` in both `_Calls.create` and `_AsyncCalls.create` in `src/openai/lib/_realtime.py`.
- Added unit tests in `tests/test_realtime_calls_unicode.py` to verify that Unicode characters remain unescaped UTF-8 in both sync and async request payloads.

Fixes #2428

## How it was tested

Ran the test suite locally:
```bash
python -m pytest -s -vv -n0 tests/test_realtime_calls_unicode.py
```

Output:
```
============================= test session starts =============================
platform win32 -- Python 3.14.7, pytest-9.1.1, pluggy-1.6.0
rootdir: E:\open source\open ai\openai-python
configfile: pyproject.toml
plugins: anyio-4.14.2, inline-snapshot-0.35.4, langsmith-0.10.17, asyncio-1.4.0, xdist-3.8.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collecting ... collected 2 items

tests/test_realtime_calls_unicode.py::TestRealtimeCallsUnicode::test_realtime_create_unicode_session_not_escaped PASSED
tests/test_realtime_calls_unicode.py::TestRealtimeCallsUnicode::test_async_realtime_create_unicode_session_not_escaped PASSED

============================== 2 passed in 1.91s ==============================
```

Linting:
```bash
python -m ruff check src/openai/lib/_realtime.py tests/test_realtime_calls_unicode.py
All checks passed!
```
