### PR TITLE
fix: avoid repeated numpy checks for embeddings

### DIFF
--- a/src/openai/lib/_parsing/_embeddings.py
+++ b/src/openai/lib/_parsing/_embeddings.py
@@ -20,11 +20,15 @@ def parse_embedding_response(
     if not obj.data:
         raise ValueError("No embedding data received")
 
+    if not any(isinstance(embedding.embedding, str) for embedding in obj.data):
+        return obj
+
+    use_numpy = has_numpy()
     for embedding in obj.data:
         data = cast(object, embedding.embedding)
         if not isinstance(data, str):
             continue
-        if not has_numpy():
+        if not use_numpy:
             # use array for base64 optimisation
             embedding.embedding = array.array("f", base64.b64decode(data)).tolist()
         else:

--- a/tests/lib/test_embeddings.py
+++ b/tests/lib/test_embeddings.py
@@ -63,6 +63,32 @@ def test_decode_preserves_response_and_non_string_vectors(encoding_format: Omit 
     assert parsed.model == "text-embedding-3-small"
 
 
+def test_decode_checks_numpy_once_per_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    checks = 0
+
+    def has_numpy() -> bool:
+        nonlocal checks
+        checks += 1
+        return False
+
+    monkeypatch.setattr(embeddings_parser, "has_numpy", has_numpy)
+    response = make_response(ENCODED, ENCODED, ENCODED)
+
+    embeddings_parser.parse_embedding_response(response, encoding_format=omit)
+
+    assert checks == 1
+
+
+def test_decode_does_not_check_numpy_without_encoded_vectors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unexpected_decoder() -> bool:
+        raise AssertionError("a response without encoded vectors must not inspect the decoder")
+
+    monkeypatch.setattr(embeddings_parser, "has_numpy", unexpected_decoder)
+    response = make_response([1.0, 2.0], [3.0, 4.0])
+
+    assert embeddings_parser.parse_embedding_response(response, encoding_format=omit) is response
+
+
 @pytest.mark.parametrize("encoding_format", ["float", "base64", None])
 @pytest.mark.parametrize("vectors", [(ENCODED,), ("abc",), ()], ids=["encoded", "invalid", "empty"])
 def test_explicit_format_is_untouched(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Avoid calling has_numpy() once per returned embedding when the default embeddings decoder handles a bulk base64 response. The parser now checks whether any encoded vectors need decoding, resolves NumPy availability once per response, and reuses that result for every encoded vector.

Add focused regressions that verify multiple encoded vectors trigger one availability check and responses containing only already-decoded vectors do not inspect NumPy.

## Additional context & links

Closes #3753

Parser-only benchmark for 1,500 vectors x 1,536 dimensions with NumPy unavailable: 86.0 ms -> 20.5 ms median across 30 alternating runs, a 76.1% reduction and 4.18x speedup. With NumPy installed, performance was effectively unchanged/slightly improved: 24.0 ms -> 23.5 ms.

Validation:
- 79 focused embeddings tests passed under Pydantic v2
- 79 focused embeddings tests passed under Pydantic v1
- 11,232 full-suite tests passed; 144 skipped
- Ruff format/check passed
- Pyright passed
- mypy passed
- Three adversarial review rounds completed; the final two consecutive rounds were clean