### PR TITLE
fix: decode base64 embeddings as little-endian floats

### DIFF
--- a/src/openai/lib/_parsing/_embeddings.py
+++ b/src/openai/lib/_parsing/_embeddings.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import array
 import base64
 from typing import cast
@@ -28,12 +29,16 @@ def parse_embedding_response(
         data = cast(object, embedding.embedding)
         if not isinstance(data, str):
             continue
+        decoded = base64.b64decode(data)
         if not use_numpy:
             # use array for base64 optimisation
-            embedding.embedding = array.array("f", base64.b64decode(data)).tolist()
+            floats = array.array("f", decoded)
+            if sys.byteorder == "big":
+                floats.byteswap()
+            embedding.embedding = floats.tolist()
         else:
             embedding.embedding = np.frombuffer(  # type: ignore[no-untyped-call]
-                base64.b64decode(data), dtype="float32"
+                decoded, dtype="<f4"
             ).tolist()
 
     return obj

--- a/tests/lib/test_embeddings.py
+++ b/tests/lib/test_embeddings.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
-import array
 import base64
+import struct
 import binascii
+from types import SimpleNamespace
 from typing import Any, cast
 from typing_extensions import Literal
 
@@ -18,7 +19,7 @@ from openai.lib._parsing import _embeddings as embeddings_parser
 from openai.types.create_embedding_response import CreateEmbeddingResponse
 
 VALUES = [0.125, -2.5, 3.75]
-ENCODED = base64.b64encode(array.array("f", VALUES).tobytes()).decode("ascii")
+ENCODED = base64.b64encode(struct.pack("<3f", *VALUES)).decode("ascii")
 EncodingFormat = Literal["float", "base64"] | Omit
 ResponseMode = Literal["normal", "raw", "streaming"]
 
@@ -87,6 +88,36 @@ def test_decode_does_not_check_numpy_without_encoded_vectors(monkeypatch: pytest
     response = make_response([1.0, 2.0], [3.0, 4.0])
 
     assert embeddings_parser.parse_embedding_response(response, encoding_format=omit) is response
+
+
+def test_stdlib_decoder_swaps_big_endian_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = make_response(ENCODED)
+    decoded = base64.b64decode(ENCODED)
+
+    class Floats:
+        swapped = False
+
+        def byteswap(self) -> None:
+            self.swapped = True
+
+        def tolist(self) -> list[float]:
+            assert self.swapped
+            return VALUES
+
+    floats = Floats()
+
+    def make_array(typecode: str, initializer: bytes) -> Floats:
+        assert typecode == "f"
+        assert initializer == decoded
+        return floats
+
+    monkeypatch.setattr(embeddings_parser, "has_numpy", lambda: False)
+    monkeypatch.setattr(embeddings_parser, "sys", SimpleNamespace(byteorder="big"))
+    monkeypatch.setattr(embeddings_parser.array, "array", make_array)
+
+    parsed = embeddings_parser.parse_embedding_response(response, encoding_format=omit)
+
+    assert parsed.data[0].embedding == VALUES
 
 
 @pytest.mark.parametrize("encoding_format", ["float", "base64", None])


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Root cause

The base64 embedding representation contains little-endian float32 bytes, but the handwritten response parser used native byte order in both its NumPy and stdlib paths. On big-endian Python platforms, that silently produces incorrect vector values. The existing fixture was also native-endian, so it followed the test host instead of the wire format and could not expose the defect.

## Fix

- Decode the NumPy path with the explicit `<f4` dtype.
- Byte-swap the stdlib `array("f")` path on big-endian hosts.
- Construct fixture bytes with `struct.pack("<3f", ...)` so the test represents the wire format on every host.
- Cover the stdlib big-endian branch without requiring big-endian CI hardware.

The branch is rebased onto current `main` and preserves #3757: NumPy availability is still checked once per response, while each encoded vector is decoded only once.

## Validation

On the current head with Python 3.12:

- Pydantic v2: `.venv/bin/pytest -q -n 0 tests/lib/test_embeddings.py` — 60 passed
- Pydantic v1.10.26: the same focused command — 60 passed
- `.venv/bin/ruff check src/openai/lib/_parsing/_embeddings.py tests/lib/test_embeddings.py` — passed
- `.venv/bin/ruff format --check src/openai/lib/_parsing/_embeddings.py tests/lib/test_embeddings.py` — passed
- `git diff --check` — passed
