### PR TITLE
fix(types): parse steer responses when message type is omitted

### DIFF
--- a/src/openai/types/beta/beta_response_steer_input.py
+++ b/src/openai/types/beta/beta_response_steer_input.py
@@ -116,9 +116,9 @@ class ResponseSteerInputItemListFunctionCallOutput(BaseModel):
     """
 
 
-ResponseSteerInputItemList: TypeAlias = Annotated[
-    Union[ResponseSteerInputItemListMessage, ResponseSteerInputItemListFunctionCallOutput],
-    PropertyInfo(discriminator="type"),
+ResponseSteerInputItemList: TypeAlias = Union[
+    ResponseSteerInputItemListMessage,
+    ResponseSteerInputItemListFunctionCallOutput,
 ]
 
 BetaResponseSteerInput: TypeAlias = Union[str, List[ResponseSteerInputItemList]]

--- a/src/openai/types/beta/beta_response_steer_input.py
+++ b/src/openai/types/beta/beta_response_steer_input.py
@@ -35,8 +35,8 @@ class ResponseSteerInputItemListMessage(BaseModel):
     role: Literal["user"]
     """The message role. Always `user`."""
 
-    type: Literal["message"]
-    """The item type. Always `message`."""
+    type: Optional[Literal["message"]] = None
+    """The optional item type. When provided, always `message`."""
 
     id: Optional[str] = None
     """The unique ID of this message item."""

--- a/src/openai/types/responses/response_steer_input.py
+++ b/src/openai/types/responses/response_steer_input.py
@@ -94,9 +94,9 @@ class ResponseSteerInputItemListFunctionCallOutput(BaseModel):
     """
 
 
-ResponseSteerInputItemList: TypeAlias = Annotated[
-    Union[ResponseSteerInputItemListMessage, ResponseSteerInputItemListFunctionCallOutput],
-    PropertyInfo(discriminator="type"),
+ResponseSteerInputItemList: TypeAlias = Union[
+    ResponseSteerInputItemListMessage,
+    ResponseSteerInputItemListFunctionCallOutput,
 ]
 
 ResponseSteerInput: TypeAlias = Union[str, List[ResponseSteerInputItemList]]

--- a/src/openai/types/responses/response_steer_input.py
+++ b/src/openai/types/responses/response_steer_input.py
@@ -26,8 +26,8 @@ class ResponseSteerInputItemListMessage(BaseModel):
     role: Literal["user"]
     """The message role. Always `user`."""
 
-    type: Literal["message"]
-    """The item type. Always `message`."""
+    type: Optional[Literal["message"]] = None
+    """The optional item type. When provided, always `message`."""
 
     id: Optional[str] = None
     """The unique ID of this message item."""

--- a/tests/test_response_steer_failed_event_types.py
+++ b/tests/test_response_steer_failed_event_types.py
@@ -1,0 +1,34 @@
+from openai.types.beta.beta_response_steer_failed_event import BetaResponseSteerFailedEvent
+from openai.types.responses.response_steer_failed_event import ResponseSteerFailedEvent
+
+
+def _failed_event_payload() -> dict[str, object]:
+    return {
+        "error": {
+            "code": "invalid_input",
+            "message": "Invalid steering input",
+            "type": "invalid_request_error",
+        },
+        "sequence_number": 1,
+        "steer": {
+            "input": [{"role": "user", "content": "continue"}],
+            "previous_response_id": "resp_test",
+        },
+        "type": "response.steer.failed",
+    }
+
+
+def test_failed_steer_event_parses_message_without_type() -> None:
+    event = ResponseSteerFailedEvent.model_validate(_failed_event_payload())
+
+    message = event.steer.input[0]
+    assert message.role == "user"
+    assert message.type is None
+
+
+def test_beta_failed_steer_event_parses_message_without_type() -> None:
+    event = BetaResponseSteerFailedEvent.model_validate(_failed_event_payload())
+
+    message = event.steer.input[0]
+    assert message.role == "user"
+    assert message.type is None

--- a/tests/test_response_steer_failed_event_types.py
+++ b/tests/test_response_steer_failed_event_types.py
@@ -1,5 +1,9 @@
 from openai.types.beta.beta_response_steer_failed_event import BetaResponseSteerFailedEvent
+from openai.types.beta.beta_response_steer_input import (
+    ResponseSteerInputItemListMessage as BetaResponseSteerInputItemListMessage,
+)
 from openai.types.responses.response_steer_failed_event import ResponseSteerFailedEvent
+from openai.types.responses.response_steer_input import ResponseSteerInputItemListMessage
 
 
 def _failed_event_payload() -> dict[str, object]:
@@ -21,7 +25,9 @@ def _failed_event_payload() -> dict[str, object]:
 def test_failed_steer_event_parses_message_without_type() -> None:
     event = ResponseSteerFailedEvent.model_validate(_failed_event_payload())
 
+    assert isinstance(event.steer.input, list)
     message = event.steer.input[0]
+    assert isinstance(message, ResponseSteerInputItemListMessage)
     assert message.role == "user"
     assert message.type is None
 
@@ -29,6 +35,8 @@ def test_failed_steer_event_parses_message_without_type() -> None:
 def test_beta_failed_steer_event_parses_message_without_type() -> None:
     event = BetaResponseSteerFailedEvent.model_validate(_failed_event_payload())
 
+    assert isinstance(event.steer.input, list)
     message = event.steer.input[0]
+    assert isinstance(message, BetaResponseSteerInputItemListMessage)
     assert message.role == "user"
     assert message.type is None


### PR DESCRIPTION
## Summary

The `response.steer` wire contract added in 3.8.0 allows a user message to omit its optional `type` field. `response.steer.failed` can return that original uncommitted input, but the generated response-side steer input model currently requires `type` and uses it as the discriminator for the message/tool-output union.

As a result, a failed steer event can be valid on the wire but fail SDK validation when the original user message omitted `type`.

This change:
- makes the stable and beta steer message `type` optional;
- removes the `type` discriminator from the two-variant response-side message/tool-output union so an omitted message discriminator can be parsed;
- leaves the tool-output and caller variants unchanged.

## Tests

Adds stable and beta regression coverage for `response.steer.failed` events that return a user message without `type`.