### PR TITLE
chore: set a ceiling for Python SDK customization

### DIFF
--- a/.castiron-ratchet.json
+++ b/.castiron-ratchet.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "max_custom_patch_lines": 10000
+}


### PR DESCRIPTION
## Summary

Set a generous 10,000-line ceiling for the Python SDK's remaining customization of generated files. The current verified patch is 6,558 lines (+6,010 / −548), so normal development has headroom while unusually large patches need an explicit decision.

This PR intentionally changes only `.castiron-ratchet.json`. Keeping the policy separate means an SDK change cannot raise its own allowance. A human approving review is required; the automated technical review is not policy approval.

Companion tooling PR #3715 adds enforcement using the budget already on `main`. Land this policy first. This seed alone does not enable a required check, and it does not change SDK behavior or CODEOWNERS.
