### PR TITLE
refactor(api): move file processing polling into SDK-owned helpers

### DIFF
--- a/src/openai/lib/_files.py
+++ b/src/openai/lib/_files.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from ..types.file_object import FileObject
+
+if TYPE_CHECKING:
+    from ..resources.files import Files, AsyncFiles
+
+
+def wait_for_file_processing(
+    files: Files,
+    id: str,
+    *,
+    poll_interval: float,
+    max_wait_seconds: float,
+) -> FileObject:
+    """Poll a file using the caller's resource and sleep hooks."""
+    TERMINAL_STATES = {"processed", "error", "deleted"}
+
+    start = time.time()
+    file = files.retrieve(id)
+    while file.status not in TERMINAL_STATES:
+        files._sleep(poll_interval)
+
+        file = files.retrieve(id)
+        if time.time() - start > max_wait_seconds:
+            raise RuntimeError(
+                f"Giving up on waiting for file {id} to finish processing after {max_wait_seconds} seconds."
+            )
+
+    return file
+
+
+async def async_wait_for_file_processing(
+    files: AsyncFiles,
+    id: str,
+    *,
+    poll_interval: float,
+    max_wait_seconds: float,
+) -> FileObject:
+    """Poll a file using the caller's async resource and sleep hooks."""
+    TERMINAL_STATES = {"processed", "error", "deleted"}
+
+    start = time.time()
+    file = await files.retrieve(id)
+    while file.status not in TERMINAL_STATES:
+        await files._sleep(poll_interval)
+
+        file = await files.retrieve(id)
+        if time.time() - start > max_wait_seconds:
+            raise RuntimeError(
+                f"Giving up on waiting for file {id} to finish processing after {max_wait_seconds} seconds."
+            )
+
+    return file

--- a/src/openai/resources/files.py
+++ b/src/openai/resources/files.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 import typing_extensions
 from typing import Mapping, cast
 from typing_extensions import Literal
@@ -23,6 +22,10 @@ from .._response import (
     async_to_streamed_response_wrapper,
     to_custom_streamed_response_wrapper,
     async_to_custom_streamed_response_wrapper,
+)
+from ..lib._files import (
+    wait_for_file_processing as _wait_for_file_processing,
+    async_wait_for_file_processing as _async_wait_for_file_processing,
 )
 from ..pagination import SyncCursorPage, AsyncCursorPage
 from .._base_client import AsyncPaginator, make_request_options
@@ -371,20 +374,7 @@ class Files(SyncAPIResource):
         max_wait_seconds: float = 30 * 60,
     ) -> FileObject:
         """Waits for the given file to be processed, default timeout is 30 mins."""
-        TERMINAL_STATES = {"processed", "error", "deleted"}
-
-        start = time.time()
-        file = self.retrieve(id)
-        while file.status not in TERMINAL_STATES:
-            self._sleep(poll_interval)
-
-            file = self.retrieve(id)
-            if time.time() - start > max_wait_seconds:
-                raise RuntimeError(
-                    f"Giving up on waiting for file {id} to finish processing after {max_wait_seconds} seconds."
-                )
-
-        return file
+        return _wait_for_file_processing(self, id, poll_interval=poll_interval, max_wait_seconds=max_wait_seconds)
 
 
 class AsyncFiles(AsyncAPIResource):
@@ -725,20 +715,9 @@ class AsyncFiles(AsyncAPIResource):
         max_wait_seconds: float = 30 * 60,
     ) -> FileObject:
         """Waits for the given file to be processed, default timeout is 30 mins."""
-        TERMINAL_STATES = {"processed", "error", "deleted"}
-
-        start = time.time()
-        file = await self.retrieve(id)
-        while file.status not in TERMINAL_STATES:
-            await self._sleep(poll_interval)
-
-            file = await self.retrieve(id)
-            if time.time() - start > max_wait_seconds:
-                raise RuntimeError(
-                    f"Giving up on waiting for file {id} to finish processing after {max_wait_seconds} seconds."
-                )
-
-        return file
+        return await _async_wait_for_file_processing(
+            self, id, poll_interval=poll_interval, max_wait_seconds=max_wait_seconds
+        )
 
 
 class FilesWithRawResponse:

