### PR TITLE
fix(realtime): preserve explicitly set default-valued fields

### DIFF
--- a/src/openai/resources/beta/realtime/realtime.py
+++ b/src/openai/resources/beta/realtime/realtime.py
@@ -282,7 +282,7 @@ class AsyncRealtimeConnection:
 
     async def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
         data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
+            event.to_json(use_api_names=True, exclude_unset=True)
             if isinstance(event, BaseModel)
             else json.dumps(await async_maybe_transform(event, RealtimeClientEventParam))
         )
@@ -467,7 +467,7 @@ class RealtimeConnection:
 
     def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
         data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
+            event.to_json(use_api_names=True, exclude_unset=True)
             if isinstance(event, BaseModel)
             else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )

--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -345,7 +345,7 @@ class AsyncRealtimeConnection:
 
     async def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
         data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
+            event.to_json(use_api_names=True, exclude_unset=True)
             if isinstance(event, BaseModel)
             else json.dumps(await async_maybe_transform(event, RealtimeClientEventParam))
         )
@@ -603,9 +603,7 @@ class AsyncRealtimeConnectionManager:
         are automatically sent once the WebSocket connection opens.
         """
         data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
-            if isinstance(event, BaseModel)
-            else json.dumps(event)
+            event.to_json(use_api_names=True, exclude_unset=True) if isinstance(event, BaseModel) else json.dumps(event)
         )
         self.__send_queue.enqueue(data)
 
@@ -827,7 +825,7 @@ class RealtimeConnection:
 
     def send(self, event: RealtimeClientEvent | RealtimeClientEventParam) -> None:
         data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
+            event.to_json(use_api_names=True, exclude_unset=True)
             if isinstance(event, BaseModel)
             else json.dumps(maybe_transform(event, RealtimeClientEventParam))
         )
@@ -1073,9 +1071,7 @@ class RealtimeConnectionManager:
         are automatically sent once the WebSocket connection opens.
         """
         data = (
-            event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
-            if isinstance(event, BaseModel)
-            else json.dumps(event)
+            event.to_json(use_api_names=True, exclude_unset=True) if isinstance(event, BaseModel) else json.dumps(event)
         )
         self.__send_queue.enqueue(data)
 

--- a/tests/lib/test_realtime_event_serialization.py
+++ b/tests/lib/test_realtime_event_serialization.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, AsyncMock
+
+import pytest
+
+from openai.resources.realtime.realtime import (
+    RealtimeConnection,
+    AsyncRealtimeConnection,
+)
+from openai.resources.beta.realtime.realtime import (
+    RealtimeConnection as BetaRealtimeConnection,
+    AsyncRealtimeConnection as BetaAsyncRealtimeConnection,
+)
+from openai.types.realtime.session_update_event import SessionUpdateEvent
+from openai.types.beta.realtime.session_update_event import (
+    Session as BetaSession,
+    SessionUpdateEvent as BetaSessionUpdateEvent,
+)
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
+
+
+def test_sync_realtime_serializes_explicit_default_value() -> None:
+    websocket = Mock()
+    connection = RealtimeConnection(websocket)
+    event = SessionUpdateEvent(
+        type="session.update",
+        session=RealtimeSessionCreateRequest(type="realtime", instructions=None),
+    )
+
+    connection.send(event)
+
+    payload = json.loads(websocket.send.call_args.args[0])
+    assert payload["session"]["instructions"] is None
+    assert "event_id" not in payload
+
+
+@pytest.mark.asyncio
+async def test_async_realtime_serializes_explicit_default_value() -> None:
+    websocket = AsyncMock()
+    connection = AsyncRealtimeConnection(websocket)
+    event = SessionUpdateEvent(
+        type="session.update",
+        session=RealtimeSessionCreateRequest(type="realtime", instructions=None),
+    )
+
+    await connection.send(event)
+
+    payload = json.loads(websocket.send.call_args.args[0])
+    assert payload["session"]["instructions"] is None
+    assert "event_id" not in payload
+
+
+def test_sync_beta_realtime_serializes_explicit_null_turn_detection() -> None:
+    websocket = Mock()
+    connection = BetaRealtimeConnection(websocket)
+    event = BetaSessionUpdateEvent(
+        type="session.update",
+        session=BetaSession(turn_detection=None),
+    )
+
+    connection.send(event)
+
+    payload = json.loads(websocket.send.call_args.args[0])
+    assert payload["session"]["turn_detection"] is None
+    assert "event_id" not in payload
+
+
+@pytest.mark.asyncio
+async def test_async_beta_realtime_serializes_explicit_null_turn_detection() -> None:
+    websocket = AsyncMock()
+    connection = BetaAsyncRealtimeConnection(websocket)
+    event = BetaSessionUpdateEvent(
+        type="session.update",
+        session=BetaSession(turn_detection=None),
+    )
+
+    await connection.send(event)
+
+    payload = json.loads(websocket.send.call_args.args[0])
+    assert payload["session"]["turn_detection"] is None
+    assert "event_id" not in payload


### PR DESCRIPTION
## Summary

- stop excluding values merely because they equal a Realtime event model default
- keep `exclude_unset=True`, so fields the caller did not set remain omitted
- preserve explicit `None` values such as `turn_detection=None`, allowing a session setting to be cleared or reset
- apply the fix to sync/async GA Realtime and legacy `beta.realtime` event sends

Fixes #2199

## Test plan

- `uv run ruff format src/openai/resources/realtime/realtime.py src/openai/resources/beta/realtime/realtime.py tests/lib/test_realtime_event_serialization.py`
- `uv run ruff check --fix tests/lib/test_realtime_event_serialization.py`
- `uv run ruff check src/openai/resources/realtime/realtime.py src/openai/resources/beta/realtime/realtime.py tests/lib/test_realtime_event_serialization.py`
- `uv run pytest -o addopts= -q tests/lib/test_realtime_event_serialization.py`
- `git diff --check`

All focused verification steps passed before the branch was reduced to its single final commit.