### PR TITLE
refactor(api): isolate vector-store polling helpers

### DIFF
--- a/src/openai/lib/_vector_stores.py
+++ b/src/openai/lib/_vector_stores.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping
+from typing_extensions import assert_never
+
+from .._types import Omit
+from .._utils import is_given
+from ..types.vector_stores.vector_store_file import VectorStoreFile
+from ..types.vector_stores.vector_store_file_batch import VectorStoreFileBatch
+
+if TYPE_CHECKING:
+    from ..resources.vector_stores.files import Files, AsyncFiles
+    from ..resources.vector_stores.file_batches import FileBatches, AsyncFileBatches
+
+
+def _get_poll_interval_ms(headers: Mapping[str, str]) -> int:
+    """Use the server hint or the existing one-second default."""
+    from_header = headers.get("openai-poll-after-ms")
+    if from_header is not None:
+        return int(from_header)
+    return 1000
+
+
+def poll_vector_store_file(
+    resource: Files,
+    file_id: str,
+    *,
+    vector_store_id: str,
+    poll_interval_ms: int | Omit,
+) -> VectorStoreFile:
+    """Poll a vector-store file using the caller's resource hooks."""
+    headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
+    if is_given(poll_interval_ms):
+        headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
+
+    while True:
+        response = resource.with_raw_response.retrieve(
+            file_id,
+            vector_store_id=vector_store_id,
+            extra_headers=headers,
+        )
+
+        file = response.parse()
+        if file.status == "in_progress":
+            if not is_given(poll_interval_ms):
+                poll_interval_ms = _get_poll_interval_ms(response.headers)
+
+            resource._sleep(poll_interval_ms / 1000)
+        elif file.status == "cancelled" or file.status == "completed" or file.status == "failed":
+            return file
+        else:
+            if TYPE_CHECKING:  # type: ignore[unreachable]
+                assert_never(file.status)
+            else:
+                return file
+
+
+async def async_poll_vector_store_file(
+    resource: AsyncFiles,
+    file_id: str,
+    *,
+    vector_store_id: str,
+    poll_interval_ms: int | Omit,
+) -> VectorStoreFile:
+    """Poll a vector-store file using the caller's async resource hooks."""
+    headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
+    if is_given(poll_interval_ms):
+        headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
+
+    while True:
+        response = await resource.with_raw_response.retrieve(
+            file_id,
+            vector_store_id=vector_store_id,
+            extra_headers=headers,
+        )
+
+        file = response.parse()
+        if file.status == "in_progress":
+            if not is_given(poll_interval_ms):
+                poll_interval_ms = _get_poll_interval_ms(response.headers)
+
+            await resource._sleep(poll_interval_ms / 1000)
+        elif file.status == "cancelled" or file.status == "completed" or file.status == "failed":
+            return file
+        else:
+            if TYPE_CHECKING:  # type: ignore[unreachable]
+                assert_never(file.status)
+            else:
+                return file
+
+
+def poll_vector_store_file_batch(
+    resource: FileBatches,
+    batch_id: str,
+    *,
+    vector_store_id: str,
+    poll_interval_ms: int | Omit,
+) -> VectorStoreFileBatch:
+    """Poll a vector-store batch using the caller's resource hooks."""
+    headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
+    if is_given(poll_interval_ms):
+        headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
+
+    while True:
+        response = resource.with_raw_response.retrieve(
+            batch_id,
+            vector_store_id=vector_store_id,
+            extra_headers=headers,
+        )
+
+        batch = response.parse()
+        if batch.file_counts.in_progress > 0:
+            if not is_given(poll_interval_ms):
+                poll_interval_ms = _get_poll_interval_ms(response.headers)
+
+            resource._sleep(poll_interval_ms / 1000)
+            continue
+
+        return batch
+
+
+async def async_poll_vector_store_file_batch(
+    resource: AsyncFileBatches,
+    batch_id: str,
+    *,
+    vector_store_id: str,
+    poll_interval_ms: int | Omit,
+) -> VectorStoreFileBatch:
+    """Poll a vector-store batch using the caller's async resource hooks."""
+    headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
+    if is_given(poll_interval_ms):
+        headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
+
+    while True:
+        response = await resource.with_raw_response.retrieve(
+            batch_id,
+            vector_store_id=vector_store_id,
+            extra_headers=headers,
+        )
+
+        batch = response.parse()
+        if batch.file_counts.in_progress > 0:
+            if not is_given(poll_interval_ms):
+                poll_interval_ms = _get_poll_interval_ms(response.headers)
+
+            await resource._sleep(poll_interval_ms / 1000)
+            continue
+
+        return batch

