### PR TITLE
fix(embeddings): check for numpy once per response

### DIFF
--- a/src/openai/lib/_parsing/_embeddings.py
+++ b/src/openai/lib/_parsing/_embeddings.py
@@ -20,11 +20,13 @@ def parse_embedding_response(
     if not obj.data:
         raise ValueError("No embedding data received")
 
+    use_numpy = has_numpy()
+
     for embedding in obj.data:
         data = cast(object, embedding.embedding)
         if not isinstance(data, str):
             continue
-        if not has_numpy():
+        if not use_numpy:
             # use array for base64 optimisation
             embedding.embedding = array.array("f", base64.b64decode(data)).tolist()
         else:

--- a/src/openai/lib/_parsing/_embeddings.py
+++ b/src/openai/lib/_parsing/_embeddings.py
@@ -20,12 +20,14 @@ def parse_embedding_response(
     if not obj.data:
         raise ValueError("No embedding data received")
 
-    use_numpy = has_numpy()
+    use_numpy: bool | None = None
 
     for embedding in obj.data:
         data = cast(object, embedding.embedding)
         if not isinstance(data, str):
             continue
+        if use_numpy is None:
+            use_numpy = has_numpy()
         if not use_numpy:
             # use array for base64 optimisation
             embedding.embedding = array.array("f", base64.b64decode(data)).tolist()

--- a/tests/lib/test_embeddings.py
+++ b/tests/lib/test_embeddings.py
@@ -63,6 +63,24 @@ def test_decode_preserves_response_and_non_string_vectors(encoding_format: Omit 
     assert parsed.model == "text-embedding-3-small"
 
 
+@pytest.mark.parametrize("encoding_format", [omit, not_given], ids=["omit", "not-given"])
+def test_decoder_is_inspected_once(encoding_format: Omit | NotGiven, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+
+    def counting_decoder() -> bool:
+        nonlocal calls
+        calls += 1
+        return False
+
+    monkeypatch.setattr(embeddings_parser, "has_numpy", counting_decoder)
+    response = make_response(ENCODED, ENCODED, ENCODED)
+
+    parsed = embeddings_parser.parse_embedding_response(response, encoding_format=encoding_format)
+
+    assert calls == 1
+    assert [cast(object, item.embedding) for item in parsed.data] == [VALUES, VALUES, VALUES]
+
+
 @pytest.mark.parametrize("encoding_format", ["float", "base64", None])
 @pytest.mark.parametrize("vectors", [(ENCODED,), ("abc",), ()], ids=["encoded", "invalid", "empty"])
 def test_explicit_format_is_untouched(

--- a/tests/lib/test_embeddings.py
+++ b/tests/lib/test_embeddings.py
@@ -81,6 +81,19 @@ def test_decoder_is_inspected_once(encoding_format: Omit | NotGiven, monkeypatch
     assert [cast(object, item.embedding) for item in parsed.data] == [VALUES, VALUES, VALUES]
 
 
+@pytest.mark.parametrize("encoding_format", [omit, not_given], ids=["omit", "not-given"])
+def test_float_vectors_skip_the_decoder(encoding_format: Omit | NotGiven, monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_decoder() -> bool:
+        raise AssertionError("a response without string vectors must not inspect the decoder")
+
+    monkeypatch.setattr(embeddings_parser, "has_numpy", unexpected_decoder)
+    response = make_response(VALUES, [4.0, 5.0])
+
+    parsed = embeddings_parser.parse_embedding_response(response, encoding_format=encoding_format)
+
+    assert [cast(object, item.embedding) for item in parsed.data] == [VALUES, [4.0, 5.0]]
+
+
 @pytest.mark.parametrize("encoding_format", ["float", "base64", None])
 @pytest.mark.parametrize("vectors", [(ENCODED,), ("abc",), ()], ids=["encoded", "invalid", "empty"])
 def test_explicit_format_is_untouched(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`parse_embedding_response` calls `has_numpy()` once per embedding, and that function does a fresh `import numpy` every time. Python does not cache failed imports, so when numpy isn't installed each call walks the path finders again and builds an ImportError. A 1500-embedding response pays that 1500 times. Hoisting the check above the loop keeps the behaviour identical and does the import work once.

Decoding 1500 vectors without numpy goes from 96ms to 63ms on my machine, where `sys.path` has six entries. The reporter is on Windows and sees the same call take seconds.

`src/openai/lib/` is hand-written and the generator does not touch it, per CONTRIBUTING.md.

## Additional context & links

Fixes #3753
