### PR TITLE
Remove unreachable SSE error branch

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -68,20 +68,6 @@ class Stream(Generic[_T]):
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
 
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
-                        message = None
-                        error = data.get("error")
-                        if is_mapping(error):
-                            message = error.get("message")
-                        if not message or not isinstance(message, str):
-                            message = "An error occurred during streaming"
-
-                        raise APIError(
-                            message=message,
-                            request=self.response.request,
-                            body=data["error"],
-                        )
-
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:
                     data = sse.json()
@@ -177,20 +163,6 @@ class AsyncStream(Generic[_T]):
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
                     data = sse.json()
-
-                    if sse.event == "error" and is_mapping(data) and data.get("error"):
-                        message = None
-                        error = data.get("error")
-                        if is_mapping(error):
-                            message = error.get("message")
-                        if not message or not isinstance(message, str):
-                            message = "An error occurred during streaming"
-
-                        raise APIError(
-                            message=message,
-                            request=self.response.request,
-                            body=data["error"],
-                        )
 
                     yield process_data(data={"data": data, "event": sse.event}, cast_to=cast_to, response=response)
                 else:


### PR DESCRIPTION
## Summary

- Remove the unreachable `sse.event == "error"` checks nested under the `thread.` event branch in both `Stream` and `AsyncStream`.
- Preserve the existing reachable error handling for non-`thread.` SSE payloads.

Closes #2796

## Tests

- `pytest -o addopts='' tests/test_streaming.py -q` (20 passed)
- `ruff check src/openai/_streaming.py`
- `ruff format --check src/openai/_streaming.py`
- `git diff --check`
