### PR TITLE
fix: use monotonic clock for file processing timeout

### DIFF
--- a/src/openai/lib/_files.py
+++ b/src/openai/lib/_files.py
@@ -19,13 +19,13 @@ def wait_for_file_processing(
     """Poll a file using the caller's resource and sleep hooks."""
     TERMINAL_STATES = {"processed", "error", "deleted"}
 
-    start = time.time()
+    start = time.monotonic()
     file = files.retrieve(id)
     while file.status not in TERMINAL_STATES:
         files._sleep(poll_interval)
 
         file = files.retrieve(id)
-        if time.time() - start > max_wait_seconds:
+        if time.monotonic() - start > max_wait_seconds:
             raise RuntimeError(
                 f"Giving up on waiting for file {id} to finish processing after {max_wait_seconds} seconds."
             )
@@ -43,13 +43,13 @@ async def async_wait_for_file_processing(
     """Poll a file using the caller's async resource and sleep hooks."""
     TERMINAL_STATES = {"processed", "error", "deleted"}
 
-    start = time.time()
+    start = time.monotonic()
     file = await files.retrieve(id)
     while file.status not in TERMINAL_STATES:
         await files._sleep(poll_interval)
 
         file = await files.retrieve(id)
-        if time.time() - start > max_wait_seconds:
+        if time.monotonic() - start > max_wait_seconds:
             raise RuntimeError(
                 f"Giving up on waiting for file {id} to finish processing after {max_wait_seconds} seconds."
             )

--- a/tests/lib/test_file_processing.py
+++ b/tests/lib/test_file_processing.py
@@ -62,9 +62,33 @@ async def test_timeout(files_resource: Files | AsyncFiles) -> None:
         mock.patch.object(files_resource, "retrieve", return_value=make_file("uploaded")),
         mock.patch.object(files_resource, "_sleep"),
     ):
-        clock.time.side_effect = [0.0, 11.0]
+        clock.monotonic.side_effect = [0.0, 11.0]
         with pytest.raises(RuntimeError, match=f"Giving up on waiting for file {FILE_ID}"):
             await wait(files_resource, max_wait_seconds=10)
+
+
+async def test_timeout_uses_monotonic_clock_after_wall_clock_rollback(
+    files_resource: Files | AsyncFiles,
+) -> None:
+    class PollContinued(RuntimeError):
+        pass
+
+    with (
+        mock.patch.object(file_helpers, "time") as clock,
+        mock.patch.object(files_resource, "retrieve", return_value=make_file("uploaded")),
+        mock.patch.object(
+            files_resource,
+            "_sleep",
+            side_effect=[None, PollContinued("poll continued after the deadline")],
+        ) as sleep,
+    ):
+        clock.time.side_effect = [100.0, 90.0]
+        clock.monotonic.side_effect = [100.0, 102.0]
+
+        with pytest.raises(RuntimeError, match=f"Giving up on waiting for file {FILE_ID}"):
+            await wait(files_resource, poll_interval=5.0, max_wait_seconds=1.0)
+
+        sleep.assert_called_once_with(5.0)
 
 
 async def test_retrieve_error_propagates(files_resource: Files | AsyncFiles) -> None:


### PR DESCRIPTION
## Summary
- Use `time.monotonic()` for elapsed-time deadlines in both synchronous and asynchronous file-processing polling.
- Add regression coverage for a wall-clock rollback in both resource variants.

## Bug

`Files.wait_for_processing()` and its asynchronous counterpart used `time.time()` to measure elapsed time. If the system wall clock moves backwards while a file is still processing, the calculated elapsed time also moves backwards and the timeout can be postponed indefinitely.

### Reproduction

With `max_wait_seconds=1`, `poll_interval=5`, and a wall clock that changes from `100` to `90` after the first poll:

- Expected: raise the timeout error once the monotonic deadline has elapsed.
- Actual before this change: continue polling and enter another five-second sleep.

## Root cause

Wall-clock time is adjustable and is not suitable for measuring elapsed durations.

## Fix

Use Python's monotonic clock for both the initial timestamp and every deadline check. This does not change the public API, poll interval, terminal states, or error message.

## Validation

- `tests/lib/test_file_processing.py`: 15 passed
- Ruff check: passed
- Ruff format check: passed
- Isolated synchronous and asynchronous rollback reproducer: passed

Commands used:

```text
PYTHONPATH=/tmp/openai-python-file-timeout-deps-20260828:src python -m pytest -p no:cacheprovider -o addopts= --confcutdir=tests/lib --asyncio-mode=auto -q tests/lib/test_file_processing.py
python -m ruff check --no-cache src/openai/lib/_files.py tests/lib/test_file_processing.py
python -m ruff format --no-cache --check src/openai/lib/_files.py tests/lib/test_file_processing.py
```