--- a/src/openai/resources/vector_stores/file_batches.py
+++ b/src/openai/resources/vector_stores/file_batches.py
@@ -13,13 +13,17 @@ import sniffio
 from ... import _legacy_response
 from ...types import FileChunkingStrategyParam
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, SequenceNotStr, omit, not_given
-from ..._utils import is_given, path_template, maybe_transform, async_maybe_transform
+from ..._utils import path_template, maybe_transform, async_maybe_transform
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from ...pagination import SyncCursorPage, AsyncCursorPage
 from ..._base_client import AsyncPaginator, make_request_options
 from ...types.file_object import FileObject
+from ...lib._vector_stores import (
+    poll_vector_store_file_batch as _poll_vector_store_file_batch,
+    async_poll_vector_store_file_batch as _async_poll_vector_store_file_batch,
+)
 from ...types.vector_stores import file_batch_create_params, file_batch_list_files_params
 from ...types.file_chunking_strategy_param import FileChunkingStrategyParam
 from ...types.vector_stores.vector_store_file import VectorStoreFile
@@ -340,30 +344,12 @@ class FileBatches(SyncAPIResource):
         Note: this will return even if one of the files failed to process, you need to
         check batch.file_counts.failed_count to handle this case.
         """
-        headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
-        if is_given(poll_interval_ms):
-            headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
-
-        while True:
-            response = self.with_raw_response.retrieve(
-                batch_id,
-                vector_store_id=vector_store_id,
-                extra_headers=headers,
-            )
-
-            batch = response.parse()
-            if batch.file_counts.in_progress > 0:
-                if not is_given(poll_interval_ms):
-                    from_header = response.headers.get("openai-poll-after-ms")
-                    if from_header is not None:
-                        poll_interval_ms = int(from_header)
-                    else:
-                        poll_interval_ms = 1000
-
-                self._sleep(poll_interval_ms / 1000)
-                continue
-
-            return batch
+        return _poll_vector_store_file_batch(
+            self,
+            batch_id,
+            vector_store_id=vector_store_id,
+            poll_interval_ms=poll_interval_ms,
+        )
 
     def upload_and_poll(
         self,
@@ -728,30 +714,12 @@ class AsyncFileBatches(AsyncAPIResource):
         Note: this will return even if one of the files failed to process, you need to
         check batch.file_counts.failed_count to handle this case.
         """
