### PR TITLE
fix: preserve explicitly provided send queues

### DIFF
--- a/src/openai/resources/beta/responses/responses.py
+++ b/src/openai/resources/beta/responses/responses.py
@@ -4131,7 +4131,7 @@ class AsyncResponsesConnection:
         self._extra_headers = extra_headers
         self._intentionally_closed = False
         self._is_reconnecting = False
-        self._send_queue = send_queue or SendQueue()
+        self._send_queue = send_queue if send_queue is not None else SendQueue()
         self._event_handler_registry = EventHandlerRegistry(use_lock=False)
 
         self.response = AsyncResponsesResponseResource(self)
@@ -4588,7 +4588,7 @@ class ResponsesConnection:
         self._extra_headers = extra_headers
         self._intentionally_closed = False
         self._is_reconnecting = False
-        self._send_queue = send_queue or SendQueue()
+        self._send_queue = send_queue if send_queue is not None else SendQueue()
         self._event_handler_registry = EventHandlerRegistry(use_lock=True)
 
         self.response = ResponsesResponseResource(self)

--- a/src/openai/resources/realtime/realtime.py
+++ b/src/openai/resources/realtime/realtime.py
@@ -292,7 +292,7 @@ class AsyncRealtimeConnection:
         self._extra_headers = extra_headers
         self._intentionally_closed = False
         self._is_reconnecting = False
-        self._send_queue = send_queue or SendQueue()
+        self._send_queue = send_queue if send_queue is not None else SendQueue()
         self._event_handler_registry = EventHandlerRegistry(use_lock=False)
 
         self.session = AsyncRealtimeSessionResource(self)
@@ -774,7 +774,7 @@ class RealtimeConnection:
         self._extra_headers = extra_headers
         self._intentionally_closed = False
         self._is_reconnecting = False
-        self._send_queue = send_queue or SendQueue()
+        self._send_queue = send_queue if send_queue is not None else SendQueue()
         self._event_handler_registry = EventHandlerRegistry(use_lock=True)
 
         self.session = RealtimeSessionResource(self)

--- a/src/openai/resources/responses/responses.py
+++ b/src/openai/resources/responses/responses.py
@@ -4026,7 +4026,7 @@ class AsyncResponsesConnection:
         self._extra_headers = extra_headers
         self._intentionally_closed = False
         self._is_reconnecting = False
-        self._send_queue = send_queue or SendQueue()
+        self._send_queue = send_queue if send_queue is not None else SendQueue()
         self._event_handler_registry = EventHandlerRegistry(use_lock=False)
 
         self.response = AsyncResponsesResponseResource(self)
@@ -4483,7 +4483,7 @@ class ResponsesConnection:
         self._extra_headers = extra_headers
         self._intentionally_closed = False
         self._is_reconnecting = False
-        self._send_queue = send_queue or SendQueue()
+        self._send_queue = send_queue if send_queue is not None else SendQueue()
         self._event_handler_registry = EventHandlerRegistry(use_lock=True)
 
         self.response = ResponsesResponseResource(self)

--- a/tests/test_websocket_send_queue.py
+++ b/tests/test_websocket_send_queue.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+
+from openai._exceptions import WebSocketQueueFullError
+from openai._send_queue import SendQueue
+from openai.resources.realtime.realtime import RealtimeConnection, AsyncRealtimeConnection
+from openai.resources.responses.responses import (
+    ResponsesConnection,
+    AsyncResponsesConnection,
+)
+from openai.resources.beta.responses.responses import (
+    ResponsesConnection as BetaResponsesConnection,
+    AsyncResponsesConnection as AsyncBetaResponsesConnection,
+)
+
+
+@pytest.mark.parametrize(
+    "connection_type",
+    [
+        AsyncRealtimeConnection,
+        RealtimeConnection,
+        AsyncResponsesConnection,
+        ResponsesConnection,
+        AsyncBetaResponsesConnection,
+        BetaResponsesConnection,
+    ],
+)
+def test_connections_preserve_an_explicit_empty_send_queue(connection_type: Any) -> None:
+    send_queue = SendQueue(max_bytes=0)
+    connection = connection_type(cast(Any, Mock()), send_queue=send_queue)
+
+    assert connection._send_queue is send_queue
+    with pytest.raises(WebSocketQueueFullError):
+        connection._send_queue.enqueue("message")


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

WebSocket connection constructors replace an explicitly supplied empty `SendQueue` because `SendQueue.__bool__` is false when empty.

### Reproduction

1. Create `SendQueue(max_bytes=0)`.
2. Pass it to any of the realtime or responses WebSocket connection constructors.
3. Inspect the connection's queue or enqueue an item.

Expected: the connection retains the supplied queue, including its configured limits and identity.

Actual: the truthiness check constructs a new default `SendQueue`, discarding the supplied queue.

### Root cause and changes

The constructors used `send_queue or SendQueue()`. An empty queue is a valid configured dependency, but its falsey value was treated as if no queue had been supplied.

- Use an explicit `is not None` check in the six affected realtime and responses connection constructors.
- Add parametrized regression coverage across all six constructors, including the supplied queue's limit behavior.

## Additional context & links

### Validation

- `uv run --no-project --with-editable . --with pytest python -m pytest -c /dev/null --rootdir=. --noconftest -o addopts='' -q tests/test_websocket_send_queue.py` — 6 passed.
- `ruff check src/openai/resources/beta/responses/responses.py src/openai/resources/realtime/realtime.py src/openai/resources/responses/responses.py tests/test_websocket_send_queue.py` — passed.
- `ruff format --check src/openai/resources/beta/responses/responses.py src/openai/resources/realtime/realtime.py src/openai/resources/responses/responses.py tests/test_websocket_send_queue.py` — passed.
- Current-head Codex code and security reviews found no issues.

This preserves caller-provided queue identity and configuration. Default construction is unchanged when `send_queue` is `None`; no public API signatures change.