--- a/tests/lib/test_file_processing.py
+++ b/tests/lib/test_file_processing.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+from typing import Any, Callable, cast
+from unittest import mock
+
+import pytest
+
+from openai import OpenAI, AsyncOpenAI
+from openai.lib import _files as file_helpers
+from openai._models import construct_type_unchecked
+from openai.resources.files import Files, AsyncFiles
+from openai.types.file_object import FileObject
+
+FILE_ID = "file-synthetic"
+
+
+def make_file(status: str) -> FileObject:
+    return construct_type_unchecked(
+        type_=FileObject,
+        value={
+            "id": FILE_ID,
+            "bytes": 0,
+            "created_at": 0,
+            "filename": "synthetic.txt",
+            "object": "file",
+            "purpose": "user_data",
+            "status": status,
+        },
+    )
+
+
+@pytest.fixture(params=["sync", "async"])
+def files_resource(request: pytest.FixtureRequest) -> Files | AsyncFiles:
+    client = mock.Mock()
+    if request.param == "sync":
+        return Files(cast(OpenAI, client))
+    return AsyncFiles(cast(AsyncOpenAI, client))
+
+
+def configure(
+    monkeypatch: pytest.MonkeyPatch,
+    resource: Files | AsyncFiles,
+    *,
+    responses: list[FileObject | BaseException],
+    times: list[float],
+    on_sleep: Callable[[float], None] | None = None,
+) -> list[tuple[str, object]]:
+    events: list[tuple[str, object]] = []
+    response_iterator = iter(responses)
+    time_iterator = iter(times)
+
+    def clock() -> float:
+        value = next(time_iterator)
+        events.append(("clock", value))
+        return value
+
+    def retrieve(id: str) -> FileObject:
+        events.append(("retrieve", id))
+        response = next(response_iterator)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    def sleep(seconds: float) -> None:
+        events.append(("sleep", seconds))
+        if on_sleep is not None:
+            on_sleep(seconds)
+
+    async def async_retrieve(id: str) -> FileObject:
+        return retrieve(id)
+
+    async def async_sleep(seconds: float) -> None:
+        sleep(seconds)
+
+    monkeypatch.setattr(file_helpers, "time", SimpleNamespace(time=clock))
+    monkeypatch.setattr(resource, "retrieve", async_retrieve if isinstance(resource, AsyncFiles) else retrieve)
+    monkeypatch.setattr(resource, "_sleep", async_sleep if isinstance(resource, AsyncFiles) else sleep)
+    return events
+
+
+async def wait(resource: Files | AsyncFiles, id: str = FILE_ID, **kwargs: Any) -> FileObject:
+    if isinstance(resource, AsyncFiles):
+        return await resource.wait_for_processing(id, **kwargs)
+    return resource.wait_for_processing(id, **kwargs)
+
+
+@pytest.mark.parametrize("status", ["processed", "error", "deleted"])
+@pytest.mark.parametrize("max_wait_seconds", [-1.0, 0.0, 1800.0])
+async def test_initial_terminal_file_returns_without_sleep_or_timeout_check(
+    files_resource: Files | AsyncFiles,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    max_wait_seconds: float,
+) -> None:
+    terminal = make_file(status)
+    events = configure(monkeypatch, files_resource, responses=[terminal], times=[100.0])
+
+    assert await wait(files_resource, max_wait_seconds=max_wait_seconds) is terminal
+    assert events == [("clock", 100.0), ("retrieve", FILE_ID)]
+
+
+@pytest.mark.parametrize("status", ["processed", "error", "deleted"])
+@pytest.mark.parametrize("elapsed", [9.999, 10.0, 10.001], ids=["before", "exact", "after"])
+async def test_timeout_boundary_is_checked_after_retrieval_even_for_terminal_files(
+    files_resource: Files | AsyncFiles,
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    elapsed: float,
+) -> None:
+    terminal = make_file(status)
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), terminal],
+        times=[100.0, 100.0 + elapsed],
+    )
+
+    if elapsed > 10:
+        with pytest.raises(RuntimeError) as caught:
+            await wait(files_resource, poll_interval=0.25, max_wait_seconds=10)
+        assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 10 seconds."
+    else:
+        assert await wait(files_resource, poll_interval=0.25, max_wait_seconds=10) is terminal
+    assert events == [
+        ("clock", 100.0),
+        ("retrieve", FILE_ID),
+        ("sleep", 0.25),
+        ("retrieve", FILE_ID),
+        ("clock", 100.0 + elapsed),
+    ]
+
+
+async def test_repeated_unknown_states_and_backward_wall_clock_keep_poll_order(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    terminal = make_file("processed")
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), make_file("unknown-pending"), terminal],
+        times=[100.0, 99.0, 110.0],
+    )
+
+    assert await wait(files_resource, poll_interval=0.125, max_wait_seconds=10) is terminal
+    assert events == [
+        ("clock", 100.0),
+        ("retrieve", FILE_ID),
+        ("sleep", 0.125),
+        ("retrieve", FILE_ID),
+        ("clock", 99.0),
+        ("sleep", 0.125),
+        ("retrieve", FILE_ID),
+        ("clock", 110.0),
+    ]
+
+
+async def test_default_interval_and_timeout_error_are_unchanged(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), make_file("processed")],
+        times=[0.0, 1801.0],
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        await wait(files_resource)
+    assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 1800 seconds."
+    assert events[2] == ("sleep", 5.0)
+
+
+async def test_custom_float_timeout_keeps_exact_error(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), make_file("processed")],
+        times=[0.0, 2.5001],
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        await wait(files_resource, max_wait_seconds=2.5)
+    assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 2.5 seconds."
+
+
+@pytest.mark.parametrize("stage", ["initial", "sleep", "retry"])
+@pytest.mark.parametrize("error_type", [RuntimeError, ValueError, asyncio.CancelledError])
+async def test_retrieve_sleep_and_cancellation_errors_propagate_unchanged(
+    files_resource: Files | AsyncFiles,
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+    error_type: type[BaseException],
+) -> None:
+    error = error_type("synthetic failure")
+    responses: list[FileObject | BaseException] = [make_file("uploaded")]
+    if stage == "initial":
+        responses = [error]
+    elif stage == "retry":
+        responses.append(error)
+
+    def fail_sleep(_seconds: float) -> None:
+        raise error
+
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=responses,
+        times=[0.0],
+        on_sleep=fail_sleep if stage == "sleep" else None,
+    )
+
+    with pytest.raises(error_type) as caught:
+        await wait(files_resource, poll_interval=0.125)
+    assert caught.value is error
+    expected: list[tuple[str, object]] = [("clock", 0.0), ("retrieve", FILE_ID)]
+    if stage != "initial":
+        expected.append(("sleep", 0.125))
+    if stage == "retry":
+        expected.append(("retrieve", FILE_ID))
+    assert events == expected
+
+
+async def test_retrieve_override_is_looked_up_again_after_sleep(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    terminal = make_file("processed")
+    replacement = (
+        mock.AsyncMock(return_value=terminal)
+        if isinstance(files_resource, AsyncFiles)
+        else mock.Mock(return_value=terminal)
+    )
+
+    def replace_retrieve(_seconds: float) -> None:
+        monkeypatch.setattr(files_resource, "retrieve", replacement)
+
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded")],
+        times=[0.0, 0.0],
+        on_sleep=replace_retrieve,
+    )
+
+    assert await wait(files_resource, poll_interval=0.125) is terminal
+    replacement.assert_called_once_with(FILE_ID)
+    assert events == [("clock", 0.0), ("retrieve", FILE_ID), ("sleep", 0.125), ("clock", 0.0)]
+
+
+async def test_sleep_override_is_looked_up_again_on_each_poll(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    terminal = make_file("processed")
+    replacement = mock.AsyncMock() if isinstance(files_resource, AsyncFiles) else mock.Mock()
+
+    def replace_sleep(_seconds: float) -> None:
+        monkeypatch.setattr(files_resource, "_sleep", replacement)
+
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), make_file("uploaded"), terminal],
+        times=[0.0, 0.0, 0.0],
+        on_sleep=replace_sleep,
+    )
+
+    assert await wait(files_resource, poll_interval=0.125) is terminal
+    replacement.assert_called_once_with(0.125)
+    assert events == [
+        ("clock", 0.0),
+        ("retrieve", FILE_ID),
+        ("sleep", 0.125),
+        ("retrieve", FILE_ID),
+        ("clock", 0.0),
+        ("retrieve", FILE_ID),
+        ("clock", 0.0),
+    ]
+
+
+@pytest.mark.parametrize("interval", [-1.0, 0.0, 0.25])
+async def test_poll_interval_is_forwarded_without_normalization(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch, interval: float
+) -> None:
+    terminal = make_file("processed")
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), terminal],
+        times=[0.0, 0.0],
+    )
+
+    assert await wait(files_resource, poll_interval=interval) is terminal
+    assert events[2] == ("sleep", interval)
+
+
+@pytest.mark.parametrize("max_wait_seconds", [float("inf"), float("nan")], ids=["infinity", "nan"])
+async def test_nonfinite_timeout_keeps_existing_comparison_behavior(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch, max_wait_seconds: float
+) -> None:
+    terminal = make_file("processed")
+    configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), terminal],
+        times=[0.0, 1_000_000.0],
+    )
+
+    assert await wait(files_resource, max_wait_seconds=max_wait_seconds) is terminal
+
+
+async def test_zero_timeout_still_retrieves_before_strict_deadline_check(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = configure(
+        monkeypatch,
+        files_resource,
+        responses=[make_file("uploaded"), make_file("uploaded"), make_file("processed")],
+        times=[0.0, 0.0, 0.001],
+    )
+
+    with pytest.raises(RuntimeError) as caught:
+        await wait(files_resource, poll_interval=0.0, max_wait_seconds=0)
+    assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 0 seconds."
+    assert [event for event in events if event[0] == "retrieve"] == [("retrieve", FILE_ID)] * 3
+    assert [event for event in events if event[0] == "sleep"] == [("sleep", 0.0)] * 2
+
+
+async def test_public_id_keyword_is_preserved(
+    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    terminal = make_file("processed")
+    configure(monkeypatch, files_resource, responses=[terminal], times=[0.0])
+
+    if isinstance(files_resource, AsyncFiles):
+        assert await files_resource.wait_for_processing(id=FILE_ID) is terminal
+    else:
+        assert files_resource.wait_for_processing(id=FILE_ID) is terminal
+
+
+@pytest.mark.parametrize("resource,is_async", [(Files, False), (AsyncFiles, True)])
+def test_public_signature_and_coroutine_kind_are_preserved(
+    resource: type[Files] | type[AsyncFiles], is_async: bool
+) -> None:
+    signature = inspect.signature(resource.wait_for_processing)
+    assert list(signature.parameters) == ["self", "id", "poll_interval", "max_wait_seconds"]
+    assert signature.parameters["id"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+    assert signature.parameters["id"].default is inspect.Parameter.empty
+    assert signature.parameters["poll_interval"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert signature.parameters["poll_interval"].default == 5.0
+    assert signature.parameters["max_wait_seconds"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert isinstance(signature.parameters["max_wait_seconds"].default, int)
+    assert signature.parameters["max_wait_seconds"].default == 1800
+    assert signature.return_annotation == "FileObject"
+    assert inspect.iscoroutinefunction(resource.wait_for_processing) is is_async

--- a/tests/lib/test_file_processing.py
+++ b/tests/lib/test_file_processing.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
-from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Any, cast
 from unittest import mock
 
 import pytest
@@ -18,18 +16,7 @@ FILE_ID = "file-synthetic"
 
 
 def make_file(status: str) -> FileObject:
-    return construct_type_unchecked(
-        type_=FileObject,
-        value={
-            "id": FILE_ID,
-            "bytes": 0,
-            "created_at": 0,
-            "filename": "synthetic.txt",
-            "object": "file",
-            "purpose": "user_data",
-            "status": status,
-        },
-    )
+    return construct_type_unchecked(type_=FileObject, value={"id": FILE_ID, "status": status})
 
 
 @pytest.fixture(params=["sync", "async"])
@@ -40,319 +27,61 @@ def files_resource(request: pytest.FixtureRequest) -> Files | AsyncFiles:
     return AsyncFiles(cast(AsyncOpenAI, client))
 
 
-def configure(
-    monkeypatch: pytest.MonkeyPatch,
-    resource: Files | AsyncFiles,
-    *,
-    responses: list[FileObject | BaseException],
-    times: list[float],
-    on_sleep: Callable[[float], None] | None = None,
-) -> list[tuple[str, object]]:
-    events: list[tuple[str, object]] = []
-    response_iterator = iter(responses)
-    time_iterator = iter(times)
-
-    def clock() -> float:
-        value = next(time_iterator)
-        events.append(("clock", value))
-        return value
-
-    def retrieve(id: str) -> FileObject:
-        events.append(("retrieve", id))
-        response = next(response_iterator)
-        if isinstance(response, BaseException):
-            raise response
-        return response
-
-    def sleep(seconds: float) -> None:
-        events.append(("sleep", seconds))
-        if on_sleep is not None:
-            on_sleep(seconds)
-
-    async def async_retrieve(id: str) -> FileObject:
-        return retrieve(id)
-
-    async def async_sleep(seconds: float) -> None:
-        sleep(seconds)
-
-    monkeypatch.setattr(file_helpers, "time", SimpleNamespace(time=clock))
-    monkeypatch.setattr(resource, "retrieve", async_retrieve if isinstance(resource, AsyncFiles) else retrieve)
-    monkeypatch.setattr(resource, "_sleep", async_sleep if isinstance(resource, AsyncFiles) else sleep)
-    return events
-
-
-async def wait(resource: Files | AsyncFiles, id: str = FILE_ID, **kwargs: Any) -> FileObject:
+async def wait(resource: Files | AsyncFiles, **kwargs: Any) -> FileObject:
     if isinstance(resource, AsyncFiles):
-        return await resource.wait_for_processing(id, **kwargs)
-    return resource.wait_for_processing(id, **kwargs)
+        return await resource.wait_for_processing(FILE_ID, **kwargs)
+    return resource.wait_for_processing(FILE_ID, **kwargs)
 
 
 @pytest.mark.parametrize("status", ["processed", "error", "deleted"])
-@pytest.mark.parametrize("max_wait_seconds", [-1.0, 0.0, 1800.0])
-async def test_initial_terminal_file_returns_without_sleep_or_timeout_check(
-    files_resource: Files | AsyncFiles,
-    monkeypatch: pytest.MonkeyPatch,
-    status: str,
-    max_wait_seconds: float,
-) -> None:
+async def test_terminal_result(files_resource: Files | AsyncFiles, status: str) -> None:
     terminal = make_file(status)
-    events = configure(monkeypatch, files_resource, responses=[terminal], times=[100.0])
+    with (
+        mock.patch.object(files_resource, "retrieve", return_value=terminal) as retrieve,
+        mock.patch.object(files_resource, "_sleep") as sleep,
+    ):
+        assert await wait(files_resource) is terminal
+        retrieve.assert_called_once_with(FILE_ID)
+        sleep.assert_not_called()
 
-    assert await wait(files_resource, max_wait_seconds=max_wait_seconds) is terminal
-    assert events == [("clock", 100.0), ("retrieve", FILE_ID)]
+
+async def test_poll_until_processed(files_resource: Files | AsyncFiles) -> None:
+    terminal = make_file("processed")
+    with (
+        mock.patch.object(files_resource, "retrieve", side_effect=[make_file("uploaded"), terminal]) as retrieve,
+        mock.patch.object(files_resource, "_sleep") as sleep,
+    ):
+        assert await wait(files_resource, poll_interval=0.25) is terminal
+        assert retrieve.call_count == 2
+        sleep.assert_called_once_with(0.25)
 
 
-@pytest.mark.parametrize("status", ["processed", "error", "deleted"])
-@pytest.mark.parametrize("elapsed", [9.999, 10.0, 10.001], ids=["before", "exact", "after"])
-async def test_timeout_boundary_is_checked_after_retrieval_even_for_terminal_files(
-    files_resource: Files | AsyncFiles,
-    monkeypatch: pytest.MonkeyPatch,
-    status: str,
-    elapsed: float,
-) -> None:
-    terminal = make_file(status)
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), terminal],
-        times=[100.0, 100.0 + elapsed],
-    )
+async def test_timeout(files_resource: Files | AsyncFiles) -> None:
+    with (
+        mock.patch.object(file_helpers, "time") as clock,
+        mock.patch.object(files_resource, "retrieve", return_value=make_file("uploaded")),
+        mock.patch.object(files_resource, "_sleep"),
+    ):
+        clock.time.side_effect = [0.0, 11.0]
+        with pytest.raises(RuntimeError, match=f"Giving up on waiting for file {FILE_ID}"):
+            await wait(files_resource, max_wait_seconds=10)
 
-    if elapsed > 10:
+
+async def test_retrieve_error_propagates(files_resource: Files | AsyncFiles) -> None:
+    error = RuntimeError("synthetic retrieval failure")
+    with mock.patch.object(files_resource, "retrieve", side_effect=error):
         with pytest.raises(RuntimeError) as caught:
-            await wait(files_resource, poll_interval=0.25, max_wait_seconds=10)
-        assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 10 seconds."
-    else:
-        assert await wait(files_resource, poll_interval=0.25, max_wait_seconds=10) is terminal
-    assert events == [
-        ("clock", 100.0),
-        ("retrieve", FILE_ID),
-        ("sleep", 0.25),
-        ("retrieve", FILE_ID),
-        ("clock", 100.0 + elapsed),
-    ]
+            await wait(files_resource)
+        assert caught.value is error
 
 
-async def test_repeated_unknown_states_and_backward_wall_clock_keep_poll_order(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    terminal = make_file("processed")
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), make_file("unknown-pending"), terminal],
-        times=[100.0, 99.0, 110.0],
-    )
-
-    assert await wait(files_resource, poll_interval=0.125, max_wait_seconds=10) is terminal
-    assert events == [
-        ("clock", 100.0),
-        ("retrieve", FILE_ID),
-        ("sleep", 0.125),
-        ("retrieve", FILE_ID),
-        ("clock", 99.0),
-        ("sleep", 0.125),
-        ("retrieve", FILE_ID),
-        ("clock", 110.0),
-    ]
-
-
-async def test_default_interval_and_timeout_error_are_unchanged(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), make_file("processed")],
-        times=[0.0, 1801.0],
-    )
-
-    with pytest.raises(RuntimeError) as caught:
-        await wait(files_resource)
-    assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 1800 seconds."
-    assert events[2] == ("sleep", 5.0)
-
-
-async def test_custom_float_timeout_keeps_exact_error(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), make_file("processed")],
-        times=[0.0, 2.5001],
-    )
-
-    with pytest.raises(RuntimeError) as caught:
-        await wait(files_resource, max_wait_seconds=2.5)
-    assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 2.5 seconds."
-
-
-@pytest.mark.parametrize("stage", ["initial", "sleep", "retry"])
-@pytest.mark.parametrize("error_type", [RuntimeError, ValueError, asyncio.CancelledError])
-async def test_retrieve_sleep_and_cancellation_errors_propagate_unchanged(
-    files_resource: Files | AsyncFiles,
-    monkeypatch: pytest.MonkeyPatch,
-    stage: str,
-    error_type: type[BaseException],
-) -> None:
-    error = error_type("synthetic failure")
-    responses: list[FileObject | BaseException] = [make_file("uploaded")]
-    if stage == "initial":
-        responses = [error]
-    elif stage == "retry":
-        responses.append(error)
-
-    def fail_sleep(_seconds: float) -> None:
-        raise error
-
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=responses,
-        times=[0.0],
-        on_sleep=fail_sleep if stage == "sleep" else None,
-    )
-
-    with pytest.raises(error_type) as caught:
-        await wait(files_resource, poll_interval=0.125)
-    assert caught.value is error
-    expected: list[tuple[str, object]] = [("clock", 0.0), ("retrieve", FILE_ID)]
-    if stage != "initial":
-        expected.append(("sleep", 0.125))
-    if stage == "retry":
-        expected.append(("retrieve", FILE_ID))
-    assert events == expected
-
-
-async def test_retrieve_override_is_looked_up_again_after_sleep(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    terminal = make_file("processed")
-    replacement = (
-        mock.AsyncMock(return_value=terminal)
-        if isinstance(files_resource, AsyncFiles)
-        else mock.Mock(return_value=terminal)
-    )
-
-    def replace_retrieve(_seconds: float) -> None:
-        monkeypatch.setattr(files_resource, "retrieve", replacement)
-
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded")],
-        times=[0.0, 0.0],
-        on_sleep=replace_retrieve,
-    )
-
-    assert await wait(files_resource, poll_interval=0.125) is terminal
-    replacement.assert_called_once_with(FILE_ID)
-    assert events == [("clock", 0.0), ("retrieve", FILE_ID), ("sleep", 0.125), ("clock", 0.0)]
-
-
-async def test_sleep_override_is_looked_up_again_on_each_poll(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    terminal = make_file("processed")
-    replacement = mock.AsyncMock() if isinstance(files_resource, AsyncFiles) else mock.Mock()
-
-    def replace_sleep(_seconds: float) -> None:
-        monkeypatch.setattr(files_resource, "_sleep", replacement)
-
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), make_file("uploaded"), terminal],
-        times=[0.0, 0.0, 0.0],
-        on_sleep=replace_sleep,
-    )
-
-    assert await wait(files_resource, poll_interval=0.125) is terminal
-    replacement.assert_called_once_with(0.125)
-    assert events == [
-        ("clock", 0.0),
-        ("retrieve", FILE_ID),
-        ("sleep", 0.125),
-        ("retrieve", FILE_ID),
-        ("clock", 0.0),
-        ("retrieve", FILE_ID),
-        ("clock", 0.0),
-    ]
-
-
-@pytest.mark.parametrize("interval", [-1.0, 0.0, 0.25])
-async def test_poll_interval_is_forwarded_without_normalization(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch, interval: float
-) -> None:
-    terminal = make_file("processed")
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), terminal],
-        times=[0.0, 0.0],
-    )
-
-    assert await wait(files_resource, poll_interval=interval) is terminal
-    assert events[2] == ("sleep", interval)
-
-
-@pytest.mark.parametrize("max_wait_seconds", [float("inf"), float("nan")], ids=["infinity", "nan"])
-async def test_nonfinite_timeout_keeps_existing_comparison_behavior(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch, max_wait_seconds: float
-) -> None:
-    terminal = make_file("processed")
-    configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), terminal],
-        times=[0.0, 1_000_000.0],
-    )
-
-    assert await wait(files_resource, max_wait_seconds=max_wait_seconds) is terminal
-
-
-async def test_zero_timeout_still_retrieves_before_strict_deadline_check(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    events = configure(
-        monkeypatch,
-        files_resource,
-        responses=[make_file("uploaded"), make_file("uploaded"), make_file("processed")],
-        times=[0.0, 0.0, 0.001],
-    )
-
-    with pytest.raises(RuntimeError) as caught:
-        await wait(files_resource, poll_interval=0.0, max_wait_seconds=0)
-    assert str(caught.value) == f"Giving up on waiting for file {FILE_ID} to finish processing after 0 seconds."
-    assert [event for event in events if event[0] == "retrieve"] == [("retrieve", FILE_ID)] * 3
-    assert [event for event in events if event[0] == "sleep"] == [("sleep", 0.0)] * 2
-
-
-async def test_public_id_keyword_is_preserved(
-    files_resource: Files | AsyncFiles, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    terminal = make_file("processed")
-    configure(monkeypatch, files_resource, responses=[terminal], times=[0.0])
-
-    if isinstance(files_resource, AsyncFiles):
-        assert await files_resource.wait_for_processing(id=FILE_ID) is terminal
-    else:
-        assert files_resource.wait_for_processing(id=FILE_ID) is terminal
-
-
-@pytest.mark.parametrize("resource,is_async", [(Files, False), (AsyncFiles, True)])
-def test_public_signature_and_coroutine_kind_are_preserved(
-    resource: type[Files] | type[AsyncFiles], is_async: bool
-) -> None:
-    signature = inspect.signature(resource.wait_for_processing)
-    assert list(signature.parameters) == ["self", "id", "poll_interval", "max_wait_seconds"]
-    assert signature.parameters["id"].kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
-    assert signature.parameters["id"].default is inspect.Parameter.empty
-    assert signature.parameters["poll_interval"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert signature.parameters["poll_interval"].default == 5.0
-    assert signature.parameters["max_wait_seconds"].kind is inspect.Parameter.KEYWORD_ONLY
-    assert isinstance(signature.parameters["max_wait_seconds"].default, int)
-    assert signature.parameters["max_wait_seconds"].default == 1800
-    assert signature.return_annotation == "FileObject"
-    assert inspect.iscoroutinefunction(resource.wait_for_processing) is is_async
+async def test_async_cancellation_propagates() -> None:
+    resource = AsyncFiles(cast(AsyncOpenAI, mock.Mock()))
+    cancellation = asyncio.CancelledError()
+    with (
+        mock.patch.object(resource, "retrieve", return_value=make_file("uploaded")),
+        mock.patch.object(resource, "_sleep", side_effect=cancellation),
+    ):
+        with pytest.raises(asyncio.CancelledError) as caught:
+            await resource.wait_for_processing(FILE_ID)
+        assert caught.value is cancellation


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the existing sync and async file-processing polling bodies into SDK-owned `lib/_files.py`. `Files.wait_for_processing` and `AsyncFiles.wait_for_processing` keep their public signatures, defaults, docstrings, and return types, and delegate to the helpers. No schema, compiler, dependency, or generation-metadata changes are needed.

The polling bodies are unchanged apart from renaming the receiver from `self` to `files`. This preserves the `processed`/`error`/`deleted` terminal states, wall-clock timing, dynamic `retrieve` and `_sleep` hooks, return identity, and exact errors. In particular, the strict `>` timeout check still happens after a repeated retrieval, even if that retrieval returns a terminal state. This does not introduce a generic polling framework or change existing timeout behavior.

Review pointers:

- Original public methods: [sync](https://github.com/openai/openai-python/blob/bedb9a7b8839e193107e88b92f7cc166f08ac83d/src/openai/resources/files.py#L366) and [async](https://github.com/openai/openai-python/blob/bedb9a7b8839e193107e88b92f7cc166f08ac83d/src/openai/resources/files.py#L720).
- [Extracted bodies](https://github.com/openai/openai-python/blob/3dfdf85e4d33a3274270aadccda6278c41ac8ede/src/openai/lib/_files.py#L12).
- [Focused regression tests](https://github.com/openai/openai-python/blob/3dfdf85e4d33a3274270aadccda6278c41ac8ede/tests/lib/test_file_processing.py#L36): 13 cases covering sync/async terminal results, polling, timeout and retrieval-error propagation, plus async cancellation.

Following the [review discussion](https://github.com/openai/openai-python/pull/3712#discussion_r3830698221), the new handwritten suite is limited to 87 lines rather than an exhaustive matrix of clock, timeout, and event-order details. Existing Files API tests are unchanged. The review revision changes only this new test file; runtime source remains byte-identical to the original PR head.

## Additional context & links

Validation:

- Commands: `TEST_API_BASE_URL=http://127.0.0.1:4141 .venv/bin/python -m pytest tests/lib/test_file_processing.py tests/api_resources/test_files.py -q -n 0` and the same command using `.venv-pydantic-v1/bin/python`: **130 passed, 3 skipped** in each Pydantic mode. The skips are the existing aiohttp/respx2-incompatible `test_method_content`, `test_raw_response_content`, and `test_streaming_response_content` cases.
- Commands: `.venv/bin/ruff format tests/lib/test_file_processing.py` and `./scripts/lint` passed on the review revision, including Ruff, Pyright, mypy, and import checks. The initial full `./scripts/format` also passed; unrelated reporter-formatting changes were excluded.
- Command: `./scripts/build` passed. Both the wheel and source distribution contain `openai/lib/_files.py`; importing the helper and resource classes from the built wheel also passed.
- Exact source/AST comparison against the base verified both polling bodies, all other resource statements, public signatures, exports, request construction, and response wrappers.

The verified custom-code report keeps 36 mixed files and changes only the Files resource customization, shrinking it from **+47/-0 to +26/-0**. The other 35 customizations are unchanged. Reproduction command:

```sh
python3 scripts/castiron/custom_code_report.py report \
  --base bedb9a7b8839e193107e88b92f7cc166f08ac83d \
  --head 3dfdf85e4d33a3274270aadccda6278c41ac8ede \
  --fetch --require-head-hash --public \
  --out /tmp/castiron-file-processing
```
