### PR TITLE
fix: coerce API error code/param/type to str

### DIFF
--- a/src/openai/_exceptions.py
+++ b/src/openai/_exceptions.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 from typing_extensions import Literal
 
 import httpx2
 
 from ._utils import is_dict
-from ._models import construct_type
 from .types.shared.oauth_error_code import OAuthErrorCode
 
 if TYPE_CHECKING:
@@ -69,9 +68,17 @@ class APIError(OpenAIError):
         self.body = body
 
         if is_dict(body):
-            self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
-            self.param = cast(Any, construct_type(type_=Optional[str], value=body.get("param")))
-            self.type = cast(Any, construct_type(type_=str, value=body.get("type")))
+            code = body.get("code")
+            param = body.get("param")
+            error_type = body.get("type")
+
+            # The API documents `error.code`, `error.param` and `error.type` as
+            # strings, but some servers (including api.openai.com under load, and
+            # OpenAI-compatible gateways) send integer codes. Coerce to `str` so
+            # the runtime value always matches the annotation.
+            self.code = str(code) if code is not None else None
+            self.param = str(param) if param is not None else None
+            self.type = str(error_type) if error_type is not None else None
         else:
             self.code = None
             self.param = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1153,6 +1153,25 @@ class TestOpenAI:
 
         assert route.call_count == 1
 
+    @pytest.mark.respx2(base_url=base_url)
+    def test_api_status_error_code_is_coerced_to_str(self, respx2_mock: MockRouter, client: OpenAI) -> None:
+        respx2_mock.get("/foo").mock(
+            return_value=httpx2.Response(
+                400,
+                json={"error": {"code": 404, "message": "nope", "type": "invalid_request_error"}},
+            )
+        )
+
+        with pytest.raises(APIStatusError) as exc_info:
+            client.get("/foo", cast_to=httpx2.Response)
+
+        error = exc_info.value
+        assert isinstance(error.code, str)
+        assert error.code == "404"
+        assert error.type == "invalid_request_error"
+        # the raw value is preserved on the body for consumers that need it
+        assert error.body == {"code": 404, "message": "nope", "type": "invalid_request_error"}
+
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx2(base_url=base_url)
     def test_retrying_timeout_errors_doesnt_leak(self, respx2_mock: MockRouter, client: OpenAI) -> None:
@@ -2447,6 +2466,27 @@ class TestAsyncOpenAI:
             await async_client.get("/foo", cast_to=httpx2.Response)
 
         assert route.call_count == 1
+
+    @pytest.mark.respx2(base_url=base_url)
+    async def test_api_status_error_code_is_coerced_to_str(
+        self, respx2_mock: MockRouter, async_client: AsyncOpenAI
+    ) -> None:
+        respx2_mock.get("/foo").mock(
+            return_value=httpx2.Response(
+                400,
+                json={"error": {"code": 404, "message": "nope", "type": "invalid_request_error"}},
+            )
+        )
+
+        with pytest.raises(APIStatusError) as exc_info:
+            await async_client.get("/foo", cast_to=httpx2.Response)
+
+        error = exc_info.value
+        assert isinstance(error.code, str)
+        assert error.code == "404"
+        assert error.type == "invalid_request_error"
+        # the raw value is preserved on the body for consumers that need it
+        assert error.body == {"code": 404, "message": "nope", "type": "invalid_request_error"}
 
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
     @pytest.mark.respx2(base_url=base_url)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #3531 — `APIStatusError.code` is annotated `Optional[str]` but can be an `int` at runtime.

**Problem:** `APIError.__init__` builds `code`/`param`/`type` with the lenient deserializer:

```python
self.code = cast(Any, construct_type(type_=Optional[str], value=body.get("code")))
```

`construct_type` neither coerces nor rejects values that don't match the target type — it returns them unchanged — and the `cast(Any, ...)` suppresses the type checker. So when a server sends an integer error code (observed from api.openai.com under load, and routinely from OpenAI-compatible gateways), `exc.code` is an `int` while the annotation promises `str | None`. Downstream code that trusts the annotation (e.g. `exc.code.strip()`) crashes with `AttributeError` *after* the API failure already happened.

**Fix:** coerce non-`None` values to `str` in the exception constructor, so the runtime value always matches the documented annotation. The raw value remains available on `APIError.body` for consumers that need it. Applied consistently to `code`, `param` and `type` (all three share the same pattern).

**Tests:** added `test_api_status_error_code_is_coerced_to_str` to both the sync and async client suites (end-to-end via a mocked 400 response with `"code": 404`). Verified revert-proven: both new tests fail on the pre-fix code and pass with the fix. Full `tests/test_client.py`: **200 passed, 2 skipped**. `ruff check .` and `mypy src/openai/_exceptions.py` clean.

Note: `src/openai/_exceptions.py` is handwritten — it carries no Castiron "File generated from our OpenAPI spec" marker — so this change won't be overwritten by the generator.

## Additional context & links

- Issue: #3531
- Drafted with Hermes Agent (deepseek-v4-flash); every line reviewed and verified by Manny7717 (tests run, revert-proven, lint + type-checked).
