### PR TITLE
fix(ci): fail required checks when dependency locks fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     # failure instead of being skipped and accidentally satisfying branch rules.
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result != 'success')
     steps:
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'
@@ -105,7 +105,7 @@ jobs:
     needs: dependency-locks
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result != 'success')
     timeout-minutes: 10
     name: build
     permissions:
@@ -168,7 +168,7 @@ jobs:
     needs: dependency-locks
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result != 'success')
     strategy:
       fail-fast: false
       matrix:
@@ -213,7 +213,7 @@ jobs:
     needs: dependency-locks
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result != 'success')
     steps:
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,21 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    # Run the required check even when dependency-locks fails, so it reports a
+    # failure instead of being skipped and accidentally satisfying branch rules.
+    if: >-
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Fail if dependency lock validation failed
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo "dependency-locks did not pass; refusing to run this required check as green"
+          exit 1
 
       - uses: ./.github/actions/setup-node-tooling
 
@@ -93,7 +103,9 @@ jobs:
 
   build:
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     timeout-minutes: 10
     name: build
     permissions:
@@ -103,6 +115,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Fail if dependency lock validation failed
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo "dependency-locks did not pass; refusing to run this required check as green"
+          exit 1
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -148,7 +166,9 @@ jobs:
     name: test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     strategy:
       fail-fast: false
       matrix:
@@ -158,6 +178,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Fail if dependency lock validation failed
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo "dependency-locks did not pass; refusing to run this required check as green"
+          exit 1
 
       - uses: ./.github/actions/setup-node-tooling
 
@@ -185,11 +211,19 @@ jobs:
     name: test (HTTPX2)
     runs-on: ubuntu-latest
     needs: dependency-locks
-    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork
+    if: >-
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Fail if dependency lock validation failed
+        if: needs.dependency-locks.result != 'success'
+        run: |
+          echo "dependency-locks did not pass; refusing to run this required check as green"
+          exit 1
 
       - uses: ./.github/actions/setup-node-tooling
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,18 +74,18 @@ jobs:
     # Run the required check even when dependency-locks fails, so it reports a
     # failure instead of being skipped and accidentally satisfying branch rules.
     if: >-
