### PR TITLE
fix(auth): reject non-positive and non-finite token exchange expires_in

### DIFF
--- a/src/openai/auth/_workload.py
+++ b/src/openai/auth/_workload.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 import time
 import threading
 from typing import Any, Generic, TypeVar, Callable, TypedDict, cast
@@ -305,9 +306,20 @@ class _WorkloadIdentityAuth(Generic[_WorkloadIdentityT]):
         )
 
     def _validate_expires_in(self, expires_in: object) -> float:
-        if not isinstance(expires_in, (int, float)):
+        # `bool` is a subclass of `int`, so guard against it explicitly to avoid
+        # treating `true`/`false` as a `1`/`0` second lifetime.
+        if isinstance(expires_in, bool) or not isinstance(expires_in, (int, float)):
             raise OpenAIError("Token exchange response did not include a valid expires_in")
-        return float(expires_in)
+        try:
+            expires_in_value = float(expires_in)
+        except OverflowError:
+            raise OpenAIError("Token exchange response did not include a valid expires_in") from None
+        # A non-positive lifetime yields an already-expired token, while a
+        # non-finite one (e.g. `inf`) would never trigger a refresh, leaving the
+        # client to reuse a token indefinitely after it has expired server-side.
+        if not math.isfinite(expires_in_value) or expires_in_value <= 0:
+            raise OpenAIError("Token exchange response did not include a valid expires_in")
+        return expires_in_value
 
     def _token_unusable(self) -> bool:
         return self._cached_token is None or self._token_expired()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,7 @@ import pytest
 from inline_snapshot import snapshot
 
 from tests import respx2
