### PR TITLE
fix(logging): support standard OPENAI_LOG levels

### DIFF
--- a/src/openai/_utils/_logs.py
+++ b/src/openai/_utils/_logs.py
@@ -8,7 +8,7 @@ logger: logging.Logger = logging.getLogger("openai")
 
 
 SENSITIVE_HEADERS = {"api-key", "authorization", "x-amz-security-token"}
-LOG_LEVELS = {
+_LOG_LEVELS = {
     "debug": logging.DEBUG,
     "info": logging.INFO,
     "warning": logging.WARNING,
@@ -36,9 +36,15 @@ def setup_logging() -> None:
     # Transport loggers may include complete URLs. Leave their configuration to
     # the application instead of enabling them with the SDK's logging switch.
     env = os.environ.get("OPENAI_LOG")
-    if env in LOG_LEVELS:
-        _basic_config()
-        logger.setLevel(LOG_LEVELS[env])  # type: ignore[index]
+    if env is None:
+        return
+
+    level = _LOG_LEVELS.get(env)
+    if level is None:
+        return
+
+    _basic_config()
+    logger.setLevel(level)
 
 
 class SensitiveHeadersFilter(logging.Filter):

--- a/src/openai/_utils/_logs.py
+++ b/src/openai/_utils/_logs.py
@@ -8,6 +8,13 @@ logger: logging.Logger = logging.getLogger("openai")
 
 
 SENSITIVE_HEADERS = {"api-key", "authorization", "x-amz-security-token"}
+LOG_LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
 
 
 def _basic_config() -> None:
@@ -29,12 +36,9 @@ def setup_logging() -> None:
     # Transport loggers may include complete URLs. Leave their configuration to
     # the application instead of enabling them with the SDK's logging switch.
     env = os.environ.get("OPENAI_LOG")
-    if env == "debug":
+    if env in LOG_LEVELS:
         _basic_config()
-        logger.setLevel(logging.DEBUG)
-    elif env == "info":
-        _basic_config()
-        logger.setLevel(logging.INFO)
+        logger.setLevel(LOG_LEVELS[env])  # type: ignore[index]
 
 
 class SensitiveHeadersFilter(logging.Filter):

--- a/tests/test_log_levels.py
+++ b/tests/test_log_levels.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from openai._utils._logs import setup_logging
+
+
+@pytest.mark.parametrize(
+    ("setting", "expected_level"),
+    [
+        ("debug", logging.DEBUG),
+        ("info", logging.INFO),
+        ("warning", logging.WARNING),
+        ("error", logging.ERROR),
+        ("critical", logging.CRITICAL),
+    ],
+)
+def test_openai_log_sets_standard_log_level(
+    setting: str,
+    expected_level: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = logging.getLogger("openai")
+    original_level = logger.level
+
+    try:
+        monkeypatch.setenv("OPENAI_LOG", setting)
+        setup_logging()
+        assert logger.level == expected_level
+    finally:
+        logger.setLevel(original_level)


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3096.

`OPENAI_LOG` currently recognizes only `debug` and `info`. This change supports the standard logging levels `debug`, `info`, `warning`, `error`, and `critical` through a single level mapping, while preserving the existing behavior for unset or unknown values.

This lets applications suppress routine SDK request logs without having to reconfigure the `openai` logger in application code.

## Additional context & links

Adds regression coverage asserting that each supported `OPENAI_LOG` value configures the `openai` logger at the corresponding standard-library logging level.