### PR TITLE
fix: resume interrupted file downloads with byte-range retries

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -135,15 +135,23 @@ def _is_identity_encoded(response: httpx2.Response) -> bool:
     return value in ("", "identity")
 
 
-def _range_start_bytes(response: httpx2.Response) -> int | None:
-    """Start offset reported by a `206` response's `Content-Range: bytes <start>-…` header."""
+def _content_range_bounds(response: httpx2.Response) -> tuple[int, int | None, int | None] | None:
+    """Parse a `206` response's `Content-Range: bytes <start>-<end>/<total>` header.
+
+    `end` and `total` are `None` when absent or unknown (`*`).
+    """
     value = str(response.headers.get("content-range", ""))
     if not value.startswith("bytes "):
         return None
     try:
-        return int(value[len("bytes ") :].split("-", 1)[0].strip())
+        start_part, rest = value[len("bytes ") :].split("-", 1)
+        end_part, _, total_part = rest.partition("/")
+        start = int(start_part.strip())
+        end = int(end_part.strip()) if end_part.strip() not in ("", "*") else None
+        total = int(total_part.strip()) if total_part.strip() not in ("", "*") else None
     except ValueError:
         return None
+    return start, end, total
 
 
 def _range_total_bytes(response: httpx2.Response) -> int | None:
@@ -189,7 +197,12 @@ def _resume_validator(response: httpx2.Response) -> str | None:
     return last_modified or None
 
 