-from openai import OpenAI, OAuthError
+from openai import OpenAI, OAuthError, OpenAIError
 from openai.auth import WorkloadIdentity, WorkloadIdentityAuth, SubjectTokenWorkloadIdentity
 from tests.respx2.models import Call
 from openai.auth._workload import (
@@ -162,6 +162,43 @@ def test_workload_identity_exchange_error() -> None:
     assert exc.value.message == "No service account mapping found for the provided service_account_id."
     assert exc.value.error == "invalid_grant"
     assert exc.value.status_code == 401
+    assert exchange_route.call_count == 1
+    assert api_route.call_count == 0
+
+
+@respx2.mock
+@pytest.mark.parametrize("expires_in", [0, -1, True, "3600", None, 10**400])
+def test_workload_identity_rejects_nonpositive_or_nonnumeric_expiration(expires_in: object) -> None:
+    exchange_route = respx2.post("https://auth.openai.com/oauth/token").mock(
+        return_value=httpx2.Response(
+            200,
+            json={
+                "access_token": "fake_access_token",
+                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+                "token_type": "Bearer",
+                "expires_in": expires_in,
+            },
+        )
+    )
+    api_route = respx2.get("https://api.openai.com/v1/models").mock(
+        return_value=httpx2.Response(200, json={"data": [], "object": "list"})
+    )
+
+    client = OpenAI(
+        max_retries=0,
+        workload_identity={
+            "identity_provider_id": "idp_123",
+            "service_account_id": "sa_123",
+            "provider": {
+                "get_token": lambda: "fake_subject_token",
+                "token_type": "jwt",
+            },
+        },
+    )
+
+    with pytest.raises(OpenAIError, match="expires_in"):
+        client.models.list()
+
     assert exchange_route.call_count == 1
     assert api_route.call_count == 0
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,7 @@ import pytest
 from inline_snapshot import snapshot
 
 from tests import respx2
-from openai import OpenAI, OAuthError, OpenAIError
+from openai import OpenAI, OAuthError, AsyncOpenAI, OpenAIError
 from openai.auth import WorkloadIdentity, WorkloadIdentityAuth, SubjectTokenWorkloadIdentity
 from tests.respx2.models import Call
 from openai.auth._workload import (
@@ -15,6 +15,20 @@ from openai.auth._workload import (
     k8s_service_account_token_provider,
     azure_managed_identity_token_provider,
 )
+
+
+def token_exchange_response(*, expires_in: object | None = None, raw_expires_in: str | None = None) -> httpx2.Response:
+    body = {
+        "access_token": "fake_access_token",
+        "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+        "token_type": "Bearer",
+    }
+    if raw_expires_in is None:
+        body["expires_in"] = expires_in
+        return httpx2.Response(200, json=body)
+
+    body_json = json.dumps(body, separators=(",", ":"))
+    return httpx2.Response(200, content=body_json[:-1] + f',"expires_in":{raw_expires_in}' + "}")
 
 
 def test_workload_identity_preserves_callable_typed_dict_api() -> None:
@@ -167,18 +181,25 @@ def test_workload_identity_exchange_error() -> None:
 
 
 @respx2.mock
-@pytest.mark.parametrize("expires_in", [0, -1, True, "3600", None, 10**400])
-def test_workload_identity_rejects_nonpositive_or_nonnumeric_expiration(expires_in: object) -> None:
+@pytest.mark.parametrize(
+    ("expires_in", "raw_expires_in"),
+    [
+        (0, None),
+        (-1, None),
+        (True, None),
+        ("3600", None),
+        (None, None),
+        (10**400, None),
+        (None, "NaN"),
+        (None, "Infinity"),
+        (None, "-Infinity"),
+    ],
+)
+def test_workload_identity_rejects_nonpositive_or_nonnumeric_expiration(
+    expires_in: object | None, raw_expires_in: str | None
+) -> None:
     exchange_route = respx2.post("https://auth.openai.com/oauth/token").mock(
-        return_value=httpx2.Response(
-            200,
-            json={
-                "access_token": "fake_access_token",
-                "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
-                "token_type": "Bearer",
-                "expires_in": expires_in,
-            },
-        )
+        return_value=token_exchange_response(expires_in=expires_in, raw_expires_in=raw_expires_in)
     )
     api_route = respx2.get("https://api.openai.com/v1/models").mock(
         return_value=httpx2.Response(200, json={"data": [], "object": "list"})
@@ -198,6 +219,35 @@ def test_workload_identity_rejects_nonpositive_or_nonnumeric_expiration(expires_
 
     with pytest.raises(OpenAIError, match="expires_in"):
         client.models.list()
+
+    assert exchange_route.call_count == 1
+    assert api_route.call_count == 0
+
+
+@respx2.mock
+@pytest.mark.parametrize("raw_expires_in", ["NaN", "Infinity", "-Infinity"])
+async def test_async_workload_identity_rejects_nonfinite_expiration(raw_expires_in: str) -> None:
+    exchange_route = respx2.post("https://auth.openai.com/oauth/token").mock(
+        return_value=token_exchange_response(raw_expires_in=raw_expires_in)
+    )
+    api_route = respx2.get("https://api.openai.com/v1/models").mock(
+        return_value=httpx2.Response(200, json={"data": [], "object": "list"})
+    )
+
+    client = AsyncOpenAI(
+        max_retries=0,
+        workload_identity={
+            "identity_provider_id": "idp_123",
+            "service_account_id": "sa_123",
+            "provider": {
+                "get_token": lambda: "fake_subject_token",
+                "token_type": "jwt",
+            },
+        },
+    )
+
+    with pytest.raises(OpenAIError, match="expires_in"):
+        await client.models.list()
 
     assert exchange_route.call_count == 1
     assert api_route.call_count == 0


### PR DESCRIPTION
### Changes being requested

`WorkloadIdentityAuth._validate_expires_in` (the base subject-token exchange path used by the JWT / GCP / Azure workload-identity flows) accepted any `int`/`float` and returned `float(expires_in)` without validation. Because `bool` subclasses `int`, a `true`/`false` value was silently treated as a `1`/`0` second lifetime; negative, zero, `NaN`, and infinite values were also accepted, and a value that overflows `float()` (e.g. `10**400`) raised an uncaught `OverflowError` surfaced to the caller as a generic connection error.

An infinite/overflowing lifetime is the most harmful case: `_needs_refresh()` never fires, so the client keeps reusing a token indefinitely after it has expired server-side, producing persistent auth failures that never self-heal.

The X.509 workload-identity path already enforces this contract (`_x509._as_finite_float` + `test_x509_rejects_nonpositive_or_nonnumeric_expiration`, which rejects `[0, -1, True, "3600", None, 10**400]`). This applies the same rule — a positive, finite `expires_in` is required — to the base path. X.509 behavior is unchanged; it keeps its own override.

Added a parametrized regression test (`test_workload_identity_rejects_nonpositive_or_nonnumeric_expiration`) mirroring the existing X.509 test. Fails before the change, passes after; the full auth/x509 suite (390 tests) passes and `ruff` is clean.

### Additional context & links

None.

- [x] I understand that this repository is auto-generated and my pull request may not be merged