-        headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
-        if is_given(poll_interval_ms):
-            headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
-
-        while True:
-            response = await self.with_raw_response.retrieve(
-                batch_id,
-                vector_store_id=vector_store_id,
-                extra_headers=headers,
-            )
-
-            batch = response.parse()
-            if batch.file_counts.in_progress > 0:
-                if not is_given(poll_interval_ms):
-                    from_header = response.headers.get("openai-poll-after-ms")
-                    if from_header is not None:
-                        poll_interval_ms = int(from_header)
-                    else:
-                        poll_interval_ms = 1000
-
-                await self._sleep(poll_interval_ms / 1000)
-                continue
-
-            return batch
+        return await _async_poll_vector_store_file_batch(
+            self,
+            batch_id,
+            vector_store_id=vector_store_id,
+            poll_interval_ms=poll_interval_ms,
+        )
 
     async def upload_and_poll(
         self,

--- a/src/openai/resources/vector_stores/files.py
+++ b/src/openai/resources/vector_stores/files.py
@@ -2,20 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Union, Optional
-from typing_extensions import Literal, assert_never
+from typing import Dict, Union, Optional
+from typing_extensions import Literal
 
 import httpx2
 
 from ... import _legacy_response
 from ...types import FileChunkingStrategyParam
 from ..._types import Body, Omit, Query, Headers, NotGiven, FileTypes, omit, not_given
-from ..._utils import is_given, path_template, maybe_transform, async_maybe_transform
+from ..._utils import path_template, maybe_transform, async_maybe_transform
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import to_streamed_response_wrapper, async_to_streamed_response_wrapper
 from ...pagination import SyncPage, AsyncPage, SyncCursorPage, AsyncCursorPage
 from ..._base_client import AsyncPaginator, make_request_options
+from ...lib._vector_stores import (
+    poll_vector_store_file as _poll_vector_store_file,
+    async_poll_vector_store_file as _async_poll_vector_store_file,
+)
 from ...types.vector_stores import file_list_params, file_create_params, file_update_params
 from ...types.file_chunking_strategy_param import FileChunkingStrategyParam
 from ...types.vector_stores.vector_store_file import VectorStoreFile
@@ -369,34 +373,12 @@ class Files(SyncAPIResource):
         Note: this will return even if the file failed to process, you need to check
         file.last_error and file.status to handle these cases
         """
-        headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
-        if is_given(poll_interval_ms):
-            headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
-
-        while True:
-            response = self.with_raw_response.retrieve(
-                file_id,
-                vector_store_id=vector_store_id,
-                extra_headers=headers,
-            )
-
-            file = response.parse()
-            if file.status == "in_progress":
-                if not is_given(poll_interval_ms):
-                    from_header = response.headers.get("openai-poll-after-ms")
-                    if from_header is not None:
-                        poll_interval_ms = int(from_header)
-                    else:
-                        poll_interval_ms = 1000
-
-                self._sleep(poll_interval_ms / 1000)
-            elif file.status == "cancelled" or file.status == "completed" or file.status == "failed":
-                return file
-            else:
-                if TYPE_CHECKING:  # type: ignore[unreachable]
-                    assert_never(file.status)
-                else:
-                    return file
+        return _poll_vector_store_file(
+            self,
+            file_id,
+            vector_store_id=vector_store_id,
+            poll_interval_ms=poll_interval_ms,
+        )
 
     def upload(
         self,
@@ -823,34 +805,12 @@ class AsyncFiles(AsyncAPIResource):
         Note: this will return even if the file failed to process, you need to check
         file.last_error and file.status to handle these cases
         """
-        headers: dict[str, str] = {"X-Stainless-Poll-Helper": "true"}
-        if is_given(poll_interval_ms):
-            headers["X-Stainless-Custom-Poll-Interval"] = str(poll_interval_ms)
-
-        while True:
-            response = await self.with_raw_response.retrieve(
-                file_id,
-                vector_store_id=vector_store_id,
-                extra_headers=headers,
-            )
-
-            file = response.parse()
-            if file.status == "in_progress":
-                if not is_given(poll_interval_ms):
-                    from_header = response.headers.get("openai-poll-after-ms")
-                    if from_header is not None:
-                        poll_interval_ms = int(from_header)
-                    else:
-                        poll_interval_ms = 1000
-
-                await self._sleep(poll_interval_ms / 1000)
-            elif file.status == "cancelled" or file.status == "completed" or file.status == "failed":
-                return file
-            else:
-                if TYPE_CHECKING:  # type: ignore[unreachable]
-                    assert_never(file.status)
-                else:
-                    return file
+        return await _async_poll_vector_store_file(
+            self,
+            file_id,
+            vector_store_id=vector_store_id,
+            poll_interval_ms=poll_interval_ms,
+        )
 
     async def upload(
         self,

--- a/tests/lib/test_vector_store_polling.py
+++ b/tests/lib/test_vector_store_polling.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+from unittest import mock
+from typing_extensions import TypeAlias
+
+import pytest
+
+from openai._types import Omit, omit
+from openai._models import construct_type_unchecked
+from openai.resources.vector_stores.files import Files, AsyncFiles
+from openai.resources.vector_stores.file_batches import FileBatches, AsyncFileBatches
+from openai.types.vector_stores.vector_store_file import VectorStoreFile
+from openai.types.vector_stores.vector_store_file_batch import VectorStoreFileBatch
+
+PollResource: TypeAlias = Files | AsyncFiles | FileBatches | AsyncFileBatches
+ITEM_ID = "item-synthetic"
+VECTOR_STORE_ID = "vs-synthetic"
+
+
+@pytest.fixture(params=[Files, AsyncFiles, FileBatches, AsyncFileBatches])
+def resource(request: pytest.FixtureRequest) -> PollResource:
+    resource_type = cast(type[PollResource], request.param)
+    return resource_type(cast(Any, mock.Mock()))
+
+
+def raw_response(resource: PollResource, *, pending: bool = False, headers: dict[str, str] | None = None) -> mock.Mock:
+    result: VectorStoreFile | VectorStoreFileBatch
+    if isinstance(resource, (Files, AsyncFiles)):
+        result = construct_type_unchecked(
+            type_=VectorStoreFile, value={"id": ITEM_ID, "status": "in_progress" if pending else "completed"}
+        )
+    else:
+        result = construct_type_unchecked(
+            type_=VectorStoreFileBatch, value={"id": ITEM_ID, "file_counts": {"in_progress": int(pending)}}
+        )
+    return mock.Mock(headers=headers or {}, parse=mock.Mock(return_value=result))
+
+
+async def poll(resource: PollResource, interval: int | Omit = omit) -> VectorStoreFile | VectorStoreFileBatch:
+    if isinstance(resource, (AsyncFiles, AsyncFileBatches)):
+        return await resource.poll(ITEM_ID, vector_store_id=VECTOR_STORE_ID, poll_interval_ms=interval)
+    return resource.poll(ITEM_ID, vector_store_id=VECTOR_STORE_ID, poll_interval_ms=interval)
+
+
+async def test_terminal_result(resource: PollResource) -> None:
+    terminal = raw_response(resource)
+    with (
+        mock.patch.object(resource.with_raw_response, "retrieve", return_value=terminal) as retrieve,
+        mock.patch.object(resource, "_sleep") as sleep,
+    ):
+        assert await poll(resource) is terminal.parse.return_value
+        retrieve.assert_called_once_with(
+            ITEM_ID, vector_store_id=VECTOR_STORE_ID, extra_headers={"X-Stainless-Poll-Helper": "true"}
+        )
+        sleep.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("interval", "headers", "seconds"),
+    [(omit, {}, 1.0), (omit, {"openai-poll-after-ms": "2000"}, 2.0), (250, {"openai-poll-after-ms": "2000"}, 0.25)],
+    ids=["default", "server-hint", "explicit"],
+)
+async def test_poll_interval_and_headers(
+    resource: PollResource, interval: int | Omit, headers: dict[str, str], seconds: float
+) -> None:
+    terminal = raw_response(resource)
+    with (
+        mock.patch.object(
+            resource.with_raw_response,
+            "retrieve",
+            side_effect=[raw_response(resource, pending=True, headers=headers), terminal],
+        ) as retrieve,
+        mock.patch.object(resource, "_sleep") as sleep,
+    ):
+        assert await poll(resource, interval) is terminal.parse.return_value
+        expected_headers = {"X-Stainless-Poll-Helper": "true"}
+        if isinstance(interval, int):
+            expected_headers["X-Stainless-Custom-Poll-Interval"] = str(interval)
+        assert (
+            retrieve.call_args_list
+            == [mock.call(ITEM_ID, vector_store_id=VECTOR_STORE_ID, extra_headers=expected_headers)] * 2
+        )
+        sleep.assert_called_once_with(seconds)
+
+
+async def test_retrieve_error_propagates(resource: PollResource) -> None:
+    error = RuntimeError("synthetic retrieval failure")
+    with mock.patch.object(resource.with_raw_response, "retrieve", side_effect=error):
+        with pytest.raises(RuntimeError) as caught:
+            await poll(resource)
+        assert caught.value is error
+
+
+@pytest.mark.parametrize("resource_type", [AsyncFiles, AsyncFileBatches])
+async def test_async_cancellation_propagates(resource_type: type[AsyncFiles] | type[AsyncFileBatches]) -> None:
+    resource = resource_type(cast(Any, mock.Mock()))
+    cancellation = asyncio.CancelledError()
+    with (
+        mock.patch.object(resource.with_raw_response, "retrieve", return_value=raw_response(resource, pending=True)),
+        mock.patch.object(resource, "_sleep", side_effect=cancellation),
+    ):
+        with pytest.raises(asyncio.CancelledError) as caught:
+            await poll(resource)
+        assert caught.value is cancellation


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Move the existing sync/async vector-store file and file-batch polling bodies into SDK-owned `lib/_vector_stores.py`, sharing their identical `openai-poll-after-ms` lookup, integer conversion, and one-second fallback. The public `poll` methods remain thin delegates with the same signatures, defaults, docstrings, and return types.

Request headers, response parsing, interval handling, terminal conditions, return identity, and error/cancellation propagation are preserved. Upload orchestration, create-and-poll methods, other requests, and response wrappers are untouched. This adds no generic polling framework, timeout behavior, schema/compiler changes, or generation-metadata changes.

Review pointers:

- Original public polling bodies: [Files](https://github.com/openai/openai-python/blob/bedb9a7b8839e193107e88b92f7cc166f08ac83d/src/openai/resources/vector_stores/files.py#L360) and [FileBatches](https://github.com/openai/openai-python/blob/bedb9a7b8839e193107e88b92f7cc166f08ac83d/src/openai/resources/vector_stores/file_batches.py#L331), with the corresponding async methods in the same files.
- [SDK-owned helper](https://github.com/openai/openai-python/blob/25e95b31c1402b3a927cedb9fff5d3d7a785bbeb/src/openai/lib/_vector_stores.py#L16): the four bodies only rename their receiver and replace the repeated interval block with the shared lookup. Source/AST comparison against the base verifies those edits and the unchanged remainder of both resources.
- [Focused tests](https://github.com/openai/openai-python/blob/25e95b31c1402b3a927cedb9fff5d3d7a785bbeb/tests/lib/test_vector_store_polling.py#L47): 106 lines / 22 cases covering the four public entry points, terminal results, default/server/explicit intervals and headers, retrieval errors, and async cancellation. Existing API and helper-signature tests are unchanged.

## Additional context & links

Validation:

- Commands: `.venv/bin/python -m pytest tests/lib/test_vector_store_polling.py -q -n 0` and the same command with `.venv-pydantic-v1/bin/python` passed all **22 cases against the original implementation and again after extraction**.
- Commands: `TEST_API_BASE_URL=http://127.0.0.1:4142 .venv/bin/python -m pytest tests/api_resources/vector_stores tests/lib/test_vector_store_files.py tests/lib/test_vector_store_file_batches.py tests/lib/test_vector_store_polling.py -q -n 0` and the same command with `.venv-pydantic-v1/bin/python` passed **248 tests in each Pydantic mode**.
- Commands: `./scripts/format` and `./scripts/lint` passed, including Ruff, Pyright, mypy, and import checks. Unrelated reporter-formatting edits were excluded.
- Command: `./scripts/build` passed. Both distributions include the helper, and a fresh import from the built wheel loads the helper and all four resource classes.

The verified custom-code report keeps **36 mixed files**, with only the two vector-store resource customizations changed:

- `files.py`: **+222/-4 to +179/-1**.
- `file_batches.py`: **+275/-4 to +242/-3**.

All other 34 customizations, generation metadata, API reference, dependencies, and workflows are unchanged. Reproduction command:

```sh
python3 scripts/castiron/custom_code_report.py report \
  --base bedb9a7b8839e193107e88b92f7cc166f08ac83d \
  --head 25e95b31c1402b3a927cedb9fff5d3d7a785bbeb \
  --fetch --require-head-hash --public \
  --out /tmp/castiron-vector-polling
```