-def _reassembled_download_response(representation: httpx2.Response, content: bytes) -> httpx2.Response:
+def _reassembled_download_response(
+    representation: httpx2.Response,
+    content: bytes,
+    *,
+    elapsed_from: httpx2.Response,
+) -> httpx2.Response:
     headers = [
         (key, value)
         for key, value in representation.headers.raw
@@ -198,7 +211,7 @@ def _reassembled_download_response(representation: httpx2.Response, content: byt
     # keep the response class of the client that actually served the request
     # (legacy `httpx` clients produce legacy `httpx.Response` objects)
     response_cls = httpx2.Response if isinstance(representation, httpx2.Response) else type(representation)
-    return response_cls(
+    rebuilt = response_cls(
         200,
         headers=headers,
         content=content,
@@ -207,6 +220,13 @@ def _reassembled_download_response(representation: httpx2.Response, content: byt
         extensions=representation.extensions,
         history=representation.history,
     )
+    try:
+        rebuilt.elapsed = elapsed_from.elapsed
+    except RuntimeError:
+        # the serving transport did not record timing; leave the field unset
+        # exactly as an unread response would be
+        pass
+    return rebuilt
 
 
 if TYPE_CHECKING:
@@ -1108,7 +1128,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                 # the earlier attempt already received every byte; only the
                 # terminating chunks went missing
                 response.close()
-                return self._finish_download(partial)
+                return self._finish_download(partial, elapsed_from=representation)
             received = len(partial.data)
             response.close()
             partial.clear()
@@ -1119,8 +1139,8 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
 
         accumulate = False
         if resuming and response.status_code == 206:
-            start = _range_start_bytes(response)
-            if start is not None and start == len(partial.data):
+            bounds = _content_range_bounds(response)
+            if bounds is not None and bounds[0] == len(partial.data):
                 # partial content; append the missing tail to what we already have
                 accumulate = True
             else:
@@ -1133,8 +1153,16 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                     f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
                     request=response.request,
                 )
-        elif response.status_code == 200 and _accepts_byte_ranges(response) and _is_identity_encoded(response):
-            # either no range was sent or the server ignored it; this body is complete
+        elif (
+            response.status_code == 200
+            and _accepts_byte_ranges(response)
+            and _is_identity_encoded(response)
+            and _resume_validator(response) is not None
+        ):
+            # either no range was sent or the server ignored it; this body is
+            # complete. without a strong validator a later range request could
+            # silently splice bytes from a different version of the resource,
+            # so only validator-bearing responses may be resumed
             partial.reset(response)
             accumulate = True
         elif resuming and response.status_code == 200:
@@ -1143,7 +1171,11 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             partial.clear()
 
         if not accumulate:
-            response.read()
+            try:
+                response.read()
+            except Exception:
+                response.close()
+                raise
             return response
 
         # on a 206 the original response stays the representation of the full
@@ -1156,14 +1188,23 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             # connection before the retry loop takes over
             response.close()
             raise
-        return self._finish_download(partial)
+        bounds = _content_range_bounds(response)
+        if bounds is not None and resuming and bounds[2] is not None and bounds[2] != len(partial.data):
+            # the origin served a satisfying-but-short segment; keep the bytes
+            # it did send so the next attempt resumes from the new offset
+            response.close()
+            raise httpx2.ReadError(
+                f"Partial response ended at byte {len(partial.data)} of {bounds[2]}; resuming",
+                request=response.request,
+            )
+        return self._finish_download(partial, elapsed_from=response)
 
-    def _finish_download(self, partial: _PartialDownload) -> httpx2.Response:
+    def _finish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
         representation = partial.representation
         assert representation is not None
         content = bytes(partial.data)
         partial.clear()  # release the mutable buffer before response processing
-        return _reassembled_download_response(representation, content)
+        return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
 
     @overload
     def request(
@@ -1818,7 +1859,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                 # the earlier attempt already received every byte; only the
                 # terminating chunks went missing
                 await response.aclose()
-                return await self._afinish_download(partial)
+                return await self._afinish_download(partial, elapsed_from=representation)
             received = len(partial.data)
             await response.aclose()
             partial.clear()
@@ -1829,8 +1870,8 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
 
         accumulate = False
         if resuming and response.status_code == 206:
-            start = _range_start_bytes(response)
-            if start is not None and start == len(partial.data):
+            bounds = _content_range_bounds(response)
+            if bounds is not None and bounds[0] == len(partial.data):
                 # partial content; append the missing tail to what we already have
                 accumulate = True
             else:
@@ -1843,8 +1884,16 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                     f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
                     request=response.request,
                 )
-        elif response.status_code == 200 and _accepts_byte_ranges(response) and _is_identity_encoded(response):
-            # either no range was sent or the server ignored it; this body is complete
+        elif (
+            response.status_code == 200
+            and _accepts_byte_ranges(response)
+            and _is_identity_encoded(response)
+            and _resume_validator(response) is not None
+        ):
+            # either no range was sent or the server ignored it; this body is
+            # complete. without a strong validator a later range request could
+            # silently splice bytes from a different version of the resource,
+            # so only validator-bearing responses may be resumed
             partial.reset(response)
             accumulate = True
         elif resuming and response.status_code == 200:
@@ -1853,7 +1902,11 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             partial.clear()
 
         if not accumulate:
-            await response.aread()
+            try:
+                await response.aread()
+            except Exception:
+                await response.aclose()
+                raise
             return response
 
         # on a 206 the original response stays the representation of the full
@@ -1866,14 +1919,23 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             # connection before the retry loop takes over
             await response.aclose()
             raise
-        return await self._afinish_download(partial)
+        bounds = _content_range_bounds(response)
+        if bounds is not None and resuming and bounds[2] is not None and bounds[2] != len(partial.data):
+            # the origin served a satisfying-but-short segment; keep the bytes
+            # it did send so the next attempt resumes from the new offset
+            await response.aclose()
+            raise httpx2.ReadError(
+                f"Partial response ended at byte {len(partial.data)} of {bounds[2]}; resuming",
+                request=response.request,
+            )
+        return await self._afinish_download(partial, elapsed_from=response)
 
-    async def _afinish_download(self, partial: _PartialDownload) -> httpx2.Response:
+    async def _afinish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
         representation = partial.representation
         assert representation is not None
         content = bytes(partial.data)
         partial.clear()  # release the mutable buffer before response processing
-        return _reassembled_download_response(representation, content)
+        return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
 
     @overload
     async def request(

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -107,6 +107,7 @@ from ._exceptions import (
 )
 from ._utils._json import openapi_dumps
 from ._utils._logs import get_http_method_for_logging
+from .lib._resumable import _PartialDownload, _resume_validator, read_resumable_body, aread_resumable_body
 from ._legacy_response import LegacyAPIResponse
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -122,150 +123,6 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 _StreamT = TypeVar("_StreamT", bound=Stream[Any])
 _AsyncStreamT = TypeVar("_AsyncStreamT", bound=AsyncStream[Any])
-
-
-def _accepts_byte_ranges(response: httpx2.Response) -> bool:
-    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Ranges
-    # the header is a comma-separated list of supported range units
-    value = str(response.headers.get("accept-ranges", ""))
-    return any(unit.strip() == "bytes" for unit in value.lower().split(","))
-
-
-def _is_identity_encoded(response: httpx2.Response) -> bool:
-    # byte ranges address the encoded representation, but `iter_bytes()` yields
-    # decoded bytes — resuming is only sound when the two are the same
-    value = str(response.headers.get("content-encoding", "")).strip().lower()
-    return value in ("", "identity")
-
-
-def _content_range_bounds(response: httpx2.Response) -> tuple[int, int | None, int | None] | None:
-    """Parse a `206` response's `Content-Range: bytes <start>-<end>/<total>` header.
-
-    `end` and `total` are `None` when absent or unknown (`*`). Range unit names
-    are case-insensitive, so the header is normalised before parsing.
-    """
-    value = str(response.headers.get("content-range", "")).strip().lower()
-    if not value.startswith("bytes "):
-        return None
-    try:
-        start_part, rest = value[len("bytes ") :].split("-", 1)
-        end_part, _, total_part = rest.partition("/")
-        start = int(start_part.strip())
-        end = int(end_part.strip()) if end_part.strip() not in ("", "*") else None
-        total = int(total_part.strip()) if total_part.strip() not in ("", "*") else None
-    except ValueError:
-        return None
-    return start, end, total
-
-
-def _range_total_bytes(response: httpx2.Response) -> int | None:
-    """Total size reported by a `416` response's `Content-Range: bytes */<total>` header."""
-    value = str(response.headers.get("content-range", "")).strip().lower()
-    prefix = "bytes */"
-    if not value.startswith(prefix):
-        return None
-    try:
-        return int(value[len(prefix) :].strip())
-    except ValueError:
-        return None
-
-
-class _PartialDownload:
-    """Bytes already received from a range-capable response body, plus the
-    response (headers, request, validator) that produced them."""
-
-    __slots__ = ("data", "representation")
-
-    def __init__(self) -> None:
-        self.data = bytearray()
-        self.representation: httpx2.Response | None = None
-
-    def __bool__(self) -> bool:
-        return bool(self.data)
-
-    def reset(self, response: httpx2.Response) -> None:
-        self.data.clear()
-        self.representation = response
-
-    def clear(self) -> None:
-        self.data.clear()
-        self.representation = None
-
-
-def _resume_validator(response: httpx2.Response) -> str | None:
-    """Strong validator for an `If-Range` request, from the interrupted response.
-
-    Only a strong `ETag` qualifies: a weak `W/` tag is explicitly unusable, and
-    a `Last-Modified` date cannot be assumed to be a strong validator (its
-    one-second granularity may hide changes), so both fall back to "no
-    validator" and the download restarts instead of being resumed.
-    """
-    etag = str(response.headers.get("etag", "")).strip()
-    if etag and not etag.startswith("W/"):
-        return etag
-    return None
-
-
-def _reassembled_download_response(
-    representation: httpx2.Response,
-    content: bytes,
-    *,
-    elapsed_from: httpx2.Response,
-) -> httpx2.Response:
-    headers = [
-        (key, value)
-        for key, value in representation.headers.raw
-        if key.decode("latin-1").lower() not in ("content-range", "content-length", "transfer-encoding")
-    ]
-    # keep the response class of the client that actually served the request
-    # (legacy `httpx` clients produce legacy `httpx.Response` objects)
-    response_cls = httpx2.Response if isinstance(representation, httpx2.Response) else type(representation)
-    rebuilt = response_cls(
-        200,
-        headers=headers,
-        content=content,
-        # the request/response metadata of the attempt that completed the
-        # transfer (its final URL after redirects, its request id extensions)
-        request=elapsed_from.request,
-        extensions=elapsed_from.extensions,
-        history=elapsed_from.history,
-    )
-    # keep the encoding state the serving client attached: the client-level
-    # `default_encoding` is copied as-is (a plain name, or a detector callable
-    # which then runs against the assembled body), while an encoding that was
-    # explicitly pinned on the interrupted response is preserved verbatim —
-    # a merely header-derived encoding is left to re-derive from the copied
-    # `Content-Type` header so a callable detector sees the full body
-    rebuilt.default_encoding = representation.default_encoding
-    explicit_encoding = getattr(representation, "_encoding", None)
-    if explicit_encoding is not None:
-        rebuilt.encoding = explicit_encoding
-    try:
-        rebuilt.elapsed = elapsed_from.elapsed
-    except RuntimeError:
-        # the serving transport did not record timing; leave the field unset
-        # exactly as an unread response would be
-        pass
-    return rebuilt
-
-
-def _read_and_release(response: httpx2.Response) -> None:
-    """Read a streamed response to completion, closing it if the read fails."""
-    try:
-        response.read()
-    except BaseException:
-        response.close()
-        raise
-
-
-async def _aread_and_release(response: httpx2.Response) -> None:
-    """Async counterpart of `_read_and_release`."""
-    try:
-        await response.aread()
-    except BaseException:
-        with anyio.CancelScope(shield=True):
-            await response.aclose()
-        raise
 
 
 if TYPE_CHECKING:
@@ -1151,132 +1008,6 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             response = body_reader(response)
         return response
 
-    def _read_resumable_body(
-        self,
-        response: httpx2.Response,
-        partial: _PartialDownload,
-    ) -> httpx2.Response:
-        """Read a non-streamed GET response body, resuming interrupted downloads.
-
-        Retries normally restart a failed download from the first byte, which can
-        never succeed when a transfer is deterministically cut off mid-body (for
-        example large Batch API result files). When the server advertises
-        `Accept-Ranges: bytes`, later attempts request only the bytes that are
-        still missing, so retries make forward progress instead of repeating it.
-        """
-        resuming = bool(partial)
-        if resuming and response.status_code == 416:
-            total = _range_total_bytes(response)
-            representation = partial.representation
-            assert representation is not None
-            if total is not None and total == len(partial.data):
-                # the earlier attempt already received every byte; only the
-                # terminating chunks went missing; read the (small) body so a
-                # retained reference sees a normally-consumed response
-                _read_and_release(response)
-                return self._finish_download(partial, elapsed_from=response)
-            received = len(partial.data)
-            response.close()
-            partial.clear()
-            raise httpx2.ReadError(
-                f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
-                request=representation.request,
-            )
-
-        accumulate = False
-        if resuming and response.status_code == 206:
-            bounds = _content_range_bounds(response)
-            if bounds is not None and bounds[0] == len(partial.data):
-                # partial content; append the missing tail to what we already have
-                accumulate = True
-            else:
-                # unsolicited or misaligned range — our offset is unusable for
-                # this origin, so start over on the next attempt
-                received = len(partial.data)
-                response.close()
-                partial.clear()
-                raise httpx2.ReadError(
-                    f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
-                    request=response.request,
-                )
-        elif (
-            response.status_code == 200
-            and _accepts_byte_ranges(response)
-            and _is_identity_encoded(response)
-            and _resume_validator(response) is not None
-        ):
-            # either no range was sent or the server ignored it; this body is
-            # complete. without a strong validator a later range request could
-            # silently splice bytes from a different version of the resource,
-            # so only validator-bearing responses may be resumed
-            partial.reset(response)
-            accumulate = True
-        elif resuming and response.status_code == 200:
-            # the retry delivered a complete replacement body; any partial bytes
-            # are superseded
-            partial.clear()
-
-        if not accumulate:
-            _read_and_release(response)
-            return response
-
-        # on a 206 the original response stays the representation of the full
-        # body (headers, validator, request); a 200 restart already replaced it
-        delivered = bytearray()
-        try:
-            for chunk in response.iter_bytes():
-                partial.data.extend(chunk)
-                delivered.extend(chunk)
-        except BaseException:
-            # the stream is left open when the body read fails; release the
-            # connection before the retry loop takes over
-            response.close()
-            raise
-        # exactly what a non-streaming send() would have left on this response:
-        # its own body, so retained references see metadata and content that
-        # agree (a 206 keeps its suffix-sized body, not the assembled one)
-        response._content = bytes(delivered)
-        bounds = _content_range_bounds(response)
-        if resuming and bounds is not None:
-            start, end, total = bounds
-            if end is not None and len(delivered) != end - start + 1:
-                # the delivered body contradicts the advertised range extent
-                response.close()
-                partial.clear()
-                raise httpx2.ReadError(
-                    "Partial response body does not match its Content-Range; restarting from scratch",
-                    request=response.request,
-                )
-            if total is None or total != len(partial.data):
-                response.close()
-                if total is None:
-                    # the total length is unknown, so completeness can never be
-                    # proven; restart with a plain full download instead
-                    partial.clear()
-                    raise httpx2.ReadError(
-                        "Partial response does not report a total length; restarting from scratch",
-                        request=response.request,
-                    )
-                # the origin served a satisfying-but-short segment; keep the bytes
-                # it did send so the next attempt resumes from the new offset
-                raise httpx2.ReadError(
-                    f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
-                    request=response.request,
-                )
-        return self._finish_download(partial, elapsed_from=response)
-
-    def _finish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
-        representation = partial.representation
-        assert representation is not None
-        # hand off the buffer instead of emptying it in place, so the mutable
-        # copy stops being reachable the moment the immutable one exists
-        buffer = partial.data
-        partial.data = bytearray()
-        partial.representation = None
-        content = bytes(buffer)
-        del buffer
-        return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
-
     @overload
     def request(
         self,
@@ -1370,7 +1101,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             log.debug("Sending HTTP Request: %s", get_http_method_for_logging(request.method))
 
             def resumable_reader(response_: httpx2.Response) -> httpx2.Response:
-                return self._read_resumable_body(response_, partial_download)
+                return read_resumable_body(response_, partial_download)
 
             response = None
             try:
@@ -1925,126 +1656,6 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             response = await body_reader(response)
         return response
 
-    async def _aread_resumable_body(
-        self,
-        response: httpx2.Response,
-        partial: _PartialDownload,
-    ) -> httpx2.Response:
-        """Async counterpart of `_read_resumable_body`."""
-        resuming = bool(partial)
-        if resuming and response.status_code == 416:
-            total = _range_total_bytes(response)
-            representation = partial.representation
-            assert representation is not None
-            if total is not None and total == len(partial.data):
-                # the earlier attempt already received every byte; only the
-                # terminating chunks went missing; read the (small) body so a
-                # retained reference sees a normally-consumed response
-                await _aread_and_release(response)
-                return await self._afinish_download(partial, elapsed_from=response)
-            received = len(partial.data)
-            await response.aclose()
-            partial.clear()
-            raise httpx2.ReadError(
-                f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
-                request=representation.request,
-            )
-
-        accumulate = False
-        if resuming and response.status_code == 206:
-            bounds = _content_range_bounds(response)
-            if bounds is not None and bounds[0] == len(partial.data):
-                # partial content; append the missing tail to what we already have
-                accumulate = True
-            else:
-                # unsolicited or misaligned range — our offset is unusable for
-                # this origin, so start over on the next attempt
-                received = len(partial.data)
-                await response.aclose()
-                partial.clear()
-                raise httpx2.ReadError(
-                    f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
-                    request=response.request,
-                )
-        elif (
-            response.status_code == 200
-            and _accepts_byte_ranges(response)
-            and _is_identity_encoded(response)
-            and _resume_validator(response) is not None
-        ):
-            # either no range was sent or the server ignored it; this body is
-            # complete. without a strong validator a later range request could
-            # silently splice bytes from a different version of the resource,
-            # so only validator-bearing responses may be resumed
-            partial.reset(response)
-            accumulate = True
-        elif resuming and response.status_code == 200:
-            # the retry delivered a complete replacement body; any partial bytes
-            # are superseded
-            partial.clear()
-
-        if not accumulate:
-            await _aread_and_release(response)
-            return response
-
-        # on a 206 the original response stays the representation of the full
-        # body (headers, validator, request); a 200 restart already replaced it
-        delivered = bytearray()
-        try:
-            async for chunk in response.aiter_bytes():
-                partial.data.extend(chunk)
-                delivered.extend(chunk)
-        except BaseException:
-            # includes CancelledError; shield the close so a level-triggered
-            # cancellation cannot interrupt the cleanup itself
-            with anyio.CancelScope(shield=True):
-                await response.aclose()
-            raise
-        # exactly what a non-streaming send() would have left on this response:
-        # its own body, so retained references see metadata and content that
-        # agree (a 206 keeps its suffix-sized body, not the assembled one)
-        response._content = bytes(delivered)
-        bounds = _content_range_bounds(response)
-        if resuming and bounds is not None:
-            start, end, total = bounds
-            if end is not None and len(delivered) != end - start + 1:
-                # the delivered body contradicts the advertised range extent
-                await response.aclose()
-                partial.clear()
-                raise httpx2.ReadError(
-                    "Partial response body does not match its Content-Range; restarting from scratch",
-                    request=response.request,
-                )
-            if total is None or total != len(partial.data):
-                await response.aclose()
-                if total is None:
-                    # the total length is unknown, so completeness can never be
-                    # proven; restart with a plain full download instead
-                    partial.clear()
-                    raise httpx2.ReadError(
-                        "Partial response does not report a total length; restarting from scratch",
-                        request=response.request,
-                    )
-                # the origin served a satisfying-but-short segment; keep the bytes
-                # it did send so the next attempt resumes from the new offset
-                raise httpx2.ReadError(
-                    f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
-                    request=response.request,
-                )
-        return await self._afinish_download(partial, elapsed_from=response)
-
-    async def _afinish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
-        representation = partial.representation
-        assert representation is not None
-        # hand off the buffer instead of emptying it in place, so the mutable
-        # copy stops being reachable the moment the immutable one exists
-        buffer = partial.data
-        partial.data = bytearray()
-        partial.representation = None
-        content = bytes(buffer)
-        del buffer
-        return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
-
     @overload
     async def request(
         self,
@@ -2142,7 +1753,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             log.debug("Sending HTTP Request: %s", get_http_method_for_logging(request.method))
 
             async def resumable_reader(response_: httpx2.Response) -> httpx2.Response:
-                return await self._aread_resumable_body(response_, partial_download)
+                return await aread_resumable_body(response_, partial_download)
 
             response = None
             try:

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -23,9 +23,11 @@ from typing import (
     Generic,
     Mapping,
     TypeVar,
+    Callable,
     Iterable,
     Iterator,
     Optional,
+    Awaitable,
     Generator,
     AsyncIterator,
     cast,
@@ -1139,9 +1141,15 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         request: httpx2.Request,
         *,
         stream: bool,
+        body_reader: Callable[[httpx2.Response], httpx2.Response] | None = None,
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
-        return self._client.send(request, stream=stream, **kwargs)
+        response = self._client.send(request, stream=stream, **kwargs)
+        if body_reader is not None:
+            # consumes a streamed body before any subclass-level response
+            # normalisation sees it, preserving the non-streaming contract
+            response = body_reader(response)
+        return response
 
     def _read_resumable_body(
         self,
@@ -1229,22 +1237,32 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         # agree (a 206 keeps its suffix-sized body, not the assembled one)
         response._content = bytes(delivered)
         bounds = _content_range_bounds(response)
-        if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
-            response.close()
-            if bounds[2] is None:
-                # the total length is unknown, so completeness can never be
-                # proven; restart with a plain full download instead
+        if resuming and bounds is not None:
+            start, end, total = bounds
+            if end is not None and len(delivered) != end - start + 1:
+                # the delivered body contradicts the advertised range extent
+                response.close()
                 partial.clear()
                 raise httpx2.ReadError(
-                    "Partial response does not report a total length; restarting from scratch",
+                    "Partial response body does not match its Content-Range; restarting from scratch",
                     request=response.request,
                 )
-            # the origin served a satisfying-but-short segment; keep the bytes
-            # it did send so the next attempt resumes from the new offset
-            raise httpx2.ReadError(
-                f"Partial response ended at byte {len(partial.data)} of {bounds[2]}; resuming",
-                request=response.request,
-            )
+            if total is None or total != len(partial.data):
+                response.close()
+                if total is None:
+                    # the total length is unknown, so completeness can never be
+                    # proven; restart with a plain full download instead
+                    partial.clear()
+                    raise httpx2.ReadError(
+                        "Partial response does not report a total length; restarting from scratch",
+                        request=response.request,
+                    )
+                # the origin served a satisfying-but-short segment; keep the bytes
+                # it did send so the next attempt resumes from the new offset
+                raise httpx2.ReadError(
+                    f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
+                    request=response.request,
+                )
         return self._finish_download(partial, elapsed_from=response)
 
     def _finish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
@@ -1321,7 +1339,6 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
 
             remaining_retries = max_retries - retries_taken
             request = self._build_request(options, retries_taken=retries_taken)
-            self._prepare_request(request)
 
             resumable_attempt = resumable_download and not self._should_stream_response_body(request)
             if resumable_attempt and partial_download:
@@ -1334,6 +1351,9 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                 validator = _resume_validator(representation)
                 if validator is not None:
                     request.headers["If-Range"] = validator
+
+            # prepare (and sign) the request only after every header is final
+            self._prepare_request(request)
 
             kwargs: HttpxSendArgs = {}
             custom_auth = self._custom_auth(options.security)
@@ -1349,15 +1369,17 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
 
             log.debug("Sending HTTP Request: %s", get_http_method_for_logging(request.method))
 
+            def resumable_reader(response_: httpx2.Response) -> httpx2.Response:
+                return self._read_resumable_body(response_, partial_download)
+
             response = None
             try:
                 response = self._send_request(
                     request,
                     stream=stream or self._should_stream_response_body(request=request) or resumable_attempt,
+                    body_reader=resumable_reader if resumable_attempt else None,
                     **kwargs,
                 )
-                if resumable_attempt:
-                    response = self._read_resumable_body(response, partial_download)
             except timeout_exceptions() as err:
                 log.debug("Encountered a timeout exception: %s", type(err).__name__)
 
@@ -1893,9 +1915,15 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
         request: httpx2.Request,
         *,
         stream: bool,
+        body_reader: Callable[[httpx2.Response], Awaitable[httpx2.Response]] | None = None,
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
-        return await self._client.send(request, stream=stream, **kwargs)
+        response = await self._client.send(request, stream=stream, **kwargs)
+        if body_reader is not None:
+            # consumes a streamed body before any subclass-level response
+            # normalisation sees it, preserving the non-streaming contract
+            response = await body_reader(response)
+        return response
 
     async def _aread_resumable_body(
         self,
@@ -1977,22 +2005,32 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
         # agree (a 206 keeps its suffix-sized body, not the assembled one)
         response._content = bytes(delivered)
         bounds = _content_range_bounds(response)
-        if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
-            await response.aclose()
-            if bounds[2] is None:
-                # the total length is unknown, so completeness can never be
-                # proven; restart with a plain full download instead
+        if resuming and bounds is not None:
+            start, end, total = bounds
+            if end is not None and len(delivered) != end - start + 1:
+                # the delivered body contradicts the advertised range extent
+                await response.aclose()
                 partial.clear()
                 raise httpx2.ReadError(
-                    "Partial response does not report a total length; restarting from scratch",
+                    "Partial response body does not match its Content-Range; restarting from scratch",
                     request=response.request,
                 )
-            # the origin served a satisfying-but-short segment; keep the bytes
-            # it did send so the next attempt resumes from the new offset
-            raise httpx2.ReadError(
-                f"Partial response ended at byte {len(partial.data)} of {bounds[2]}; resuming",
-                request=response.request,
-            )
+            if total is None or total != len(partial.data):
+                await response.aclose()
+                if total is None:
+                    # the total length is unknown, so completeness can never be
+                    # proven; restart with a plain full download instead
+                    partial.clear()
+                    raise httpx2.ReadError(
+                        "Partial response does not report a total length; restarting from scratch",
+                        request=response.request,
+                    )
+                # the origin served a satisfying-but-short segment; keep the bytes
+                # it did send so the next attempt resumes from the new offset
+                raise httpx2.ReadError(
+                    f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
+                    request=response.request,
+                )
         return await self._afinish_download(partial, elapsed_from=response)
 
     async def _afinish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
@@ -2074,7 +2112,6 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
 
             remaining_retries = max_retries - retries_taken
             request = self._build_request(options, retries_taken=retries_taken)
-            await self._prepare_request(request)
 
             resumable_attempt = resumable_download and not self._should_stream_response_body(request)
             if resumable_attempt and partial_download:
@@ -2087,6 +2124,9 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                 validator = _resume_validator(representation)
                 if validator is not None:
                     request.headers["If-Range"] = validator
+
+            # prepare (and sign) the request only after every header is final
+            await self._prepare_request(request)
 
             kwargs: HttpxSendArgs = {}
             if self.custom_auth is not None:
@@ -2101,15 +2141,17 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
 
             log.debug("Sending HTTP Request: %s", get_http_method_for_logging(request.method))
 
+            async def resumable_reader(response_: httpx2.Response) -> httpx2.Response:
+                return await self._aread_resumable_body(response_, partial_download)
+
             response = None
             try:
                 response = await self._send_request(
                     request,
                     stream=stream or self._should_stream_response_body(request=request) or resumable_attempt,
+                    body_reader=resumable_reader if resumable_attempt else None,
                     **kwargs,
                 )
-                if resumable_attempt:
-                    response = await self._aread_resumable_body(response, partial_download)
             except timeout_exceptions() as err:
                 log.debug("Encountered a timeout exception: %s", type(err).__name__)
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -128,6 +128,24 @@ def _accepts_byte_ranges(response: httpx2.Response) -> bool:
     return value.strip().lower() == "bytes"
 
 
+def _is_identity_encoded(response: httpx2.Response) -> bool:
+    # byte ranges address the encoded representation, but `iter_bytes()` yields
+    # decoded bytes — resuming is only sound when the two are the same
+    value = str(response.headers.get("content-encoding", "")).strip().lower()
+    return value in ("", "identity")
+
+
+def _range_start_bytes(response: httpx2.Response) -> int | None:
+    """Start offset reported by a `206` response's `Content-Range: bytes <start>-…` header."""
+    value = str(response.headers.get("content-range", ""))
+    if not value.startswith("bytes "):
+        return None
+    try:
+        return int(value[len("bytes ") :].split("-", 1)[0].strip())
+    except ValueError:
+        return None
+
+
 def _range_total_bytes(response: httpx2.Response) -> int | None:
     """Total size reported by a `416` response's `Content-Range: bytes */<total>` header."""
     value = str(response.headers.get("content-range", ""))
@@ -140,23 +158,54 @@ def _range_total_bytes(response: httpx2.Response) -> int | None:
         return None
 
 
-def _reassembled_download_response(
-    request: httpx2.Request,
-    response: httpx2.Response,
-    content: bytes,
-) -> httpx2.Response:
+class _PartialDownload:
+    """Bytes already received from a range-capable response body, plus the
+    response (headers, request, validator) that produced them."""
+
+    __slots__ = ("data", "representation")
+
+    def __init__(self) -> None:
+        self.data = bytearray()
+        self.representation: httpx2.Response | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.data)
+
+    def reset(self, response: httpx2.Response) -> None:
+        self.data.clear()
+        self.representation = response
+
+    def clear(self) -> None:
+        self.data.clear()
+        self.representation = None
+
+
+def _resume_validator(response: httpx2.Response) -> str | None:
+    """Strong validator for an `If-Range` request, from the interrupted response."""
+    etag = str(response.headers.get("etag", "")).strip()
+    if etag and not etag.startswith("W/"):
+        return etag
+    last_modified = str(response.headers.get("last-modified", "")).strip()
+    return last_modified or None
+
+
+def _reassembled_download_response(representation: httpx2.Response, content: bytes) -> httpx2.Response:
     headers = [
         (key, value)
-        for key, value in response.headers.raw
+        for key, value in representation.headers.raw
         if key.decode("latin-1").lower() not in ("content-range", "content-length", "transfer-encoding")
     ]
-    return httpx2.Response(
+    # keep the response class of the client that actually served the request
+    # (legacy `httpx` clients produce legacy `httpx.Response` objects)
+    response_cls = httpx2.Response if isinstance(representation, httpx2.Response) else type(representation)
+    return response_cls(
         200,
         headers=headers,
         content=content,
-        request=request,
-        extensions=response.extensions,
-        history=response.history,
+        # the request as it was actually sent (post-redirect, post-auth)
+        request=representation.request,
+        extensions=representation.extensions,
+        history=representation.history,
     )
 
 
@@ -1039,9 +1088,8 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
 
     def _read_resumable_body(
         self,
-        request: httpx2.Request,
         response: httpx2.Response,
-        partial: bytearray,
+        partial: _PartialDownload,
     ) -> httpx2.Response:
         """Read a non-streamed GET response body, resuming interrupted downloads.
 
@@ -1054,33 +1102,68 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         resuming = bool(partial)
         if resuming and response.status_code == 416:
             total = _range_total_bytes(response)
-            if total is not None and total == len(partial):
+            representation = partial.representation
+            assert representation is not None
+            if total is not None and total == len(partial.data):
                 # the earlier attempt already received every byte; only the
                 # terminating chunks went missing
-                return _reassembled_download_response(request, response, bytes(partial))
-            received = len(partial)
+                response.close()
+                return self._finish_download(partial)
+            received = len(partial.data)
+            response.close()
             partial.clear()
             raise httpx2.ReadError(
                 f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
-                request=request,
+                request=representation.request,
             )
 
         accumulate = False
         if resuming and response.status_code == 206:
-            # partial content; append the missing tail to what we already have
-            accumulate = True
-        elif response.status_code == 200 and _accepts_byte_ranges(response):
+            start = _range_start_bytes(response)
+            if start is not None and start == len(partial.data):
+                # partial content; append the missing tail to what we already have
+                accumulate = True
+            else:
+                # unsolicited or misaligned range — our offset is unusable for
+                # this origin, so start over on the next attempt
+                received = len(partial.data)
+                response.close()
+                partial.clear()
+                raise httpx2.ReadError(
+                    f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
+                    request=response.request,
+                )
+        elif response.status_code == 200 and _accepts_byte_ranges(response) and _is_identity_encoded(response):
             # either no range was sent or the server ignored it; this body is complete
-            partial.clear()
+            partial.reset(response)
             accumulate = True
+        elif resuming and response.status_code == 200:
+            # the retry delivered a complete replacement body; any partial bytes
+            # are superseded
+            partial.clear()
 
         if not accumulate:
             response.read()
             return response
 
-        for chunk in response.iter_bytes():
-            partial.extend(chunk)
-        return _reassembled_download_response(request, response, bytes(partial))
+        # on a 206 the original response stays the representation of the full
+        # body (headers, validator, request); a 200 restart already replaced it
+        try:
+            for chunk in response.iter_bytes():
+                partial.data.extend(chunk)
+        except Exception:
+            # the stream is left open when the body read fails; release the
+            # connection before the retry loop takes over
+            response.close()
+            raise
+        return self._finish_download(partial)
+
+    def _finish_download(self, partial: _PartialDownload) -> httpx2.Response:
+        representation = partial.representation
+        assert representation is not None
+        content = bytes(partial.data)
+        partial.clear()  # release the mutable buffer before response processing
+        return _reassembled_download_response(representation, content)
 
     @overload
     def request(
@@ -1135,7 +1218,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         # GET responses are idempotent, so an interrupted body can be resumed
         # with a `Range` request once the server told us it supports byte ranges
         resumable_download = input_options.method.lower() == "get" and not stream
-        partial_download = bytearray()
+        partial_download = _PartialDownload()
 
         retries_taken = 0
         for retries_taken in range(max_retries + 1):
@@ -1148,8 +1231,15 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
 
             resumable_attempt = resumable_download and not self._should_stream_response_body(request)
             if resumable_attempt and partial_download:
-                log.debug("Resuming interrupted download from byte %i", len(partial_download))
-                request.headers["Range"] = f"bytes={len(partial_download)}-"
+                log.debug("Resuming interrupted download from byte %i", len(partial_download.data))
+                request.headers["Range"] = f"bytes={len(partial_download.data)}-"
+                representation = partial_download.representation
+                assert representation is not None
+                # make the range conditional so a changed resource is re-downloaded
+                # in full instead of being spliced from two different versions
+                validator = _resume_validator(representation)
+                if validator is not None:
+                    request.headers["If-Range"] = validator
 
             kwargs: HttpxSendArgs = {}
             custom_auth = self._custom_auth(options.security)
@@ -1173,7 +1263,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                     **kwargs,
                 )
                 if resumable_attempt:
-                    response = self._read_resumable_body(request, response, partial_download)
+                    response = self._read_resumable_body(response, partial_download)
             except timeout_exceptions() as err:
                 log.debug("Encountered a timeout exception: %s", type(err).__name__)
 
@@ -1715,41 +1805,75 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
 
     async def _aread_resumable_body(
         self,
-        request: httpx2.Request,
         response: httpx2.Response,
-        partial: bytearray,
+        partial: _PartialDownload,
     ) -> httpx2.Response:
         """Async counterpart of `_read_resumable_body`."""
         resuming = bool(partial)
         if resuming and response.status_code == 416:
             total = _range_total_bytes(response)
-            if total is not None and total == len(partial):
+            representation = partial.representation
+            assert representation is not None
+            if total is not None and total == len(partial.data):
                 # the earlier attempt already received every byte; only the
                 # terminating chunks went missing
-                return _reassembled_download_response(request, response, bytes(partial))
-            received = len(partial)
+                await response.aclose()
+                return await self._afinish_download(partial)
+            received = len(partial.data)
+            await response.aclose()
             partial.clear()
             raise httpx2.ReadError(
                 f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
-                request=request,
+                request=representation.request,
             )
 
         accumulate = False
         if resuming and response.status_code == 206:
-            # partial content; append the missing tail to what we already have
-            accumulate = True
-        elif response.status_code == 200 and _accepts_byte_ranges(response):
+            start = _range_start_bytes(response)
+            if start is not None and start == len(partial.data):
+                # partial content; append the missing tail to what we already have
+                accumulate = True
+            else:
+                # unsolicited or misaligned range — our offset is unusable for
+                # this origin, so start over on the next attempt
+                received = len(partial.data)
+                await response.aclose()
+                partial.clear()
+                raise httpx2.ReadError(
+                    f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
+                    request=response.request,
+                )
+        elif response.status_code == 200 and _accepts_byte_ranges(response) and _is_identity_encoded(response):
             # either no range was sent or the server ignored it; this body is complete
-            partial.clear()
+            partial.reset(response)
             accumulate = True
+        elif resuming and response.status_code == 200:
+            # the retry delivered a complete replacement body; any partial bytes
+            # are superseded
+            partial.clear()
 
         if not accumulate:
             await response.aread()
             return response
 
-        async for chunk in response.aiter_bytes():
-            partial.extend(chunk)
-        return _reassembled_download_response(request, response, bytes(partial))
+        # on a 206 the original response stays the representation of the full
+        # body (headers, validator, request); a 200 restart already replaced it
+        try:
+            async for chunk in response.aiter_bytes():
+                partial.data.extend(chunk)
+        except Exception:
+            # the stream is left open when the body read fails; release the
+            # connection before the retry loop takes over
+            await response.aclose()
+            raise
+        return await self._afinish_download(partial)
+
+    async def _afinish_download(self, partial: _PartialDownload) -> httpx2.Response:
+        representation = partial.representation
+        assert representation is not None
+        content = bytes(partial.data)
+        partial.clear()  # release the mutable buffer before response processing
+        return _reassembled_download_response(representation, content)
 
     @overload
     async def request(
@@ -1809,7 +1933,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
         # GET responses are idempotent, so an interrupted body can be resumed
         # with a `Range` request once the server told us it supports byte ranges
         resumable_download = input_options.method.lower() == "get" and not stream
-        partial_download = bytearray()
+        partial_download = _PartialDownload()
 
         retries_taken = 0
         for retries_taken in range(max_retries + 1):
@@ -1822,8 +1946,15 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
 
             resumable_attempt = resumable_download and not self._should_stream_response_body(request)
             if resumable_attempt and partial_download:
-                log.debug("Resuming interrupted download from byte %i", len(partial_download))
-                request.headers["Range"] = f"bytes={len(partial_download)}-"
+                log.debug("Resuming interrupted download from byte %i", len(partial_download.data))
+                request.headers["Range"] = f"bytes={len(partial_download.data)}-"
+                representation = partial_download.representation
+                assert representation is not None
+                # make the range conditional so a changed resource is re-downloaded
+                # in full instead of being spliced from two different versions
+                validator = _resume_validator(representation)
+                if validator is not None:
+                    request.headers["If-Range"] = validator
 
             kwargs: HttpxSendArgs = {}
             if self.custom_auth is not None:
@@ -1846,7 +1977,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                     **kwargs,
                 )
                 if resumable_attempt:
-                    response = await self._aread_resumable_body(request, response, partial_download)
+                    response = await self._aread_resumable_body(response, partial_download)
             except timeout_exceptions() as err:
                 log.debug("Encountered a timeout exception: %s", type(err).__name__)
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -121,6 +121,45 @@ _T_co = TypeVar("_T_co", covariant=True)
 _StreamT = TypeVar("_StreamT", bound=Stream[Any])
 _AsyncStreamT = TypeVar("_AsyncStreamT", bound=AsyncStream[Any])
 
+
+def _accepts_byte_ranges(response: httpx2.Response) -> bool:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Ranges
+    value = str(response.headers.get("accept-ranges", ""))
+    return value.strip().lower() == "bytes"
+
+
+def _range_total_bytes(response: httpx2.Response) -> int | None:
+    """Total size reported by a `416` response's `Content-Range: bytes */<total>` header."""
+    value = str(response.headers.get("content-range", ""))
+    prefix = "bytes */"
+    if not value.startswith(prefix):
+        return None
+    try:
+        return int(value[len(prefix) :].strip())
+    except ValueError:
+        return None
+
+
+def _reassembled_download_response(
+    request: httpx2.Request,
+    response: httpx2.Response,
+    content: bytes,
+) -> httpx2.Response:
+    headers = [
+        (key, value)
+        for key, value in response.headers.raw
+        if key.decode("latin-1").lower() not in ("content-range", "content-length", "transfer-encoding")
+    ]
+    return httpx2.Response(
+        200,
+        headers=headers,
+        content=content,
+        request=request,
+        extensions=response.extensions,
+        history=response.history,
+    )
+
+
 if TYPE_CHECKING:
     from httpx2._config import (
         DEFAULT_TIMEOUT_CONFIG,  # pyright: ignore[reportPrivateImportUsage]
@@ -998,6 +1037,51 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
     ) -> httpx2.Response:
         return self._client.send(request, stream=stream, **kwargs)
 
+    def _read_resumable_body(
+        self,
+        request: httpx2.Request,
+        response: httpx2.Response,
+        partial: bytearray,
+    ) -> httpx2.Response:
+        """Read a non-streamed GET response body, resuming interrupted downloads.
+
+        Retries normally restart a failed download from the first byte, which can
+        never succeed when a transfer is deterministically cut off mid-body (for
+        example large Batch API result files). When the server advertises
+        `Accept-Ranges: bytes`, later attempts request only the bytes that are
+        still missing, so retries make forward progress instead of repeating it.
+        """
+        resuming = bool(partial)
+        if resuming and response.status_code == 416:
+            total = _range_total_bytes(response)
+            if total is not None and total == len(partial):
+                # the earlier attempt already received every byte; only the
+                # terminating chunks went missing
+                return _reassembled_download_response(request, response, bytes(partial))
+            received = len(partial)
+            partial.clear()
+            raise httpx2.ReadError(
+                f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
+                request=request,
+            )
+
+        accumulate = False
+        if resuming and response.status_code == 206:
+            # partial content; append the missing tail to what we already have
+            accumulate = True
+        elif response.status_code == 200 and _accepts_byte_ranges(response):
+            # either no range was sent or the server ignored it; this body is complete
+            partial.clear()
+            accumulate = True
+
+        if not accumulate:
+            response.read()
+            return response
+
+        for chunk in response.iter_bytes():
+            partial.extend(chunk)
+        return _reassembled_download_response(request, response, bytes(partial))
+
     @overload
     def request(
         self,
@@ -1048,6 +1132,11 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         response: httpx2.Response | None = None
         max_retries = input_options.get_max_retries(self.max_retries)
 
+        # GET responses are idempotent, so an interrupted body can be resumed
+        # with a `Range` request once the server told us it supports byte ranges
+        resumable_download = input_options.method.lower() == "get" and not stream
+        partial_download = bytearray()
+
         retries_taken = 0
         for retries_taken in range(max_retries + 1):
             options = model_copy(input_options)
@@ -1056,6 +1145,11 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             remaining_retries = max_retries - retries_taken
             request = self._build_request(options, retries_taken=retries_taken)
             self._prepare_request(request)
+
+            resumable_attempt = resumable_download and not self._should_stream_response_body(request)
+            if resumable_attempt and partial_download:
+                log.debug("Resuming interrupted download from byte %i", len(partial_download))
+                request.headers["Range"] = f"bytes={len(partial_download)}-"
 
             kwargs: HttpxSendArgs = {}
             custom_auth = self._custom_auth(options.security)
@@ -1075,9 +1169,11 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             try:
                 response = self._send_request(
                     request,
-                    stream=stream or self._should_stream_response_body(request=request),
+                    stream=stream or self._should_stream_response_body(request=request) or resumable_attempt,
                     **kwargs,
                 )
+                if resumable_attempt:
+                    response = self._read_resumable_body(request, response, partial_download)
             except timeout_exceptions() as err:
                 log.debug("Encountered a timeout exception: %s", type(err).__name__)
 
@@ -1617,6 +1713,44 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
     ) -> httpx2.Response:
         return await self._client.send(request, stream=stream, **kwargs)
 
+    async def _aread_resumable_body(
+        self,
+        request: httpx2.Request,
+        response: httpx2.Response,
+        partial: bytearray,
+    ) -> httpx2.Response:
+        """Async counterpart of `_read_resumable_body`."""
+        resuming = bool(partial)
+        if resuming and response.status_code == 416:
+            total = _range_total_bytes(response)
+            if total is not None and total == len(partial):
+                # the earlier attempt already received every byte; only the
+                # terminating chunks went missing
+                return _reassembled_download_response(request, response, bytes(partial))
+            received = len(partial)
+            partial.clear()
+            raise httpx2.ReadError(
+                f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
+                request=request,
+            )
+
+        accumulate = False
+        if resuming and response.status_code == 206:
+            # partial content; append the missing tail to what we already have
+            accumulate = True
+        elif response.status_code == 200 and _accepts_byte_ranges(response):
+            # either no range was sent or the server ignored it; this body is complete
+            partial.clear()
+            accumulate = True
+
+        if not accumulate:
+            await response.aread()
+            return response
+
+        async for chunk in response.aiter_bytes():
+            partial.extend(chunk)
+        return _reassembled_download_response(request, response, bytes(partial))
+
     @overload
     async def request(
         self,
@@ -1672,6 +1806,11 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
         response: httpx2.Response | None = None
         max_retries = input_options.get_max_retries(self.max_retries)
 
+        # GET responses are idempotent, so an interrupted body can be resumed
+        # with a `Range` request once the server told us it supports byte ranges
+        resumable_download = input_options.method.lower() == "get" and not stream
+        partial_download = bytearray()
+
         retries_taken = 0
         for retries_taken in range(max_retries + 1):
             options = model_copy(input_options)
@@ -1680,6 +1819,11 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             remaining_retries = max_retries - retries_taken
             request = self._build_request(options, retries_taken=retries_taken)
             await self._prepare_request(request)
+
+            resumable_attempt = resumable_download and not self._should_stream_response_body(request)
+            if resumable_attempt and partial_download:
+                log.debug("Resuming interrupted download from byte %i", len(partial_download))
+                request.headers["Range"] = f"bytes={len(partial_download)}-"
 
             kwargs: HttpxSendArgs = {}
             if self.custom_auth is not None:
@@ -1698,9 +1842,11 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             try:
                 response = await self._send_request(
                     request,
-                    stream=stream or self._should_stream_response_body(request=request),
+                    stream=stream or self._should_stream_response_body(request=request) or resumable_attempt,
                     **kwargs,
                 )
+                if resumable_attempt:
+                    response = await self._aread_resumable_body(request, response, partial_download)
             except timeout_exceptions() as err:
                 log.debug("Encountered a timeout exception: %s", type(err).__name__)
 

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -138,9 +138,10 @@ def _is_identity_encoded(response: httpx2.Response) -> bool:
 def _content_range_bounds(response: httpx2.Response) -> tuple[int, int | None, int | None] | None:
     """Parse a `206` response's `Content-Range: bytes <start>-<end>/<total>` header.
 
-    `end` and `total` are `None` when absent or unknown (`*`).
+    `end` and `total` are `None` when absent or unknown (`*`). Range unit names
+    are case-insensitive, so the header is normalised before parsing.
     """
-    value = str(response.headers.get("content-range", ""))
+    value = str(response.headers.get("content-range", "")).strip().lower()
     if not value.startswith("bytes "):
         return None
     try:
@@ -156,7 +157,7 @@ def _content_range_bounds(response: httpx2.Response) -> tuple[int, int | None, i
 
 def _range_total_bytes(response: httpx2.Response) -> int | None:
     """Total size reported by a `416` response's `Content-Range: bytes */<total>` header."""
-    value = str(response.headers.get("content-range", ""))
+    value = str(response.headers.get("content-range", "")).strip().lower()
     prefix = "bytes */"
     if not value.startswith(prefix):
         return None
@@ -189,12 +190,17 @@ class _PartialDownload:
 
 
 def _resume_validator(response: httpx2.Response) -> str | None:
-    """Strong validator for an `If-Range` request, from the interrupted response."""
+    """Strong validator for an `If-Range` request, from the interrupted response.
+
+    Only a strong `ETag` qualifies: a weak `W/` tag is explicitly unusable, and
+    a `Last-Modified` date cannot be assumed to be a strong validator (its
+    one-second granularity may hide changes), so both fall back to "no
+    validator" and the download restarts instead of being resumed.
+    """
     etag = str(response.headers.get("etag", "")).strip()
     if etag and not etag.startswith("W/"):
         return etag
-    last_modified = str(response.headers.get("last-modified", "")).strip()
-    return last_modified or None
+    return None
 
 
 def _reassembled_download_response(
@@ -1173,7 +1179,9 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         if not accumulate:
             try:
                 response.read()
-            except Exception:
+            except BaseException:
+                # includes KeyboardInterrupt and other BaseExceptions — the
+                # stream must not outlive the failed read either way
                 response.close()
                 raise
             return response
@@ -1183,16 +1191,24 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
         try:
             for chunk in response.iter_bytes():
                 partial.data.extend(chunk)
-        except Exception:
+        except BaseException:
             # the stream is left open when the body read fails; release the
             # connection before the retry loop takes over
             response.close()
             raise
         bounds = _content_range_bounds(response)
-        if bounds is not None and resuming and bounds[2] is not None and bounds[2] != len(partial.data):
+        if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
+            response.close()
+            if bounds[2] is None:
+                # the total length is unknown, so completeness can never be
+                # proven; restart with a plain full download instead
+                partial.clear()
+                raise httpx2.ReadError(
+                    "Partial response does not report a total length; restarting from scratch",
+                    request=response.request,
+                )
             # the origin served a satisfying-but-short segment; keep the bytes
             # it did send so the next attempt resumes from the new offset
-            response.close()
             raise httpx2.ReadError(
                 f"Partial response ended at byte {len(partial.data)} of {bounds[2]}; resuming",
                 request=response.request,
@@ -1904,7 +1920,9 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
         if not accumulate:
             try:
                 await response.aread()
-            except Exception:
+            except BaseException:
+                # includes CancelledError and other BaseExceptions — the stream
+                # must not outlive the failed read either way
                 await response.aclose()
                 raise
             return response
@@ -1914,16 +1932,24 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
         try:
             async for chunk in response.aiter_bytes():
                 partial.data.extend(chunk)
-        except Exception:
-            # the stream is left open when the body read fails; release the
-            # connection before the retry loop takes over
+        except BaseException:
+            # the stream is left open when the body read fails or the task is
+            # cancelled; release the connection before propagating
             await response.aclose()
             raise
         bounds = _content_range_bounds(response)
-        if bounds is not None and resuming and bounds[2] is not None and bounds[2] != len(partial.data):
+        if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
+            await response.aclose()
+            if bounds[2] is None:
+                # the total length is unknown, so completeness can never be
+                # proven; restart with a plain full download instead
+                partial.clear()
+                raise httpx2.ReadError(
+                    "Partial response does not report a total length; restarting from scratch",
+                    request=response.request,
+                )
             # the origin served a satisfying-but-short segment; keep the bytes
             # it did send so the next attempt resumes from the new offset
-            await response.aclose()
             raise httpx2.ReadError(
                 f"Partial response ended at byte {len(partial.data)} of {bounds[2]}; resuming",
                 request=response.request,

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -228,19 +228,16 @@ def _reassembled_download_response(
         extensions=elapsed_from.extensions,
         history=elapsed_from.history,
     )
-    # the consumed response stays reachable to callers that retained it (for
-    # example through a response event hook), so populate its content too
-    # instead of leaving it unreadable
-    elapsed_from._content = content
-    # keep the encoding state the serving client attached (a custom
-    # `default_encoding` or a hook-set encoding), so `.text` still decodes
-    # the same way it would have on the original response; when the source
-    # derived its encoding from headers, the copied `Content-Type` header
-    # reproduces the same derivation
+    # keep the encoding state the serving client attached: the client-level
+    # `default_encoding` is copied as-is (a plain name, or a detector callable
+    # which then runs against the assembled body), while an encoding that was
+    # explicitly pinned on the interrupted response is preserved verbatim —
+    # a merely header-derived encoding is left to re-derive from the copied
+    # `Content-Type` header so a callable detector sees the full body
     rebuilt.default_encoding = representation.default_encoding
-    effective_encoding = representation.encoding
-    if effective_encoding is not None:
-        rebuilt.encoding = effective_encoding
+    explicit_encoding = getattr(representation, "_encoding", None)
+    if explicit_encoding is not None:
+        rebuilt.encoding = explicit_encoding
     try:
         rebuilt.elapsed = elapsed_from.elapsed
     except RuntimeError:
@@ -248,6 +245,25 @@ def _reassembled_download_response(
         # exactly as an unread response would be
         pass
     return rebuilt
+
+
+def _read_and_release(response: httpx2.Response) -> None:
+    """Read a streamed response to completion, closing it if the read fails."""
+    try:
+        response.read()
+    except BaseException:
+        response.close()
+        raise
+
+
+async def _aread_and_release(response: httpx2.Response) -> None:
+    """Async counterpart of `_read_and_release`."""
+    try:
+        await response.aread()
+    except BaseException:
+        with anyio.CancelScope(shield=True):
+            await response.aclose()
+        raise
 
 
 if TYPE_CHECKING:
@@ -1147,8 +1163,9 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             assert representation is not None
             if total is not None and total == len(partial.data):
                 # the earlier attempt already received every byte; only the
-                # terminating chunks went missing
-                response.close()
+                # terminating chunks went missing; read the (small) body so a
+                # retained reference sees a normally-consumed response
+                _read_and_release(response)
                 return self._finish_download(partial, elapsed_from=response)
             received = len(partial.data)
             response.close()
@@ -1192,25 +1209,25 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             partial.clear()
 
         if not accumulate:
-            try:
-                response.read()
-            except BaseException:
-                # includes KeyboardInterrupt and other BaseExceptions — the
-                # stream must not outlive the failed read either way
-                response.close()
-                raise
+            _read_and_release(response)
             return response
 
         # on a 206 the original response stays the representation of the full
         # body (headers, validator, request); a 200 restart already replaced it
+        delivered = bytearray()
         try:
             for chunk in response.iter_bytes():
                 partial.data.extend(chunk)
+                delivered.extend(chunk)
         except BaseException:
             # the stream is left open when the body read fails; release the
             # connection before the retry loop takes over
             response.close()
             raise
+        # exactly what a non-streaming send() would have left on this response:
+        # its own body, so retained references see metadata and content that
+        # agree (a 206 keeps its suffix-sized body, not the assembled one)
+        response._content = bytes(delivered)
         bounds = _content_range_bounds(response)
         if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
             response.close()
@@ -1893,8 +1910,9 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             assert representation is not None
             if total is not None and total == len(partial.data):
                 # the earlier attempt already received every byte; only the
-                # terminating chunks went missing
-                await response.aclose()
+                # terminating chunks went missing; read the (small) body so a
+                # retained reference sees a normally-consumed response
+                await _aread_and_release(response)
                 return await self._afinish_download(partial, elapsed_from=response)
             received = len(partial.data)
             await response.aclose()
@@ -1938,27 +1956,26 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             partial.clear()
 
         if not accumulate:
-            try:
-                await response.aread()
-            except BaseException:
-                # includes CancelledError; shield the close so a level-triggered
-                # cancellation cannot interrupt the cleanup itself
-                with anyio.CancelScope(shield=True):
-                    await response.aclose()
-                raise
+            await _aread_and_release(response)
             return response
 
         # on a 206 the original response stays the representation of the full
         # body (headers, validator, request); a 200 restart already replaced it
+        delivered = bytearray()
         try:
             async for chunk in response.aiter_bytes():
                 partial.data.extend(chunk)
+                delivered.extend(chunk)
         except BaseException:
             # includes CancelledError; shield the close so a level-triggered
             # cancellation cannot interrupt the cleanup itself
             with anyio.CancelScope(shield=True):
                 await response.aclose()
             raise
+        # exactly what a non-streaming send() would have left on this response:
+        # its own body, so retained references see metadata and content that
+        # agree (a 206 keeps its suffix-sized body, not the assembled one)
+        response._content = bytes(delivered)
         bounds = _content_range_bounds(response)
         if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
             await response.aclose()

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -124,8 +124,9 @@ _AsyncStreamT = TypeVar("_AsyncStreamT", bound=AsyncStream[Any])
 
 def _accepts_byte_ranges(response: httpx2.Response) -> bool:
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Ranges
+    # the header is a comma-separated list of supported range units
     value = str(response.headers.get("accept-ranges", ""))
-    return value.strip().lower() == "bytes"
+    return any(unit.strip() == "bytes" for unit in value.lower().split(","))
 
 
 def _is_identity_encoded(response: httpx2.Response) -> bool:
@@ -221,11 +222,16 @@ def _reassembled_download_response(
         200,
         headers=headers,
         content=content,
-        # the request as it was actually sent (post-redirect, post-auth)
-        request=representation.request,
-        extensions=representation.extensions,
-        history=representation.history,
+        # the request/response metadata of the attempt that completed the
+        # transfer (its final URL after redirects, its request id extensions)
+        request=elapsed_from.request,
+        extensions=elapsed_from.extensions,
+        history=elapsed_from.history,
     )
+    # the consumed response stays reachable to callers that retained it (for
+    # example through a response event hook), so populate its content too
+    # instead of leaving it unreadable
+    elapsed_from._content = content
     # keep the encoding state the serving client attached (a custom
     # `default_encoding` or a hook-set encoding), so `.text` still decodes
     # the same way it would have on the original response; when the source
@@ -1143,7 +1149,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
                 # the earlier attempt already received every byte; only the
                 # terminating chunks went missing
                 response.close()
-                return self._finish_download(partial, elapsed_from=representation)
+                return self._finish_download(partial, elapsed_from=response)
             received = len(partial.data)
             response.close()
             partial.clear()
@@ -1889,7 +1895,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
                 # the earlier attempt already received every byte; only the
                 # terminating chunks went missing
                 await response.aclose()
-                return await self._afinish_download(partial, elapsed_from=representation)
+                return await self._afinish_download(partial, elapsed_from=response)
             received = len(partial.data)
             await response.aclose()
             partial.clear()

--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -226,6 +226,15 @@ def _reassembled_download_response(
         extensions=representation.extensions,
         history=representation.history,
     )
+    # keep the encoding state the serving client attached (a custom
+    # `default_encoding` or a hook-set encoding), so `.text` still decodes
+    # the same way it would have on the original response; when the source
+    # derived its encoding from headers, the copied `Content-Type` header
+    # reproduces the same derivation
+    rebuilt.default_encoding = representation.default_encoding
+    effective_encoding = representation.encoding
+    if effective_encoding is not None:
+        rebuilt.encoding = effective_encoding
     try:
         rebuilt.elapsed = elapsed_from.elapsed
     except RuntimeError:
@@ -1218,8 +1227,13 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
     def _finish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
         representation = partial.representation
         assert representation is not None
-        content = bytes(partial.data)
-        partial.clear()  # release the mutable buffer before response processing
+        # hand off the buffer instead of emptying it in place, so the mutable
+        # copy stops being reachable the moment the immutable one exists
+        buffer = partial.data
+        partial.data = bytearray()
+        partial.representation = None
+        content = bytes(buffer)
+        del buffer
         return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
 
     @overload
@@ -1921,9 +1935,10 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             try:
                 await response.aread()
             except BaseException:
-                # includes CancelledError and other BaseExceptions — the stream
-                # must not outlive the failed read either way
-                await response.aclose()
+                # includes CancelledError; shield the close so a level-triggered
+                # cancellation cannot interrupt the cleanup itself
+                with anyio.CancelScope(shield=True):
+                    await response.aclose()
                 raise
             return response
 
@@ -1933,9 +1948,10 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             async for chunk in response.aiter_bytes():
                 partial.data.extend(chunk)
         except BaseException:
-            # the stream is left open when the body read fails or the task is
-            # cancelled; release the connection before propagating
-            await response.aclose()
+            # includes CancelledError; shield the close so a level-triggered
+            # cancellation cannot interrupt the cleanup itself
+            with anyio.CancelScope(shield=True):
+                await response.aclose()
             raise
         bounds = _content_range_bounds(response)
         if resuming and bounds is not None and (bounds[2] is None or bounds[2] != len(partial.data)):
@@ -1959,8 +1975,13 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
     async def _afinish_download(self, partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
         representation = partial.representation
         assert representation is not None
-        content = bytes(partial.data)
-        partial.clear()  # release the mutable buffer before response processing
+        # hand off the buffer instead of emptying it in place, so the mutable
+        # copy stops being reachable the moment the immutable one exists
+        buffer = partial.data
+        partial.data = bytearray()
+        partial.representation = None
+        content = bytes(buffer)
+        del buffer
         return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
 
     @overload

--- a/src/openai/_client.py
+++ b/src/openai/_client.py
@@ -578,9 +578,14 @@ class OpenAI(SyncAPIClient):
         request: httpx2.Request,
         *,
         stream: bool,
+        body_reader: Callable[[httpx2.Response], httpx2.Response] | None = None,
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
         response = self._send_with_auth_retry(request, stream=stream, **kwargs)
+        if body_reader is not None:
+            # consume the streamed body before provider normalisation so the
+            # callback sees the same read response a non-streaming send gives it
+            response = body_reader(response)
         if self._provider_runtime is not None and self._provider_runtime.normalize_response is not None:
             response = self._provider_runtime.normalize_response(response)
         return response
@@ -1320,9 +1325,14 @@ class AsyncOpenAI(AsyncAPIClient):
         request: httpx2.Request,
         *,
         stream: bool,
+        body_reader: Callable[[httpx2.Response], Awaitable[httpx2.Response]] | None = None,
         **kwargs: Unpack[HttpxSendArgs],
     ) -> httpx2.Response:
         response = await self._send_with_auth_retry(request, stream=stream, **kwargs)
+        if body_reader is not None:
+            # consume the streamed body before provider normalisation so the
+            # callback sees the same read response a non-streaming send gives it
+            response = await body_reader(response)
         if self._provider_runtime is not None:
             if self._provider_runtime.normalize_async_response is not None:
                 response = await self._provider_runtime.normalize_async_response(response)

--- a/src/openai/lib/_resumable.py
+++ b/src/openai/lib/_resumable.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import anyio
+import httpx2
+
+
+def _accepts_byte_ranges(response: httpx2.Response) -> bool:
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Ranges
+    # the header is a comma-separated list of supported range units
+    value = str(response.headers.get("accept-ranges", ""))
+    return any(unit.strip() == "bytes" for unit in value.lower().split(","))
+
+
+def _is_identity_encoded(response: httpx2.Response) -> bool:
+    # byte ranges address the encoded representation, but `iter_bytes()` yields
+    # decoded bytes — resuming is only sound when the two are the same
+    value = str(response.headers.get("content-encoding", "")).strip().lower()
+    return value in ("", "identity")
+
+
+def _content_range_bounds(response: httpx2.Response) -> tuple[int, int | None, int | None] | None:
+    """Parse a `206` response's `Content-Range: bytes <start>-<end>/<total>` header.
+
+    `end` and `total` are `None` when absent or unknown (`*`). Range unit names
+    are case-insensitive, so the header is normalised before parsing.
+    """
+    value = str(response.headers.get("content-range", "")).strip().lower()
+    if not value.startswith("bytes "):
+        return None
+    try:
+        start_part, rest = value[len("bytes ") :].split("-", 1)
+        end_part, _, total_part = rest.partition("/")
+        start = int(start_part.strip())
+        end = int(end_part.strip()) if end_part.strip() not in ("", "*") else None
+        total = int(total_part.strip()) if total_part.strip() not in ("", "*") else None
+    except ValueError:
+        return None
+    return start, end, total
+
+
+def _range_total_bytes(response: httpx2.Response) -> int | None:
+    """Total size reported by a `416` response's `Content-Range: bytes */<total>` header."""
+    value = str(response.headers.get("content-range", "")).strip().lower()
+    prefix = "bytes */"
+    if not value.startswith(prefix):
+        return None
+    try:
+        return int(value[len(prefix) :].strip())
+    except ValueError:
+        return None
+
+
+class _PartialDownload:
+    """Bytes already received from a range-capable response body, plus the
+    response (headers, request, validator) that produced them."""
+
+    __slots__ = ("data", "representation")
+
+    def __init__(self) -> None:
+        self.data = bytearray()
+        self.representation: httpx2.Response | None = None
+
+    def __bool__(self) -> bool:
+        return bool(self.data)
+
+    def reset(self, response: httpx2.Response) -> None:
+        self.data.clear()
+        self.representation = response
+
+    def clear(self) -> None:
+        self.data.clear()
+        self.representation = None
+
+
+def _resume_validator(response: httpx2.Response) -> str | None:
+    """Strong validator for an `If-Range` request, from the interrupted response.
+
+    Only a strong `ETag` qualifies: a weak `W/` tag is explicitly unusable, and
+    a `Last-Modified` date cannot be assumed to be a strong validator (its
+    one-second granularity may hide changes), so both fall back to "no
+    validator" and the download restarts instead of being resumed.
+    """
+    etag = str(response.headers.get("etag", "")).strip()
+    if etag and not etag.startswith("W/"):
+        return etag
+    return None
+
+
+def _reassembled_download_response(
+    representation: httpx2.Response,
+    content: bytes,
+    *,
+    elapsed_from: httpx2.Response,
+) -> httpx2.Response:
+    headers = [
+        (key, value)
+        for key, value in representation.headers.raw
+        if key.decode("latin-1").lower() not in ("content-range", "content-length", "transfer-encoding")
+    ]
+    # keep the response class of the client that actually served the request
+    # (legacy `httpx` clients produce legacy `httpx.Response` objects)
+    response_cls = httpx2.Response if isinstance(representation, httpx2.Response) else type(representation)
+    rebuilt = response_cls(
+        200,
+        headers=headers,
+        content=content,
+        # the request/response metadata of the attempt that completed the
+        # transfer (its final URL after redirects, its request id extensions)
+        request=elapsed_from.request,
+        extensions=elapsed_from.extensions,
+        history=elapsed_from.history,
+    )
+    # keep the encoding state the serving client attached: the client-level
+    # `default_encoding` is copied as-is (a plain name, or a detector callable
+    # which then runs against the assembled body), while an encoding that was
+    # explicitly pinned on the interrupted response is preserved verbatim —
+    # a merely header-derived encoding is left to re-derive from the copied
+    # `Content-Type` header so a callable detector sees the full body
+    rebuilt.default_encoding = representation.default_encoding
+    explicit_encoding = getattr(representation, "_encoding", None)
+    if explicit_encoding is not None:
+        rebuilt.encoding = explicit_encoding
+    try:
+        rebuilt.elapsed = elapsed_from.elapsed
+    except RuntimeError:
+        # the serving transport did not record timing; leave the field unset
+        # exactly as an unread response would be
+        pass
+    return rebuilt
+
+
+def _read_and_release(response: httpx2.Response) -> None:
+    """Read a streamed response to completion, closing it if the read fails."""
+    try:
+        response.read()
+    except BaseException:
+        response.close()
+        raise
+
+
+async def _aread_and_release(response: httpx2.Response) -> None:
+    """Async counterpart of `_read_and_release`."""
+    try:
+        await response.aread()
+    except BaseException:
+        with anyio.CancelScope(shield=True):
+            await response.aclose()
+        raise
+
+
+def read_resumable_body(
+    response: httpx2.Response,
+    partial: _PartialDownload,
+) -> httpx2.Response:
+    """Read a non-streamed GET response body, resuming interrupted downloads.
+
+    Retries normally restart a failed download from the first byte, which can
+    never succeed when a transfer is deterministically cut off mid-body (for
+    example large Batch API result files). When the server advertises
+    `Accept-Ranges: bytes`, later attempts request only the bytes that are
+    still missing, so retries make forward progress instead of repeating it.
+    """
+    resuming = bool(partial)
+    if resuming and response.status_code == 416:
+        total = _range_total_bytes(response)
+        representation = partial.representation
+        assert representation is not None
+        if total is not None and total == len(partial.data):
+            # the earlier attempt already received every byte; only the
+            # terminating chunks went missing; read the (small) body so a
+            # retained reference sees a normally-consumed response
+            _read_and_release(response)
+            return finish_download(partial, elapsed_from=response)
+        received = len(partial.data)
+        response.close()
+        partial.clear()
+        raise httpx2.ReadError(
+            f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
+            request=representation.request,
+        )
+
+    accumulate = False
+    if resuming and response.status_code == 206:
+        bounds = _content_range_bounds(response)
+        if bounds is not None and bounds[0] == len(partial.data):
+            # partial content; append the missing tail to what we already have
+            accumulate = True
+        else:
+            # unsolicited or misaligned range — our offset is unusable for
+            # this origin, so start over on the next attempt
+            received = len(partial.data)
+            response.close()
+            partial.clear()
+            raise httpx2.ReadError(
+                f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
+                request=response.request,
+            )
+    elif (
+        response.status_code == 200
+        and _accepts_byte_ranges(response)
+        and _is_identity_encoded(response)
+        and _resume_validator(response) is not None
+    ):
+        # either no range was sent or the server ignored it; this body is
+        # complete. without a strong validator a later range request could
+        # silently splice bytes from a different version of the resource,
+        # so only validator-bearing responses may be resumed
+        partial.reset(response)
+        accumulate = True
+    elif resuming and response.status_code == 200:
+        # the retry delivered a complete replacement body; any partial bytes
+        # are superseded
+        partial.clear()
+
+    if not accumulate:
+        _read_and_release(response)
+        return response
+
+    # on a 206 the original response stays the representation of the full
+    # body (headers, validator, request); a 200 restart already replaced it
+    delivered = bytearray()
+    try:
+        for chunk in response.iter_bytes():
+            partial.data.extend(chunk)
+            delivered.extend(chunk)
+    except BaseException:
+        # the stream is left open when the body read fails; release the
+        # connection before the retry loop takes over
+        response.close()
+        raise
+    # exactly what a non-streaming send() would have left on this response:
+    # its own body, so retained references see metadata and content that
+    # agree (a 206 keeps its suffix-sized body, not the assembled one)
+    response._content = bytes(delivered)
+    bounds = _content_range_bounds(response)
+    if resuming and bounds is not None:
+        start, end, total = bounds
+        if end is not None and len(delivered) != end - start + 1:
+            # the delivered body contradicts the advertised range extent
+            response.close()
+            partial.clear()
+            raise httpx2.ReadError(
+                "Partial response body does not match its Content-Range; restarting from scratch",
+                request=response.request,
+            )
+        if total is None or total != len(partial.data):
+            response.close()
+            if total is None:
+                # the total length is unknown, so completeness can never be
+                # proven; restart with a plain full download instead
+                partial.clear()
+                raise httpx2.ReadError(
+                    "Partial response does not report a total length; restarting from scratch",
+                    request=response.request,
+                )
+            # the origin served a satisfying-but-short segment; keep the bytes
+            # it did send so the next attempt resumes from the new offset
+            raise httpx2.ReadError(
+                f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
+                request=response.request,
+            )
+    return finish_download(partial, elapsed_from=response)
+
+
+def finish_download(partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
+    representation = partial.representation
+    assert representation is not None
+    # hand off the buffer instead of emptying it in place, so the mutable
+    # copy stops being reachable the moment the immutable one exists
+    buffer = partial.data
+    partial.data = bytearray()
+    partial.representation = None
+    content = bytes(buffer)
+    del buffer
+    return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)
+
+
+async def aread_resumable_body(
+    response: httpx2.Response,
+    partial: _PartialDownload,
+) -> httpx2.Response:
+    """Async counterpart of `_read_resumable_body`."""
+    resuming = bool(partial)
+    if resuming and response.status_code == 416:
+        total = _range_total_bytes(response)
+        representation = partial.representation
+        assert representation is not None
+        if total is not None and total == len(partial.data):
+            # the earlier attempt already received every byte; only the
+            # terminating chunks went missing; read the (small) body so a
+            # retained reference sees a normally-consumed response
+            await _aread_and_release(response)
+            return await afinish_download(partial, elapsed_from=response)
+        received = len(partial.data)
+        await response.aclose()
+        partial.clear()
+        raise httpx2.ReadError(
+            f"Server rejected resuming the download at byte {received} with 416; restarting from scratch",
+            request=representation.request,
+        )
+
+    accumulate = False
+    if resuming and response.status_code == 206:
+        bounds = _content_range_bounds(response)
+        if bounds is not None and bounds[0] == len(partial.data):
+            # partial content; append the missing tail to what we already have
+            accumulate = True
+        else:
+            # unsolicited or misaligned range — our offset is unusable for
+            # this origin, so start over on the next attempt
+            received = len(partial.data)
+            await response.aclose()
+            partial.clear()
+            raise httpx2.ReadError(
+                f"Server returned a partial response that does not start at byte {received}; restarting from scratch",
+                request=response.request,
+            )
+    elif (
+        response.status_code == 200
+        and _accepts_byte_ranges(response)
+        and _is_identity_encoded(response)
+        and _resume_validator(response) is not None
+    ):
+        # either no range was sent or the server ignored it; this body is
+        # complete. without a strong validator a later range request could
+        # silently splice bytes from a different version of the resource,
+        # so only validator-bearing responses may be resumed
+        partial.reset(response)
+        accumulate = True
+    elif resuming and response.status_code == 200:
+        # the retry delivered a complete replacement body; any partial bytes
+        # are superseded
+        partial.clear()
+
+    if not accumulate:
+        await _aread_and_release(response)
+        return response
+
+    # on a 206 the original response stays the representation of the full
+    # body (headers, validator, request); a 200 restart already replaced it
+    delivered = bytearray()
+    try:
+        async for chunk in response.aiter_bytes():
+            partial.data.extend(chunk)
+            delivered.extend(chunk)
+    except BaseException:
+        # includes CancelledError; shield the close so a level-triggered
+        # cancellation cannot interrupt the cleanup itself
+        with anyio.CancelScope(shield=True):
+            await response.aclose()
+        raise
+    # exactly what a non-streaming send() would have left on this response:
+    # its own body, so retained references see metadata and content that
+    # agree (a 206 keeps its suffix-sized body, not the assembled one)
+    response._content = bytes(delivered)
+    bounds = _content_range_bounds(response)
+    if resuming and bounds is not None:
+        start, end, total = bounds
+        if end is not None and len(delivered) != end - start + 1:
+            # the delivered body contradicts the advertised range extent
+            await response.aclose()
+            partial.clear()
+            raise httpx2.ReadError(
+                "Partial response body does not match its Content-Range; restarting from scratch",
+                request=response.request,
+            )
+        if total is None or total != len(partial.data):
+            await response.aclose()
+            if total is None:
+                # the total length is unknown, so completeness can never be
+                # proven; restart with a plain full download instead
+                partial.clear()
+                raise httpx2.ReadError(
+                    "Partial response does not report a total length; restarting from scratch",
+                    request=response.request,
+                )
+            # the origin served a satisfying-but-short segment; keep the bytes
+            # it did send so the next attempt resumes from the new offset
+            raise httpx2.ReadError(
+                f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
+                request=response.request,
+            )
+    return await afinish_download(partial, elapsed_from=response)
+
+
+async def afinish_download(partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
+    representation = partial.representation
+    assert representation is not None
+    # hand off the buffer instead of emptying it in place, so the mutable
+    # copy stops being reachable the moment the immutable one exists
+    buffer = partial.data
+    partial.data = bytearray()
+    partial.representation = None
+    content = bytes(buffer)
+    del buffer
+    return _reassembled_download_response(representation, content, elapsed_from=elapsed_from)

--- a/src/openai/lib/_resumable.py
+++ b/src/openai/lib/_resumable.py
@@ -95,8 +95,14 @@ def _reassembled_download_response(
     headers = [
         (key, value)
         for key, value in representation.headers.raw
-        if key.decode("latin-1").lower() not in ("content-range", "content-length", "transfer-encoding")
+        if key.decode("latin-1").lower() not in ("content-range", "content-length", "transfer-encoding", "x-request-id")
     ]
+    # the request id belongs to the exchange that completed the transfer, so
+    # it must agree with the request/extensions/elapsed taken from that
+    # attempt below rather than with the interrupted one
+    headers.extend(
+        (key, value) for key, value in elapsed_from.headers.raw if key.decode("latin-1").lower() == "x-request-id"
+    )
     # keep the response class of the client that actually served the request
     # (legacy `httpx` clients produce legacy `httpx.Response` objects)
     response_cls = httpx2.Response if isinstance(representation, httpx2.Response) else type(representation)
@@ -217,25 +223,23 @@ def read_resumable_body(
         return response
 
     # on a 206 the original response stays the representation of the full
-    # body (headers, validator, request); a 200 restart already replaced it
-    delivered = bytearray()
+    # body (headers, validator, request); a 200 restart already replaced it.
+    # chunks are accumulated exactly once, into the shared partial buffer —
+    # per-response copies only happen once the assembled body exists
+    offset = len(partial.data)
     try:
         for chunk in response.iter_bytes():
             partial.data.extend(chunk)
-            delivered.extend(chunk)
     except BaseException:
         # the stream is left open when the body read fails; release the
         # connection before the retry loop takes over
         response.close()
         raise
-    # exactly what a non-streaming send() would have left on this response:
-    # its own body, so retained references see metadata and content that
-    # agree (a 206 keeps its suffix-sized body, not the assembled one)
-    response._content = bytes(delivered)
+    delivered_len = len(partial.data) - offset
     bounds = _content_range_bounds(response)
     if resuming and bounds is not None:
         start, end, total = bounds
-        if end is not None and len(delivered) != end - start + 1:
+        if end is not None and delivered_len != end - start + 1:
             # the delivered body contradicts the advertised range extent
             response.close()
             partial.clear()
@@ -259,7 +263,13 @@ def read_resumable_body(
                 f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
                 request=response.request,
             )
-    return finish_download(partial, elapsed_from=response)
+    rebuilt = finish_download(partial, elapsed_from=response)
+    # exactly what a non-streaming send() would have left on this response:
+    # its own body, so retained references see metadata and content that
+    # agree. a fresh 200 restart shares the assembled body zero-copy; a 206
+    # keeps its suffix-sized body, not the assembled one
+    response._content = rebuilt.content if offset == 0 else rebuilt.content[offset:]
+    return rebuilt
 
 
 def finish_download(partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:
@@ -337,26 +347,24 @@ async def aread_resumable_body(
         return response
 
     # on a 206 the original response stays the representation of the full
-    # body (headers, validator, request); a 200 restart already replaced it
-    delivered = bytearray()
+    # body (headers, validator, request); a 200 restart already replaced it.
+    # chunks are accumulated exactly once, into the shared partial buffer —
+    # per-response copies only happen once the assembled body exists
+    offset = len(partial.data)
     try:
         async for chunk in response.aiter_bytes():
             partial.data.extend(chunk)
-            delivered.extend(chunk)
     except BaseException:
         # includes CancelledError; shield the close so a level-triggered
         # cancellation cannot interrupt the cleanup itself
         with anyio.CancelScope(shield=True):
             await response.aclose()
         raise
-    # exactly what a non-streaming send() would have left on this response:
-    # its own body, so retained references see metadata and content that
-    # agree (a 206 keeps its suffix-sized body, not the assembled one)
-    response._content = bytes(delivered)
+    delivered_len = len(partial.data) - offset
     bounds = _content_range_bounds(response)
     if resuming and bounds is not None:
         start, end, total = bounds
-        if end is not None and len(delivered) != end - start + 1:
+        if end is not None and delivered_len != end - start + 1:
             # the delivered body contradicts the advertised range extent
             await response.aclose()
             partial.clear()
@@ -380,7 +388,13 @@ async def aread_resumable_body(
                 f"Partial response ended at byte {len(partial.data)} of {total}; resuming",
                 request=response.request,
             )
-    return await afinish_download(partial, elapsed_from=response)
+    rebuilt = await afinish_download(partial, elapsed_from=response)
+    # exactly what a non-streaming send() would have left on this response:
+    # its own body, so retained references see metadata and content that
+    # agree. a fresh 200 restart shares the assembled body zero-copy; a 206
+    # keeps its suffix-sized body, not the assembled one
+    response._content = rebuilt.content if offset == 0 else rebuilt.content[offset:]
+    return rebuilt
 
 
 async def afinish_download(partial: _PartialDownload, *, elapsed_from: httpx2.Response) -> httpx2.Response:

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -375,6 +375,33 @@ class TestResumableDownloads:
         assert rebuilt.encoding == "latin-1"
         assert rebuilt.text == "café"
 
+    def test_rebuilt_response_keeps_explicit_and_detected_encoding(self) -> None:
+        from openai._base_client import _reassembled_download_response
+
+        request = httpx2.Request("GET", "https://example.test/files/abc/content")
+
+        # an encoding pinned explicitly on the interrupted response survives
+        pinned = httpx2.Response(200, request=request, content=b"hello")
+        pinned.encoding = "cp1252"
+        rebuilt = _reassembled_download_response(pinned, b"hello", elapsed_from=pinned)
+        assert rebuilt.encoding == "cp1252"
+
+        # a callable default_encoding detector runs against the assembled body,
+        # not against the unread interrupted response
+        def detect(raw: bytes) -> str | None:
+            return "latin-1" if b"\xe9" in raw else "utf-8"
+
+        interrupted = httpx2.Response(
+            200,
+            request=request,
+            stream=CutOffStream(b"caf\xe9", None),
+            default_encoding=detect,
+        )
+        rebuilt = _reassembled_download_response(interrupted, b"caf\xe9", elapsed_from=interrupted)
+        assert rebuilt.default_encoding is detect
+        assert rebuilt.encoding == "latin-1"
+        assert rebuilt.text == "café"
+
     @pytest.mark.asyncio
     async def test_real_task_cancellation_closes_the_response(self) -> None:
         served: list[httpx2.Response] = []
@@ -469,7 +496,10 @@ class TestResumableDownloads:
 
         assert content == DATA
         assert len(served) == 2
-        assert served[1].content == DATA
+        # the retained response keeps the metadata AND body of its own
+        # exchange: a 206 with the suffix it actually delivered
+        assert served[1].status_code == 206
+        assert served[1].content == DATA[CUT:]
 
     def test_rebuilt_response_reports_completing_request(self) -> None:
         server = RangeServer()

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -525,6 +525,77 @@ class TestResumableDownloads:
         # transfer, i.e. the resumed ranged request
         assert response.request.headers.get("range") == f"bytes={CUT}-"
 
+    def test_rebuilt_response_reports_completing_request_id(self) -> None:
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            first = not request.headers.get("range")
+            if first:
+                return httpx2.Response(
+                    200,
+                    headers={
+                        "content-type": "application/binary",
+                        "accept-ranges": "bytes",
+                        "etag": '"version-1"',
+                        "x-request-id": "req_interrupted",
+                    },
+                    request=request,
+                    stream=CutOffStream(DATA, CUT),
+                )
+            start = int(request.headers["range"].removeprefix("bytes=").split("-")[0])
+            return httpx2.Response(
+                206,
+                headers={
+                    "content-type": "application/binary",
+                    "accept-ranges": "bytes",
+                    "etag": '"version-1"',
+                    "content-range": f"bytes {start}-{len(DATA) - 1}/{len(DATA)}",
+                    "x-request-id": "req_completing",
+                },
+                request=request,
+                content=DATA[start:],
+            )
+
+        with openai.OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            max_retries=2,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        ) as client:
+            response = client.get("/files/file_abc/content", cast_to=httpx2.Response)
+
+        # the request id must agree with the request/elapsed metadata, which
+        # both come from the completing attempt
+        assert response.headers.get("x-request-id") == "req_completing"
+
+    def test_full_download_body_is_not_duplicated(self) -> None:
+        # a successful range-capable 200 that never fails must not hold a
+        # second full-body copy: the retained response shares the assembled
+        # body zero-copy instead of copying it
+        served: list[httpx2.Response] = []
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            response = httpx2.Response(
+                200,
+                headers={
+                    "content-type": "application/binary",
+                    "accept-ranges": "bytes",
+                    "etag": '"version-1"',
+                },
+                request=request,
+                stream=CutOffStream(DATA, None),
+            )
+            served.append(response)
+            return response
+
+        with openai.OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        ) as client:
+            response = client.get("/files/file_abc/content", cast_to=httpx2.Response)
+
+        assert response.content == DATA
+        assert served[0].content is response.content
+
     def test_content_range_body_mismatch_restarts(self) -> None:
         server = RangeServer(lie_about_range_end=True)
         with _sync_client(server) as client:

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -366,7 +366,7 @@ class TestResumableDownloads:
     def test_rebuilt_response_preserves_elapsed(self) -> None:
         from datetime import timedelta
 
-        from openai._base_client import _reassembled_download_response
+        from openai.lib._resumable import _reassembled_download_response
 
         request = httpx2.Request("GET", "https://example.test/files/abc/content")
         representation = httpx2.Response(200, request=request, content=b"hello")
@@ -377,7 +377,7 @@ class TestResumableDownloads:
         assert rebuilt.elapsed == timedelta(seconds=1.5)
 
     def test_rebuilt_response_preserves_encoding_state(self) -> None:
-        from openai._base_client import _reassembled_download_response
+        from openai.lib._resumable import _reassembled_download_response
 
         request = httpx2.Request("GET", "https://example.test/files/abc/content")
         representation = httpx2.Response(200, request=request, content=b"caf\xe9", default_encoding="latin-1")
@@ -389,7 +389,7 @@ class TestResumableDownloads:
         assert rebuilt.text == "café"
 
     def test_rebuilt_response_keeps_explicit_and_detected_encoding(self) -> None:
-        from openai._base_client import _reassembled_download_response
+        from openai.lib._resumable import _reassembled_download_response
 
         request = httpx2.Request("GET", "https://example.test/files/abc/content")
 

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -361,6 +361,59 @@ class TestResumableDownloads:
 
         assert rebuilt.elapsed == timedelta(seconds=1.5)
 
+    def test_rebuilt_response_preserves_encoding_state(self) -> None:
+        from openai._base_client import _reassembled_download_response
+
+        request = httpx2.Request("GET", "https://example.test/files/abc/content")
+        representation = httpx2.Response(200, request=request, content=b"caf\xe9", default_encoding="latin-1")
+
+        rebuilt = _reassembled_download_response(representation, b"caf\xe9", elapsed_from=representation)
+
+        assert rebuilt.default_encoding == "latin-1"
+        assert rebuilt.encoding == "latin-1"
+        assert rebuilt.text == "café"
+
+    @pytest.mark.asyncio
+    async def test_real_task_cancellation_closes_the_response(self) -> None:
+        served: list[httpx2.Response] = []
+        reading = asyncio.Event()
+
+        class SlowStream(AsyncByteStream):
+            async def __aiter__(self) -> AsyncIterator[bytes]:
+                yield DATA[:64]
+                reading.set()
+                await asyncio.sleep(30)  # the cancellation lands here
+                yield DATA[64:]
+
+        async def handler(request: httpx2.Request) -> httpx2.Response:
+            response = httpx2.Response(
+                200,
+                headers={
+                    "content-type": "application/binary",
+                    "accept-ranges": "bytes",
+                    "etag": '"version-1"',
+                },
+                request=request,
+                stream=SlowStream(),
+            )
+            served.append(response)
+            return response
+
+        async with openai.AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+        ) as client:
+            task = asyncio.create_task(client.files.content("file_abc"))
+            await reading.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # a real (asyncio-delivered) cancellation must still close the response
+        assert len(served) == 1
+        assert served[0].is_closed
+
     def test_last_modified_alone_is_not_a_validator(self) -> None:
         server = RangeServer(etag=None, last_modified="Sun, 30 Aug 2026 12:00:00 GMT")
         with _sync_client(server) as client:
@@ -472,3 +525,132 @@ class TestResumableDownloads:
             page = client.models.list()
 
         assert page.data == []
+
+
+# Large-payload regression probes, mirroring tests/test_large_payload_contract.py:
+# the resume path targets real Batch API result files (200-300 MB in
+# production), so the fixture must be large enough to catch payload-size
+# dependent buffering regressions. High memory use is intentional — keep this
+# above 32 MiB and do not shrink it to make the test pass. Data is generated
+# in memory and the cases run sequentially inside a single test to bound peak
+# memory under pytest-xdist.
+LARGE_SIZE = 32 * 1024 * 1024 + 1
+LARGE_CHUNK = 1024 * 1024
+
+
+def _large_data() -> bytes:
+    block = bytes(range(256)) * 256  # 64 KiB
+    return (block * (LARGE_SIZE // len(block) + 1))[:LARGE_SIZE]
+
+
+class ChunkedCutStream(SyncByteStream):
+    """Streams a large body in bounded chunks, optionally dying mid-transfer."""
+
+    def __init__(self, data: bytes, cut_at: int | None) -> None:
+        self.data = data
+        self.cut_at = cut_at
+
+    def __iter__(self) -> Iterator[bytes]:
+        for start in range(0, len(self.data), LARGE_CHUNK):
+            end = min(start + LARGE_CHUNK, len(self.data))
+            if self.cut_at is not None and end > self.cut_at:
+                yield self.data[start : self.cut_at]
+                raise httpx2.RemoteProtocolError("peer closed connection without sending complete message body")
+            yield self.data[start:end]
+
+
+class AsyncChunkedCutStream(AsyncByteStream):
+    def __init__(self, data: bytes, cut_at: int | None) -> None:
+        self.data = data
+        self.cut_at = cut_at
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for start in range(0, len(self.data), LARGE_CHUNK):
+            end = min(start + LARGE_CHUNK, len(self.data))
+            if self.cut_at is not None and end > self.cut_at:
+                yield self.data[start : self.cut_at]
+                raise httpx2.RemoteProtocolError("peer closed connection without sending complete message body")
+            yield self.data[start:end]
+
+
+class LargeRangeServer:
+    """Serves a 32 MiB+ body through the interrupted-then-resumed flow."""
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.request_count = 0
+
+    def _chunked(self, data: bytes, cut_at: int | None, is_async: bool) -> AsyncByteStream | SyncByteStream:
+        if is_async:
+            return AsyncChunkedCutStream(data, cut_at)
+        return ChunkedCutStream(data, cut_at)
+
+    def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
+        self.request_count += 1
+        headers = {
+            "content-type": "application/binary",
+            "accept-ranges": "bytes",
+            "etag": '"large-version-1"',
+        }
+        range_header = request.headers.get("range")
+        if range_header:
+            start = int(range_header.removeprefix("bytes=").split("-")[0])
+            headers["content-range"] = f"bytes {start}-{len(self.data) - 1}/{len(self.data)}"
+            return httpx2.Response(
+                206,
+                headers=headers,
+                request=request,
+                stream=self._chunked(self.data[start:], None, is_async),
+            )
+        cut = len(self.data) // 2 if self.request_count == 1 else None
+        return httpx2.Response(
+            200,
+            headers=headers,
+            request=request,
+            stream=self._chunked(self.data, cut, is_async),
+        )
+
+    def handle(self, request: httpx2.Request) -> httpx2.Response:
+        return self._handle(request, is_async=False)
+
+    async def handle_async(self, request: httpx2.Request) -> httpx2.Response:
+        return self._handle(request, is_async=True)
+
+
+def check_large_resume_sync() -> None:
+    data = _large_data()
+    server = LargeRangeServer(data)
+    with openai.OpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        max_retries=2,
+        http_client=httpx2.Client(transport=httpx2.MockTransport(server.handle)),
+    ) as client:
+        content = client.files.content("file_large").content
+
+    # keep the 32 MiB payload out of pytest's assertion diagnostics
+    intact = content == data
+    assert intact, "the large resumed download was truncated or corrupted"
+    assert server.request_count == 2
+
+
+async def check_large_resume_async() -> None:
+    data = _large_data()
+    server = LargeRangeServer(data)
+    async with openai.AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        max_retries=2,
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(server.handle_async)),
+    ) as client:
+        content = (await client.files.content("file_large")).content
+
+    intact = content == data
+    assert intact, "the large resumed download was truncated or corrupted"
+    assert server.request_count == 2
+
+
+async def test_large_resumable_download() -> None:
+    # One test prevents pytest-xdist from running the high-memory cases together.
+    check_large_resume_sync()
+    await check_large_resume_async()

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -62,14 +62,16 @@ class RangeServer:
         accept_ranges: bool = True,
         honor_range: bool = True,
         cut_first_attempt_at: int | None = CUT,
-        etag: str | None = None,
+        etag: str | None = '"version-1"',
         misalign_content_range: bool = False,
+        shorten_first_ranged_segment: bool = False,
     ) -> None:
         self.accept_ranges = accept_ranges
         self.honor_range = honor_range
         self.cut_first_attempt_at = cut_first_attempt_at
         self.etag = etag
         self.misalign_content_range = misalign_content_range
+        self.shorten_first_ranged_segment = shorten_first_ranged_segment
         self.requests: list[httpx2.Request] = []
 
     def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
@@ -84,12 +86,23 @@ class RangeServer:
         range_header = request.headers.get("range")
         if not first_attempt and range_header and self.honor_range:
             start = int(range_header.removeprefix("bytes=").split("-")[0])
+            end = len(DATA) - 1
             if self.misalign_content_range:
                 # claims a range that does not match what we asked for
                 headers["content-range"] = f"bytes 0-{len(DATA) - 1}/{len(DATA)}"
                 start = 0
+            elif self.shorten_first_ranged_segment and len(self.requests) == 2:
+                # a satisfying-but-short segment: legally ends before the total
+                end = start + (len(DATA) - start) // 2 - 1
+                headers["content-range"] = f"bytes {start}-{end}/{len(DATA)}"
+                return httpx2.Response(
+                    206,
+                    headers=headers,
+                    request=request,
+                    stream=_stream_cls(is_async)(DATA[start : end + 1], None),
+                )
             else:
-                headers["content-range"] = f"bytes {start}-{len(DATA) - 1}/{len(DATA)}"
+                headers["content-range"] = f"bytes {start}-{end}/{len(DATA)}"
             return httpx2.Response(
                 206,
                 headers=headers,
@@ -123,6 +136,7 @@ class AlwaysCutsServer(RangeServer):
             headers={
                 "content-type": "application/binary",
                 "accept-ranges": "bytes",
+                "etag": '"version-1"',
             },
             request=request,
             stream=_stream_cls(is_async)(DATA, CUT),
@@ -144,6 +158,7 @@ class CutAtVeryEndServer(RangeServer):
                 headers={
                     "content-type": "application/binary",
                     "accept-ranges": "bytes",
+                    "etag": '"version-1"',
                     "content-disposition": 'attachment; filename="result.jsonl"',
                 },
                 request=request,
@@ -282,7 +297,45 @@ class TestResumableDownloads:
             content = client.files.content("file_abc").content
 
         assert content == DATA
+        # a weak validator cannot guard against a changed resource, so the
+        # interrupted download is not resumed at all
         assert server.requests[1].headers.get("if-range") is None
+        assert server.requests[1].headers.get("range") is None
+
+    def test_no_resume_without_any_validator(self) -> None:
+        server = RangeServer(etag=None)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+        assert server.requests[1].headers.get("range") is None
+
+    def test_short_partial_segments_resume_until_complete(self) -> None:
+        server = RangeServer(shorten_first_ranged_segment=True)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # attempt 2 served half the remainder, attempt 3 the rest
+        assert len(server.requests) == 3
+        second = int(server.requests[1].headers.get("range", "").removeprefix("bytes=").split("-")[0])
+        third = int(server.requests[2].headers.get("range", "").removeprefix("bytes=").split("-")[0])
+        assert second == CUT
+        assert third > CUT
+
+    def test_rebuilt_response_preserves_elapsed(self) -> None:
+        from datetime import timedelta
+
+        from openai._base_client import _reassembled_download_response
+
+        request = httpx2.Request("GET", "https://example.test/files/abc/content")
+        representation = httpx2.Response(200, request=request, content=b"hello")
+        representation.elapsed = timedelta(seconds=1.5)
+
+        rebuilt = _reassembled_download_response(representation, b"hello", elapsed_from=representation)
+
+        assert rebuilt.elapsed == timedelta(seconds=1.5)
 
     def test_restarts_when_content_range_does_not_match_offset(self) -> None:
         server = RangeServer(misalign_content_range=True)

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+
+import httpx2
+import pytest
+from httpx2._types import SyncByteStream, AsyncByteStream
+
+import openai
+
+base_url = "http://localhost:7123/v1"
+api_key = "test-api-key"
+
+DATA = b"".join(bytes([i % 256]) * 64 for i in range(160))  # 10240 bytes
+CUT = 4096
+
+
+class CutOffStream(SyncByteStream):
+    """Simulates a connection that dies part-way through the response body."""
+
+    def __init__(self, data: bytes, cut_at: int | None) -> None:
+        self.data = data
+        self.cut_at = cut_at
+
+    def __iter__(self) -> Iterator[bytes]:
+        if self.cut_at is None:
+            yield self.data
+            return
+        yield self.data[: self.cut_at]
+        raise httpx2.RemoteProtocolError("peer closed connection without sending complete message body")
+
+
+class AsyncCutOffStream(AsyncByteStream):
+    def __init__(self, data: bytes, cut_at: int | None) -> None:
+        self.data = data
+        self.cut_at = cut_at
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        if self.cut_at is None:
+            yield self.data
+            return
+        yield self.data[: self.cut_at]
+        raise httpx2.RemoteProtocolError("peer closed connection without sending complete message body")
+
+
+def _stream_cls(is_async: bool) -> type[CutOffStream] | type[AsyncCutOffStream]:
+    return AsyncCutOffStream if is_async else CutOffStream
+
+
+class RangeServer:
+    """Stateful handler that serves `DATA`, cutting the first transfer short.
+
+    Mirrors the failure mode from https://github.com/openai/openai-python/issues/2959:
+    the first response dies mid-body; the server supports byte ranges so a later
+    attempt can request only the missing bytes.
+    """
+
+    def __init__(
+        self,
+        *,
+        accept_ranges: bool = True,
+        honor_range: bool = True,
+        cut_first_attempt_at: int | None = CUT,
+    ) -> None:
+        self.accept_ranges = accept_ranges
+        self.honor_range = honor_range
+        self.cut_first_attempt_at = cut_first_attempt_at
+        self.requests: list[httpx2.Request] = []
+
+    def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
+        self.requests.append(request)
+        first_attempt = len(self.requests) == 1
+        headers = {"content-type": "application/binary"}
+        if self.accept_ranges:
+            headers["accept-ranges"] = "bytes"
+
+        range_header = request.headers.get("range")
+        if not first_attempt and range_header and self.honor_range:
+            start = int(range_header.removeprefix("bytes=").split("-")[0])
+            headers["content-range"] = f"bytes {start}-{len(DATA) - 1}/{len(DATA)}"
+            return httpx2.Response(
+                206,
+                headers=headers,
+                request=request,
+                stream=_stream_cls(is_async)(DATA[start:], None),
+            )
+
+        # first attempt (or a range-ignoring server): full body, possibly cut short
+        cut_at = self.cut_first_attempt_at if first_attempt else None
+        return httpx2.Response(
+            200,
+            headers=headers,
+            request=request,
+            stream=_stream_cls(is_async)(DATA, cut_at),
+        )
+
+    def handle(self, request: httpx2.Request) -> httpx2.Response:
+        return self._handle(request, is_async=False)
+
+    async def handle_async(self, request: httpx2.Request) -> httpx2.Response:
+        return self._handle(request, is_async=True)
+
+
+class AlwaysCutsServer(RangeServer):
+    """Every attempt is cut off at the same byte, so retries can never finish."""
+
+    def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
+        self.requests.append(request)
+        return httpx2.Response(
+            200,
+            headers={
+                "content-type": "application/binary",
+                "accept-ranges": "bytes",
+            },
+            request=request,
+            stream=_stream_cls(is_async)(DATA, CUT),
+        )
+
+
+class CutAtVeryEndServer(RangeServer):
+    """Delivers every byte, then the connection dies before the terminator.
+
+    The next attempt's `Range` is unsatisfiable (`416`), but the `Content-Range`
+    total proves the download is already complete.
+    """
+
+    def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
+        self.requests.append(request)
+        if len(self.requests) == 1:
+            return httpx2.Response(
+                200,
+                headers={
+                    "content-type": "application/binary",
+                    "accept-ranges": "bytes",
+                },
+                request=request,
+                stream=_stream_cls(is_async)(DATA, len(DATA)),
+            )
+        assert request.headers.get("range") == f"bytes={len(DATA)}-"
+        return httpx2.Response(
+            416,
+            headers={"content-range": f"bytes */{len(DATA)}"},
+            request=request,
+            content=b"",
+        )
+
+
+def _sync_client(server: RangeServer) -> openai.OpenAI:
+    return openai.OpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        max_retries=2,
+        http_client=httpx2.Client(transport=httpx2.MockTransport(server.handle)),
+    )
+
+
+def _async_client(server: RangeServer) -> openai.AsyncOpenAI:
+    return openai.AsyncOpenAI(
+        base_url=base_url,
+        api_key=api_key,
+        max_retries=2,
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(server.handle_async)),
+    )
+
+
+@pytest.fixture(autouse=True)
+def fast_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "openai._base_client.BaseClient._calculate_retry_timeout",
+        lambda *_args, **_kwargs: 0.01,
+    )
+
+
+class TestResumableDownloads:
+    def test_resumes_interrupted_download_sync(self) -> None:
+        server = RangeServer()
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+        assert server.requests[1].headers.get("range") == f"bytes={CUT}-"
+
+    @pytest.mark.asyncio
+    async def test_resumes_interrupted_download_async(self) -> None:
+        server = RangeServer()
+        async with _async_client(server) as client:
+            content = (await client.files.content("file_abc")).content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+        assert server.requests[1].headers.get("range") == f"bytes={CUT}-"
+
+    def test_restarts_from_scratch_when_server_has_no_ranges(self) -> None:
+        server = RangeServer(accept_ranges=False)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+        # without `accept-ranges` we can't resume, so no `Range` is sent
+        assert server.requests[1].headers.get("range") is None
+
+    def test_recovers_when_range_is_ignored(self) -> None:
+        server = RangeServer(honor_range=False)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+
+    def test_completes_download_that_was_cut_at_the_very_end(self) -> None:
+        server = CutAtVeryEndServer()
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+
+    def test_raises_when_retries_are_exhausted(self) -> None:
+        server = AlwaysCutsServer()
+        with _sync_client(server) as client:
+            with pytest.raises(openai.APIConnectionError):
+                client.files.content("file_abc")
+
+        # max_retries=2 -> three attempts, each resuming where the last one died
+        assert len(server.requests) == 3
+        assert [r.headers.get("range") for r in server.requests] == [
+            None,
+            f"bytes={CUT}-",
+            f"bytes={CUT}-",
+        ]
+
+    def test_plain_get_is_unaffected(self) -> None:
+        # a JSON endpoint that never advertises ranges keeps today's behaviour
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            assert request.headers.get("range") is None
+            return httpx2.Response(200, json={"data": [], "object": "list"})
+
+        with openai.OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        ) as client:
+            page = client.models.list()
+
+        assert page.data == []

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Iterator
+import gzip
+from collections.abc import Iterator, AsyncIterator
 
 import httpx2
 import pytest
@@ -61,10 +62,14 @@ class RangeServer:
         accept_ranges: bool = True,
         honor_range: bool = True,
         cut_first_attempt_at: int | None = CUT,
+        etag: str | None = None,
+        misalign_content_range: bool = False,
     ) -> None:
         self.accept_ranges = accept_ranges
         self.honor_range = honor_range
         self.cut_first_attempt_at = cut_first_attempt_at
+        self.etag = etag
+        self.misalign_content_range = misalign_content_range
         self.requests: list[httpx2.Request] = []
 
     def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
@@ -73,11 +78,18 @@ class RangeServer:
         headers = {"content-type": "application/binary"}
         if self.accept_ranges:
             headers["accept-ranges"] = "bytes"
+        if self.etag:
+            headers["etag"] = self.etag
 
         range_header = request.headers.get("range")
         if not first_attempt and range_header and self.honor_range:
             start = int(range_header.removeprefix("bytes=").split("-")[0])
-            headers["content-range"] = f"bytes {start}-{len(DATA) - 1}/{len(DATA)}"
+            if self.misalign_content_range:
+                # claims a range that does not match what we asked for
+                headers["content-range"] = f"bytes 0-{len(DATA) - 1}/{len(DATA)}"
+                start = 0
+            else:
+                headers["content-range"] = f"bytes {start}-{len(DATA) - 1}/{len(DATA)}"
             return httpx2.Response(
                 206,
                 headers=headers,
@@ -132,6 +144,7 @@ class CutAtVeryEndServer(RangeServer):
                 headers={
                     "content-type": "application/binary",
                     "accept-ranges": "bytes",
+                    "content-disposition": 'attachment; filename="result.jsonl"',
                 },
                 request=request,
                 stream=_stream_cls(is_async)(DATA, len(DATA)),
@@ -145,7 +158,35 @@ class CutAtVeryEndServer(RangeServer):
         )
 
 
-def _sync_client(server: RangeServer) -> openai.OpenAI:
+class GzipServer:
+    """Serves a gzip-encoded body — byte ranges don't apply to decoded bytes."""
+
+    def __init__(self) -> None:
+        self.encoded = gzip.compress(DATA)
+        self.requests: list[httpx2.Request] = []
+
+    def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
+        self.requests.append(request)
+        cut_at = len(self.encoded) // 2 if len(self.requests) == 1 else None
+        return httpx2.Response(
+            200,
+            headers={
+                "content-type": "application/binary",
+                "accept-ranges": "bytes",
+                "content-encoding": "gzip",
+            },
+            request=request,
+            stream=_stream_cls(is_async)(self.encoded, cut_at),
+        )
+
+    def handle(self, request: httpx2.Request) -> httpx2.Response:
+        return self._handle(request, is_async=False)
+
+    async def handle_async(self, request: httpx2.Request) -> httpx2.Response:
+        return self._handle(request, is_async=True)
+
+
+def _sync_client(server: RangeServer | GzipServer) -> openai.OpenAI:
     return openai.OpenAI(
         base_url=base_url,
         api_key=api_key,
@@ -154,7 +195,7 @@ def _sync_client(server: RangeServer) -> openai.OpenAI:
     )
 
 
-def _async_client(server: RangeServer) -> openai.AsyncOpenAI:
+def _async_client(server: RangeServer | GzipServer) -> openai.AsyncOpenAI:
     return openai.AsyncOpenAI(
         base_url=base_url,
         api_key=api_key,
@@ -216,6 +257,55 @@ class TestResumableDownloads:
 
         assert content == DATA
         assert len(server.requests) == 2
+
+    def test_416_completion_preserves_original_response_headers(self) -> None:
+        server = CutAtVeryEndServer()
+        with _sync_client(server) as client:
+            response = client.with_raw_response.files.content("file_abc")
+
+        assert response.content == DATA
+        assert response.headers.get("content-type") == "application/binary"
+        assert response.headers.get("content-disposition") == 'attachment; filename="result.jsonl"'
+        assert "content-range" not in response.headers
+
+    def test_resume_sends_if_range_with_strong_etag(self) -> None:
+        server = RangeServer(etag='"version-1"')
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert server.requests[1].headers.get("if-range") == '"version-1"'
+
+    def test_weak_etag_is_not_used_as_validator(self) -> None:
+        server = RangeServer(etag='W/"version-1"')
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert server.requests[1].headers.get("if-range") is None
+
+    def test_restarts_when_content_range_does_not_match_offset(self) -> None:
+        server = RangeServer(misalign_content_range=True)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # attempt 2 returned a 206 that starts at the wrong offset, so the
+        # partial state was dropped and attempt 3 downloaded from scratch
+        assert len(server.requests) == 3
+        assert server.requests[1].headers.get("range") == f"bytes={CUT}-"
+        assert server.requests[2].headers.get("range") is None
+
+    def test_encoded_bodies_are_not_resumed(self) -> None:
+        server = GzipServer()
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+        # byte ranges address the encoded representation, so a gzip body is
+        # never resumed — the retry restarts from the first byte
+        assert server.requests[1].headers.get("range") is None
 
     def test_raises_when_retries_are_exhausted(self) -> None:
         server = AlwaysCutsServer()

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gzip
 import asyncio
 from collections.abc import Iterator, AsyncIterator
+from typing_extensions import override
 
 import httpx2
 import pytest
@@ -81,6 +82,7 @@ class RangeServer:
         unknown_total: bool = False,
         uppercase_units: bool = False,
         accept_ranges_value: str = "bytes",
+        lie_about_range_end: bool = False,
     ) -> None:
         self.accept_ranges = accept_ranges
         self.honor_range = honor_range
@@ -92,6 +94,7 @@ class RangeServer:
         self.unknown_total = unknown_total
         self.uppercase_units = uppercase_units
         self.accept_ranges_value = accept_ranges_value
+        self.lie_about_range_end = lie_about_range_end
         self.requests: list[httpx2.Request] = []
 
     def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
@@ -117,6 +120,16 @@ class RangeServer:
                 # claims a range that does not match what we asked for
                 headers["content-range"] = f"bytes 0-{len(DATA) - 1}/{len(DATA)}"
                 start = 0
+            elif self.lie_about_range_end and len(self.requests) == 2:
+                # claims a quarter of the bytes it actually delivers
+                claimed_end = start + (len(DATA) - start) // 4 - 1
+                headers["content-range"] = f"bytes {start}-{claimed_end}/{len(DATA)}"
+                return httpx2.Response(
+                    206,
+                    headers=headers,
+                    request=request,
+                    stream=_stream_cls(is_async)(DATA[start:], None),
+                )
             elif self.shorten_first_ranged_segment and len(self.requests) == 2:
                 # a satisfying-but-short segment: legally ends before the total
                 end = start + (len(DATA) - start) // 2 - 1
@@ -511,6 +524,62 @@ class TestResumableDownloads:
         # the rebuilt response is attributed to the request that completed the
         # transfer, i.e. the resumed ranged request
         assert response.request.headers.get("range") == f"bytes={CUT}-"
+
+    def test_content_range_body_mismatch_restarts(self) -> None:
+        server = RangeServer(lie_about_range_end=True)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # attempt 2 delivered more bytes than its Content-Range advertised, so
+        # the partial state was dropped and attempt 3 downloaded from scratch
+        assert len(server.requests) == 3
+        assert server.requests[1].headers.get("range") == f"bytes={CUT}-"
+        assert server.requests[2].headers.get("range") is None
+
+    def test_resume_headers_are_set_before_request_preparation(self) -> None:
+        server = RangeServer()
+        prepared_ranges: list[str | None] = []
+
+        class RecordingClient(openai.OpenAI):
+            @override
+            def _prepare_request(self, request: httpx2.Request) -> None:
+                prepared_ranges.append(request.headers.get("range"))
+                super()._prepare_request(request)
+
+        with RecordingClient(
+            base_url=base_url,
+            api_key=api_key,
+            max_retries=2,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(server.handle)),
+        ) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # signing/preparation must see the final header set, Range included
+        assert prepared_ranges[0] is None
+        assert prepared_ranges[1] == f"bytes={CUT}-"
+
+    def test_provider_normalization_sees_read_response(self) -> None:
+        from openai._provider import _ProviderRuntime
+
+        server = RangeServer()
+        normalized: list[bytes] = []
+
+        def normalize(response: httpx2.Response) -> httpx2.Response:
+            normalized.append(response.content)  # raises ResponseNotRead when unread
+            return response
+
+        with _sync_client(server) as client:
+            client._provider_runtime = _ProviderRuntime(
+                name="test", base_url=client.base_url, normalize_response=normalize
+            )
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # only the completing exchange reaches normalisation, and it arrives
+        # already read — the reassembled response the pipeline consumes
+        assert normalized == [DATA]
 
     def test_last_modified_alone_is_not_a_validator(self) -> None:
         server = RangeServer(etag=None, last_modified="Sun, 30 Aug 2026 12:00:00 GMT")

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -80,6 +80,7 @@ class RangeServer:
         shorten_first_ranged_segment: bool = False,
         unknown_total: bool = False,
         uppercase_units: bool = False,
+        accept_ranges_value: str = "bytes",
     ) -> None:
         self.accept_ranges = accept_ranges
         self.honor_range = honor_range
@@ -90,6 +91,7 @@ class RangeServer:
         self.shorten_first_ranged_segment = shorten_first_ranged_segment
         self.unknown_total = unknown_total
         self.uppercase_units = uppercase_units
+        self.accept_ranges_value = accept_ranges_value
         self.requests: list[httpx2.Request] = []
 
     def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
@@ -97,7 +99,7 @@ class RangeServer:
         first_attempt = len(self.requests) == 1
         headers = {"content-type": "application/binary"}
         if self.accept_ranges:
-            headers["accept-ranges"] = "bytes"
+            headers["accept-ranges"] = self.accept_ranges_value
         if self.etag:
             headers["etag"] = self.etag
         if self.last_modified:
@@ -413,6 +415,72 @@ class TestResumableDownloads:
         # a real (asyncio-delivered) cancellation must still close the response
         assert len(served) == 1
         assert served[0].is_closed
+
+    def test_accept_ranges_with_multiple_units(self) -> None:
+        server = RangeServer(accept_ranges_value="bytes, example-unit")
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+        assert server.requests[1].headers.get("range") == f"bytes={CUT}-"
+
+    def test_completing_response_stays_readable(self) -> None:
+        # a response event hook may retain the response the transport handed
+        # out; after a successful resume that object must still expose content
+        served: list[httpx2.Response] = []
+
+        def handler(request: httpx2.Request) -> httpx2.Response:
+            first = len(served) == 0
+            if not first:
+                start = int(request.headers.get("range", "").removeprefix("bytes=").split("-")[0])
+                response = httpx2.Response(
+                    206,
+                    headers={
+                        "content-type": "application/binary",
+                        "accept-ranges": "bytes",
+                        "etag": '"version-1"',
+                        "content-range": f"bytes {start}-{len(DATA) - 1}/{len(DATA)}",
+                    },
+                    request=request,
+                    content=DATA[start:],
+                )
+            else:
+                response = httpx2.Response(
+                    200,
+                    headers={
+                        "content-type": "application/binary",
+                        "accept-ranges": "bytes",
+                        "etag": '"version-1"',
+                    },
+                    request=request,
+                    stream=CutOffStream(DATA, CUT),
+                )
+            served.append(response)
+            return response
+
+        with openai.OpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            max_retries=2,
+            http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        ) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(served) == 2
+        assert served[1].content == DATA
+
+    def test_rebuilt_response_reports_completing_request(self) -> None:
+        server = RangeServer()
+        with _sync_client(server) as client:
+            response = client.get("/files/file_abc/content", cast_to=httpx2.Response)
+
+        assert response.status_code == 200
+        assert response.content == DATA
+        # the rebuilt response is attributed to the request that completed the
+        # transfer, i.e. the resumed ranged request
+        assert response.request.headers.get("range") == f"bytes={CUT}-"
 
     def test_last_modified_alone_is_not_a_validator(self) -> None:
         server = RangeServer(etag=None, last_modified="Sun, 30 Aug 2026 12:00:00 GMT")

--- a/tests/test_resumable_downloads.py
+++ b/tests/test_resumable_downloads.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import asyncio
 from collections.abc import Iterator, AsyncIterator
 
 import httpx2
@@ -48,6 +49,17 @@ def _stream_cls(is_async: bool) -> type[CutOffStream] | type[AsyncCutOffStream]:
     return AsyncCutOffStream if is_async else CutOffStream
 
 
+class CancellingStream(AsyncByteStream):
+    """Yields some bytes, then the task reading the body is cancelled."""
+
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield self.data[:64]
+        raise asyncio.CancelledError()
+
+
 class RangeServer:
     """Stateful handler that serves `DATA`, cutting the first transfer short.
 
@@ -63,15 +75,21 @@ class RangeServer:
         honor_range: bool = True,
         cut_first_attempt_at: int | None = CUT,
         etag: str | None = '"version-1"',
+        last_modified: str | None = None,
         misalign_content_range: bool = False,
         shorten_first_ranged_segment: bool = False,
+        unknown_total: bool = False,
+        uppercase_units: bool = False,
     ) -> None:
         self.accept_ranges = accept_ranges
         self.honor_range = honor_range
         self.cut_first_attempt_at = cut_first_attempt_at
         self.etag = etag
+        self.last_modified = last_modified
         self.misalign_content_range = misalign_content_range
         self.shorten_first_ranged_segment = shorten_first_ranged_segment
+        self.unknown_total = unknown_total
+        self.uppercase_units = uppercase_units
         self.requests: list[httpx2.Request] = []
 
     def _handle(self, request: httpx2.Request, *, is_async: bool) -> httpx2.Response:
@@ -82,11 +100,17 @@ class RangeServer:
             headers["accept-ranges"] = "bytes"
         if self.etag:
             headers["etag"] = self.etag
+        if self.last_modified:
+            headers["last-modified"] = self.last_modified
 
         range_header = request.headers.get("range")
         if not first_attempt and range_header and self.honor_range:
             start = int(range_header.removeprefix("bytes=").split("-")[0])
             end = len(DATA) - 1
+            total: int | str = len(DATA)
+            if self.unknown_total:
+                total = "*"
+            unit = "Bytes" if self.uppercase_units else "bytes"
             if self.misalign_content_range:
                 # claims a range that does not match what we asked for
                 headers["content-range"] = f"bytes 0-{len(DATA) - 1}/{len(DATA)}"
@@ -102,7 +126,7 @@ class RangeServer:
                     stream=_stream_cls(is_async)(DATA[start : end + 1], None),
                 )
             else:
-                headers["content-range"] = f"bytes {start}-{end}/{len(DATA)}"
+                headers["content-range"] = f"{unit} {start}-{end}/{total}"
             return httpx2.Response(
                 206,
                 headers=headers,
@@ -336,6 +360,66 @@ class TestResumableDownloads:
         rebuilt = _reassembled_download_response(representation, b"hello", elapsed_from=representation)
 
         assert rebuilt.elapsed == timedelta(seconds=1.5)
+
+    def test_last_modified_alone_is_not_a_validator(self) -> None:
+        server = RangeServer(etag=None, last_modified="Sun, 30 Aug 2026 12:00:00 GMT")
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # a Last-Modified date cannot be proven strong, so nothing is resumed
+        assert server.requests[1].headers.get("range") is None
+
+    def test_unknown_total_restarts_from_scratch(self) -> None:
+        server = RangeServer(unknown_total=True)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        # attempt 2's segment reported no total, so completeness was unprovable
+        # and attempt 3 downloaded the whole body instead of resuming
+        assert len(server.requests) == 3
+        assert server.requests[1].headers.get("range") == f"bytes={CUT}-"
+        assert server.requests[2].headers.get("range") is None
+
+    def test_range_units_are_parsed_case_insensitively(self) -> None:
+        server = RangeServer(uppercase_units=True)
+        with _sync_client(server) as client:
+            content = client.files.content("file_abc").content
+
+        assert content == DATA
+        assert len(server.requests) == 2
+
+    @pytest.mark.asyncio
+    async def test_cancelled_body_read_closes_the_response(self) -> None:
+        served: list[httpx2.Response] = []
+
+        async def handler(request: httpx2.Request) -> httpx2.Response:
+            response = httpx2.Response(
+                200,
+                headers={
+                    "content-type": "application/binary",
+                    "accept-ranges": "bytes",
+                    "etag": '"version-1"',
+                },
+                request=request,
+                stream=CancellingStream(DATA),
+            )
+            served.append(response)
+            return response
+
+        async with openai.AsyncOpenAI(
+            base_url=base_url,
+            api_key=api_key,
+            http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+        ) as client:
+            with pytest.raises(asyncio.CancelledError):
+                await client.files.content("file_abc")
+
+        # CancelledError bypasses `except Exception` handlers; the response
+        # must still have been closed by the BaseException cleanup path
+        assert len(served) == 1
+        assert served[0].is_closed
 
     def test_restarts_when_content_range_does_not_match_offset(self) -> None:
         server = RangeServer(misalign_content_range=True)


### PR DESCRIPTION
## Maintainer summary (30s TL;DR)

Non-streamed `GET` file downloads (e.g. `client.files.content()`) now resume automatically with byte-range requests when the origin supports it, fixing #2959. Servers without `Accept-Ranges: bytes`, streamed responses, and non-GET requests keep today's behavior byte-for-byte. Seven rounds of automated review drove the edge cases below; each is covered by a focused test:

| Edge case / risk | How it is handled | Test |
|---|---|---|
| Resource changed between attempts | Resume only with a strong `ETag` (`If-Range`); weak ETags / `Last-Modified` / no validator restart from byte 0 | `test_resume_sends_if_range_with_strong_etag`, `test_weak_etag_is_not_used_as_validator`, `test_last_modified_alone_is_not_a_validator` |
| Compressed bodies | Only `Content-Encoding: identity` resumes; gzip/br restart cleanly | `test_encoded_bodies_are_not_resumed` |
| Connection cut at the very end | A `416` whose `Content-Range` total matches the received bytes completes without a re-download | `test_completes_download_that_was_cut_at_the_very_end` |
| Truncated or lying `206`s | Delivered length must equal `end - start + 1`; short segments resume from the new offset; unknown `*` totals restart | `test_short_partial_segments_resume_until_complete`, `test_content_range_body_mismatch_restarts` |
| Misaligned or multi-unit ranges | A `206` not starting at the requested offset restarts; `Accept-Ranges: bytes, other-unit` is recognized | `test_restarts_when_content_range_does_not_match_offset`, `test_accept_ranges_with_multiple_units` |
| Task cancellation / failed reads | `aclose()` under `anyio.CancelScope(shield=True)`; failed streams are closed before retrying | `test_real_task_cancellation_closes_the_response` |
| Provider & hook compatibility | Bodies are consumed via a `body_reader` before `normalize_response`; retained responses keep their own exchange's body | `test_provider_normalization_sees_read_response`, `test_completing_response_stays_readable` |
| Large payloads | Buffer is handed off rather than retained twice; 32 MiB+ in-memory probes, sync and async, per the repo's large-payload contract | `test_large_resumable_download` |

As noted in the comments, I'm happy to move the helpers out of `_base_client.py` into SDK-owned files under `lib/` (cf. #3712/#3713) or otherwise reshape the patch — whatever minimizes template intrusion.

---

Fixes #2959

## Problem

Downloading large Batch API result files (the report is about >200–300 MB `.jsonl` outputs) fails with `httpcore.RemoteProtocolError: peer closed connection without sending complete message body`. The cutoff reproduces with plain `requests` against the same URL, so it is the long-lived single connection that dies, not the library — but the SDK's retries currently make the situation impossible to recover from: `client.files.content()` reads the body inside the retry loop, and **each retry restarts the download from byte 0**. When a transfer is cut at a deterministic size/duration threshold, every retry attempt dies at (roughly) the same point and `max_retries` just repeats the failure. The reporter's workaround — a manual chunked `Range` download with backoff — confirms the origin serves byte ranges happily.

The previous attempt in #2985 looped `iter_bytes()` in 1 MB chunks inside `LegacyAPIResponse.content`, which doesn't change the network behaviour (httpx already reads incrementally) and broke re-accessing `.content` on a consumed response.

## Change

GET retries in `_base_client.py` (sync + async) now **resume** an interrupted response body instead of restarting it, when the server allows it:

- attempt 1 is byte-for-byte today's behaviour, except that the body is read through `iter_bytes()` so whatever arrives before a transport error is kept;
- if the body read dies mid-transfer with a retryable error, the next attempt sends `Range: bytes=<received>-`; a `206` appends the missing tail to the partial body, a `200` from a range-ignoring server replaces the buffer;
- a `416` whose `Content-Range: bytes */<total>` total equals the bytes already received means the previous attempt actually received everything and only the terminating chunks went missing — the response is assembled from what we have;
- an unusable `416` (mismatched total, e.g. the object changed between attempts) clears the partial buffer and raises a `ReadError` so the normal retry machinery restarts from scratch;
- once complete, the response handed to response processing is rebuilt with the full body (original headers minus `content-range`/`content-length`, which is re-derived), status `200`.

Scope is deliberately conservative:

- only applies to **non-streamed GETs** whose response advertises `Accept-Ranges: bytes`; JSON endpoints and every other origin keep the current full-restart behaviour (verified by `test_restarts_from_scratch_when_server_has_no_ranges` and `test_plain_get_is_unaffected`);
- streamed responses (`stream=True`, `with_streaming_response`) are untouched;
- no public API changes.

## Tests

`tests/test_resumable_downloads.py` uses a stateful mock transport whose first response dies mid-body, covering sync + async resume, no-`accept-ranges` fallback, range-ignored servers, the cut-at-the-very-end `416` case, exhausted retries, and the untouched plain-JSON GET path. `ruff check`, `ruff format`, and `mypy` pass on the changed files; `tests/test_client.py`, `tests/test_httpx2.py`, `tests/test_legacy_response.py`, and `tests/test_resumable_downloads.py` pass together (235 passed, 2 skipped).

## Notes for reviewers

- This adds ~145 lines to the template-owned `_base_client.py`, so it will show up in the custom-code report; happy to restructure (e.g. move the helpers into a separate handwritten module) if that helps the budget, or to coordinate a template-level change if cross-SDK consistency is preferred.
- Security-wise this does not touch auth headers, redirects, or proxy handling; the only new outbound header is `Range`, and only for GETs that already received an `Accept-Ranges: bytes` response from the same origin.

