### PR TITLE
ci: stop required checks from skipping when locks fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,11 @@ jobs:
       !cancelled()
       && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
+      # A skipped required check counts as satisfied, so refuse here instead of skipping.
       - name: Require fresh dependency locks
         if: needs.dependency-locks.result != 'success'
         run: |
-          echo 'The dependency lock freshness job did not succeed.' >&2
+          echo 'Refuse to run without verified dependency locks.' >&2
           exit 1
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -113,7 +114,7 @@ jobs:
       - name: Require fresh dependency locks
         if: needs.dependency-locks.result != 'success'
         run: |
-          echo 'The dependency lock freshness job did not succeed.' >&2
+          echo 'Refuse to run without verified dependency locks.' >&2
           exit 1
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -176,7 +177,7 @@ jobs:
       - name: Require fresh dependency locks
         if: needs.dependency-locks.result != 'success'
         run: |
-          echo 'The dependency lock freshness job did not succeed.' >&2
+          echo 'Refuse to run without verified dependency locks.' >&2
           exit 1
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -216,7 +217,7 @@ jobs:
       - name: Require fresh dependency locks
         if: needs.dependency-locks.result != 'success'
         run: |
-          echo 'The dependency lock freshness job did not succeed.' >&2
+          echo 'Refuse to run without verified dependency locks.' >&2
           exit 1
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      !cancelled()
+      && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
+      - name: Require fresh dependency locks
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo 'The dependency lock freshness job did not succeed.' >&2
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -93,13 +101,21 @@ jobs:
 
   build:
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      !cancelled()
+      && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     timeout-minutes: 10
     name: build
     permissions:
       contents: read
     runs-on: ubuntu-latest
     steps:
+      - name: Require fresh dependency locks
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo 'The dependency lock freshness job did not succeed.' >&2
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -148,13 +164,21 @@ jobs:
     name: test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      !cancelled()
+      && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     strategy:
       fail-fast: false
       matrix:
         # Per-PR coverage protects both ends of the support window.
         python-version: ["3.10", "3.14"]
     steps:
+      - name: Require fresh dependency locks
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo 'The dependency lock freshness job did not succeed.' >&2
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -185,8 +209,16 @@ jobs:
     name: test (HTTPX2)
     runs-on: ubuntu-latest
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      !cancelled()
+      && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
+      - name: Require fresh dependency locks
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo 'The dependency lock freshness job did not succeed.' >&2
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/tests/test_uv_workflows.py
+++ b/tests/test_uv_workflows.py
@@ -1005,6 +1005,19 @@ def test_untrusted_provenance_leaves_no_dependency_install_reachable(tmp_path: P
     } == installers
 
 
+def test_required_checks_fail_when_dependency_provenance_fails() -> None:
+    jobs = dependency_workflow_jobs()
+    for name in ("lint", "build", "test", "test-httpx2"):
+        job = jobs[name]
+        assert re.search(r"^    needs:\s*dependency-locks\s*$", job, re.MULTILINE)
+        assert re.search(r"^    if: >-\n      !cancelled\(\)\n", job, re.MULTILINE)
+
+        guard = job.split("    steps:\n", 1)[1].split("\n\n", 1)[0]
+        assert "if: needs.dependency-locks.result != 'success'" in guard
+        assert "exit 1" in guard
+        assert "uses:" not in guard
+
+
 def test_scheduled_compatibility_keeps_dependency_provenance_gate() -> None:
     jobs = dependency_workflow_jobs()
     assert not re.search(r"^    if:.*schedule", jobs["dependency-locks"], re.MULTILINE)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`lint`, `build`, `test` and `test-httpx2` declare `needs: dependency-locks`, so a failing lock check skips all four. The `main` ruleset requires those checks but not `dependency lock freshness`, and GitHub counts a skipped required check as satisfied, so `lint`, `build` and `test (HTTPX2)` stop gating in the one run where the lockfile is known to be wrong. The two matrix contexts differ: a skipped matrix job reports once under the unexpanded name, so `test (Python 3.10)` and `test (Python 3.14)` never report and the queue waits them out instead.

The four jobs now run with `!cancelled()` and fail on their first step when `dependency-locks` did not succeed. That step runs before `actions/checkout`, so nothing from an unverified lockfile is fetched, installed or executed, and the required checks report red instead of disappearing. Same-repo pull requests still skip by design, and the merge queue still does the real run.

`test_required_checks_fail_when_dependency_provenance_fails` pins the guard next to the existing workflow assertions in `tests/test_uv_workflows.py`, which already infer reachability from `needs`. I also ran it on a fork with a stale `uv.lock`: `lint`, `build` and both `test` legs failed at `Require fresh dependency locks` with every later step skipped.

## Additional context & links

Fixes #3755

Adding `dependency lock freshness` to the required checks would close the same hole without a workflow change, if you would rather do it there. A composite action would have avoided the repetition, but a local action only loads after `actions/checkout`, which is what the guard has to run before.
