### PR TITLE
fix: allow assistant messages in Responses input types

### DIFF
--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -39474,9 +39474,10 @@ components:
         role:
           type: string
           description: |
-            The role of the message input. One of `user`, `system`, or `developer`.
+            The role of the message input. One of `user`, `assistant`, `system`, or `developer`.
           enum:
           - user
+          - assistant
           - system
           - developer
         status:
@@ -72326,9 +72327,10 @@ components:
         role:
           type: string
           description: |
-            The role of the message input. One of `user`, `system`, or `developer`.
+            The role of the message input. One of `user`, `assistant`, `system`, or `developer`.
           enum:
           - user
+          - assistant
           - system
           - developer
         status:

--- a/src/openai/types/responses/response_input_item_param.py
+++ b/src/openai/types/responses/response_input_item_param.py
@@ -89,8 +89,8 @@ class Message(TypedDict, total=False):
     types.
     """
 
-    role: Required[Literal["user", "system", "developer"]]
-    """The role of the message input. One of `user`, `system`, or `developer`."""
+    role: Required[Literal["user", "assistant", "system", "developer"]]
+    """The role of the message input. One of `user`, `assistant`, `system`, or `developer`."""
 
     status: Literal["in_progress", "completed", "incomplete"]
     """The status of item.


### PR DESCRIPTION
Closes #3544

The Responses API accepts client-authored assistant turns without an id or status, but the generated `ResponseInputItemParam` type rejected the assistant role. This updates the generated type and OpenAPI schema enum so valid assistant input messages are accepted.

Validation:
- `python3 -m compileall -q src`
- `git diff --check