### PR TITLE
fix(types): allow find_in_page actions without url

### DIFF
--- a/src/openai/types/beta/beta_response_function_web_search.py
+++ b/src/openai/types/beta/beta_response_function_web_search.py
@@ -62,8 +62,8 @@ class ActionFindInPage(BaseModel):
     type: Literal["find_in_page"]
     """The action type."""
 
-    url: str
-    """The URL of the page searched for the pattern."""
+    url: Optional[str] = None
+    """The URL of the page searched for the pattern, when provided."""
 
 
 Action: TypeAlias = Annotated[Union[ActionSearch, ActionOpenPage, ActionFindInPage], PropertyInfo(discriminator="type")]

--- a/src/openai/types/beta/beta_response_function_web_search_param.py
+++ b/src/openai/types/beta/beta_response_function_web_search_param.py
@@ -63,8 +63,8 @@ class ActionFindInPage(TypedDict, total=False):
     type: Required[Literal["find_in_page"]]
     """The action type."""
 
-    url: Required[str]
-    """The URL of the page searched for the pattern."""
+    url: Optional[str]
+    """The URL of the page searched for the pattern, when provided."""
 
 
 Action: TypeAlias = Union[ActionSearch, ActionOpenPage, ActionFindInPage]

--- a/src/openai/types/responses/response_function_web_search.py
+++ b/src/openai/types/responses/response_function_web_search.py
@@ -61,8 +61,8 @@ class ActionFind(BaseModel):
     type: Literal["find_in_page"]
     """The action type."""
 
-    url: str
-    """The URL of the page searched for the pattern."""
+    url: Optional[str] = None
+    """The URL of the page searched for the pattern, when provided."""
 
 
 Action: TypeAlias = Annotated[Union[ActionSearch, ActionOpenPage, ActionFind], PropertyInfo(discriminator="type")]

--- a/src/openai/types/responses/response_function_web_search_param.py
+++ b/src/openai/types/responses/response_function_web_search_param.py
@@ -62,8 +62,8 @@ class ActionFind(TypedDict, total=False):
     type: Required[Literal["find_in_page"]]
     """The action type."""
 
-    url: Required[str]
-    """The URL of the page searched for the pattern."""
+    url: Optional[str]
+    """The URL of the page searched for the pattern, when provided."""
 
 
 Action: TypeAlias = Union[ActionSearch, ActionOpenPage, ActionFind]

--- a/tests/test_web_search_action_types.py
+++ b/tests/test_web_search_action_types.py
@@ -1,0 +1,17 @@
+from openai.types.responses.response_function_web_search import ResponseFunctionWebSearch
+from openai.types.responses.response_function_web_search_param import ActionFind as ActionFindParam
+
+
+def test_find_in_page_action_allows_missing_url() -> None:
+    item = ResponseFunctionWebSearch.model_validate(
+        {
+            "id": "ws_test",
+            "type": "web_search_call",
+            "status": "completed",
+            "action": {"type": "find_in_page", "pattern": "og:image"},
+        }
+    )
+
+    assert item.action.type == "find_in_page"
+    assert item.action.url is None
+    assert "url" not in ActionFindParam.__required_keys__

--- a/tests/test_web_search_action_types.py
+++ b/tests/test_web_search_action_types.py
@@ -1,6 +1,7 @@
+from openai._compat import model_parse
 from openai.types.beta.beta_response_function_web_search import BetaResponseFunctionWebSearch
-from openai.types.beta.beta_response_function_web_search_param import ActionFindInPage as BetaActionFindParam
 from openai.types.responses.response_function_web_search import ResponseFunctionWebSearch
+from openai.types.beta.beta_response_function_web_search_param import ActionFindInPage as BetaActionFindParam
 from openai.types.responses.response_function_web_search_param import ActionFind as ActionFindParam
 
 
@@ -14,7 +15,7 @@ def _find_payload() -> dict[str, object]:
 
 
 def test_find_in_page_action_allows_missing_url() -> None:
-    item = ResponseFunctionWebSearch.model_validate(_find_payload())
+    item = model_parse(ResponseFunctionWebSearch, _find_payload())
 
     assert item.action.type == "find_in_page"
     assert item.action.url is None
@@ -22,7 +23,7 @@ def test_find_in_page_action_allows_missing_url() -> None:
 
 
 def test_beta_find_in_page_action_allows_missing_url() -> None:
-    item = BetaResponseFunctionWebSearch.model_validate(_find_payload())
+    item = model_parse(BetaResponseFunctionWebSearch, _find_payload())
 
     assert item.action.type == "find_in_page"
     assert item.action.url is None

--- a/tests/test_web_search_action_types.py
+++ b/tests/test_web_search_action_types.py
@@ -1,17 +1,29 @@
+from openai.types.beta.beta_response_function_web_search import BetaResponseFunctionWebSearch
+from openai.types.beta.beta_response_function_web_search_param import ActionFindInPage as BetaActionFindParam
 from openai.types.responses.response_function_web_search import ResponseFunctionWebSearch
 from openai.types.responses.response_function_web_search_param import ActionFind as ActionFindParam
 
 
+def _find_payload() -> dict[str, object]:
+    return {
+        "id": "ws_test",
+        "type": "web_search_call",
+        "status": "completed",
+        "action": {"type": "find_in_page", "pattern": "og:image"},
+    }
+
+
 def test_find_in_page_action_allows_missing_url() -> None:
-    item = ResponseFunctionWebSearch.model_validate(
-        {
-            "id": "ws_test",
-            "type": "web_search_call",
-            "status": "completed",
-            "action": {"type": "find_in_page", "pattern": "og:image"},
-        }
-    )
+    item = ResponseFunctionWebSearch.model_validate(_find_payload())
 
     assert item.action.type == "find_in_page"
     assert item.action.url is None
     assert "url" not in ActionFindParam.__required_keys__
+
+
+def test_beta_find_in_page_action_allows_missing_url() -> None:
+    item = BetaResponseFunctionWebSearch.model_validate(_find_payload())
+
+    assert item.action.type == "find_in_page"
+    assert item.action.url is None
+    assert "url" not in BetaActionFindParam.__required_keys__

--- a/tests/test_web_search_action_types.py
+++ b/tests/test_web_search_action_types.py
@@ -1,7 +1,7 @@
 from openai._compat import model_parse
 from openai.types.beta.beta_response_function_web_search import BetaResponseFunctionWebSearch
-from openai.types.responses.response_function_web_search import ResponseFunctionWebSearch
 from openai.types.beta.beta_response_function_web_search_param import ActionFindInPage as BetaActionFindParam
+from openai.types.responses.response_function_web_search import ResponseFunctionWebSearch
 from openai.types.responses.response_function_web_search_param import ActionFind as ActionFindParam
 
 


### PR DESCRIPTION
## Summary

Fixes #3788.

The live Responses API can omit `url` from completed `web_search_call` actions of type `find_in_page`, but the generated stable and beta `find_in_page` action types still require it. Re-validating an API-produced item therefore fails even though the payload is valid.

This aligns both stable and beta action models and parameter types with the live response shape by making `url` optional, matching the existing optional treatment for `open_page.url`.

## Tests

Adds regression coverage that validates completed stable and beta `find_in_page` actions with no `url` and verifies the parameter TypedDicts no longer require the key.