-      always() &&
+      !cancelled() &&
       (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'
         run: |
           echo "dependency-locks did not pass; refusing to run this required check as green"
           exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-tooling
 
@@ -104,7 +104,7 @@ jobs:
   build:
     needs: dependency-locks
     if: >-
-      always() &&
+      !cancelled() &&
       (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     timeout-minutes: 10
     name: build
@@ -112,15 +112,15 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'
         run: |
           echo "dependency-locks did not pass; refusing to run this required check as green"
           exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: dependency-locks
     if: >-
-      always() &&
+      !cancelled() &&
       (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     strategy:
       fail-fast: false
@@ -175,15 +175,15 @@ jobs:
         # Per-PR coverage protects both ends of the support window.
         python-version: ["3.10", "3.14"]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'
         run: |
           echo "dependency-locks did not pass; refusing to run this required check as green"
           exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-tooling
 
@@ -212,18 +212,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: dependency-locks
     if: >-
-      always() &&
+      !cancelled() &&
       (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'
         run: |
           echo "dependency-locks did not pass; refusing to run this required check as green"
           exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-node-tooling
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     # failure instead of being skipped and accidentally satisfying branch rules.
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
     steps:
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'
@@ -105,7 +105,7 @@ jobs:
     needs: dependency-locks
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
     timeout-minutes: 10
     name: build
     permissions:
@@ -168,7 +168,7 @@ jobs:
     needs: dependency-locks
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
     strategy:
       fail-fast: false
       matrix:
@@ -213,7 +213,7 @@ jobs:
     needs: dependency-locks
     if: >-
       !cancelled() &&
-      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')
     steps:
       - name: Fail if dependency lock validation failed
         if: needs.dependency-locks.result != 'success'

--- a/tests/test_uv_workflows.py
+++ b/tests/test_uv_workflows.py
@@ -83,7 +83,7 @@ def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
     guard = (
         "    if: >-\n"
         "      !cancelled() &&\n"
-        "      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)\n"
+        "      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')\n"
     )
     failure_step = (
         "      - name: Fail if dependency lock validation failed\n"
@@ -100,6 +100,11 @@ def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
         assert failure_step in job, f"{job_name} must fail when dependency-locks fails"
         steps = job.split("    steps:\n", 1)[1]
         assert steps.startswith(failure_step), f"{job_name} must fail before checkout or other executable steps"
+
+    # A same-repository pull request normally has a false fork predicate. The
+    # dependency failure branch is what makes each required check run and fail
+    # instead of being skipped when that pull request's lock validation fails.
+    assert "github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure'" in guard
 
 
 def dependency_lock_source_command() -> str:

--- a/tests/test_uv_workflows.py
+++ b/tests/test_uv_workflows.py
@@ -82,7 +82,7 @@ def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
     workflow = path.read_text()
     guard = (
         "    if: >-\n"
-        "      always() &&\n"
+        "      !cancelled() &&\n"
         "      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)\n"
     )
     failure_step = (
@@ -98,6 +98,8 @@ def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
         job = match.group(1)
         assert guard in job, f"{job_name} must remain visible when dependency-locks fails"
         assert failure_step in job, f"{job_name} must fail when dependency-locks fails"
+        steps = job.split("    steps:\n", 1)[1]
+        assert steps.startswith(failure_step), f"{job_name} must fail before checkout or other executable steps"
 
 
 def dependency_lock_source_command() -> str:

--- a/tests/test_uv_workflows.py
+++ b/tests/test_uv_workflows.py
@@ -75,6 +75,31 @@ def test_dependabot_delays_only_ordinary_version_updates() -> None:
         assert "open-pull-requests-limit: 0" not in entry
 
 
+def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
+    path = ROOT / ".github/workflows/ci.yml"
+    if not path.exists():
+        pytest.skip("GitHub workflows are not included in source distributions")
+    workflow = path.read_text()
+    guard = (
+        "    if: >-\n"
+        "      always() &&\n"
+        "      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork)\n"
+    )
+    failure_step = (
+        "      - name: Fail if dependency lock validation failed\n"
+        "        if: needs.dependency-locks.result != 'success'\n"
+        "        run: |\n"
+        '          echo "dependency-locks did not pass; refusing to run this required check as green"\n'
+        "          exit 1\n"
+    )
+    for job_name in ("lint", "build", "test", "test-httpx2"):
+        match = re.search(rf"^  {re.escape(job_name)}:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)", workflow, re.M | re.S)
+        assert match is not None, f"Missing CI job: {job_name}"
+        job = match.group(1)
+        assert guard in job, f"{job_name} must remain visible when dependency-locks fails"
+        assert failure_step in job, f"{job_name} must fail when dependency-locks fails"
+
+
 def dependency_lock_source_command() -> str:
     path = ROOT / ".github/workflows/ci.yml"
     if not path.exists():

--- a/tests/test_uv_workflows.py
+++ b/tests/test_uv_workflows.py
@@ -83,7 +83,7 @@ def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
     guard = (
         "    if: >-\n"
         "      !cancelled() &&\n"
-        "      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure')\n"
+        "      (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || needs.dependency-locks.result != 'success')\n"
     )
     failure_step = (
         "      - name: Fail if dependency lock validation failed\n"
@@ -104,7 +104,7 @@ def test_required_ci_checks_fail_when_dependency_locks_fail() -> None:
     # A same-repository pull request normally has a false fork predicate. The
     # dependency failure branch is what makes each required check run and fail
     # instead of being skipped when that pull request's lock validation fails.
-    assert "github.event.pull_request.head.repo.fork || needs.dependency-locks.result == 'failure'" in guard
+    assert "github.event.pull_request.head.repo.fork || needs.dependency-locks.result != 'success'" in guard
 
 
 def dependency_lock_source_command() -> str:


### PR DESCRIPTION
## Changes being requested

- [x] I understand that this repository is auto-generated and my pull request may not be merged

When the required `lint`, `build`, `test`, and `test-httpx2` jobs depend on a failed `dependency-locks` job, GitHub Actions skips them. If those skipped jobs are branch-protection requirements, the pull request can appear to satisfy the required checks even though dependency validation failed.

Reproduction:
1. Make `dependency-locks` fail on a push or fork pull request.
2. Observe that each downstream required job is skipped rather than reported as failed.

Expected behavior: Required checks remain visible and fail when dependency-lock validation fails.

Actual behavior: The downstream required checks are skipped, which can let branch rules treat the workflow as successful.

Root cause: A failed job in `needs` implicitly skips dependent jobs unless their job-level condition includes a status function such as `always()`.

This change keeps the existing event filter, makes the four required jobs run after dependency-lock failure, and adds an early guard step that exits with failure before installing dependencies or executing the regular job. A static regression test protects both the job guards and the failure steps.

## Additional context & links

Fixes #3755

Validation:
- `ruby -e "require %q(yaml); YAML.load_file(%q(.github/workflows/ci.yml))"`: passed
- `.venv/bin/pytest tests/test_uv_workflows.py::test_required_ci_checks_fail_when_dependency_locks_fail -q`: 1 passed
- `.venv/bin/ruff check tests/test_uv_workflows.py`: passed
- `.venv/bin/ruff format --check tests/test_uv_workflows.py`: passed
- `git diff --check origin/main...HEAD`: passed
- Full `tests/test_uv_workflows.py`: not claimed. The first unrelated local failure is `test_editable_project_sync_requires_only_the_reviewed_root_build_exemption`: the installed uv is `0.6.14`, while `CONTRIBUTING.md` requires uv `>=0.12.1`; uv 0.6.14 rejects the test command combination `--frozen --dry-run` before the dependency assertion runs.