### PR TITLE
fix: only retry transport-level exceptions, not arbitrary ones

### DIFF
--- a/src/openai/_base_client.py
+++ b/src/openai/_base_client.py
@@ -65,6 +65,7 @@ from ._utils import SensitiveHeadersFilter, is_dict, is_list, asyncify, is_given
 from ._compat import PYDANTIC_V1, model_copy
 from ._httpx2 import (
     status_exceptions,
+    request_exceptions,
     timeout_exceptions,
     http_response_types,
     normalize_httpx_url,
@@ -1095,7 +1096,7 @@ class SyncAPIClient(BaseClient[httpx2.Client, Stream[Any]]):
             except OpenAIError as err:
                 # Propagate OpenAIErrors as-is, without retrying or wrapping in APIConnectionError
                 raise err
-            except Exception as err:
+            except request_exceptions() as err:
                 log.debug("Encountered exception: %s", type(err).__name__)
 
                 if remaining_retries > 0:
@@ -1718,7 +1719,7 @@ class AsyncAPIClient(BaseClient[httpx2.AsyncClient, AsyncStream[Any]]):
             except OpenAIError as err:
                 # Propagate OpenAIErrors as-is, without retrying or wrapping in APIConnectionError
                 raise err
-            except Exception as err:
+            except request_exceptions() as err:
                 log.debug("Encountered exception: %s", type(err).__name__)
 
                 if remaining_retries > 0:

--- a/src/openai/_httpx2.py
+++ b/src/openai/_httpx2.py
@@ -17,6 +17,7 @@ class _LegacyHttpxModule(Protocol):
     Timeout: type[httpx2.Timeout]
     Limits: type[httpx2.Limits]
     TimeoutException: type[httpx2.TimeoutException]
+    RequestError: type[httpx2.RequestError]
     HTTPStatusError: type[httpx2.HTTPStatusError]
     StreamConsumed: type[httpx2.StreamConsumed]
     RequestNotRead: type[httpx2.RequestNotRead]
@@ -97,6 +98,16 @@ def normalize_legacy_httpx_auth(value: httpx2.Auth) -> httpx2.Auth:
 def timeout_exceptions() -> tuple[type[httpx2.TimeoutException], ...]:
     module = _loaded_legacy_httpx()
     return (httpx2.TimeoutException,) if module is None else (httpx2.TimeoutException, module.TimeoutException)
+
+
+def request_exceptions() -> tuple[type[httpx2.RequestError], ...]:
+    """Exceptions raised by the transport for a single request: connection failures, protocol
+    errors, timeouts, and the like. Deliberately narrower than `Exception` so that unrelated
+    errors (e.g. a task-cancellation signal raised inside a custom transport) are not silently
+    retried and reported as an `APIConnectionError`.
+    """
+    module = _loaded_legacy_httpx()
+    return (httpx2.RequestError,) if module is None else (httpx2.RequestError, module.RequestError)
 
 
 def status_exceptions() -> tuple[type[httpx2.HTTPStatusError], ...]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,7 +23,7 @@ from openai._types import Omit
 from openai._utils import asyncify
 from openai._models import BaseModel, FinalRequestOptions
 from openai._streaming import Stream, AsyncStream
-from openai._exceptions import APIStatusError, APITimeoutError, APIResponseValidationError
+from openai._exceptions import APIStatusError, APITimeoutError, APIConnectionError, APIResponseValidationError
 from openai._base_client import (
     DEFAULT_TIMEOUT,
     HTTPX_DEFAULT_TIMEOUT,
@@ -1208,7 +1208,7 @@ class TestOpenAI:
             if nb_retries < failures_before_success:
                 nb_retries += 1
                 if failure_mode == "exception":
-                    raise RuntimeError("oops")
+                    raise httpx2.ConnectError("oops")
                 return httpx2.Response(500)
             return httpx2.Response(200)
 
@@ -1226,6 +1226,40 @@ class TestOpenAI:
 
         assert response.retries_taken == failures_before_success
         assert int(response.http_request.headers.get("x-stainless-retry-count")) == failures_before_success
+
+    @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
+    @pytest.mark.respx2(base_url=base_url)
+    def test_non_transport_exceptions_are_not_retried(self, client: OpenAI, respx2_mock: MockRouter) -> None:
+        # Exceptions that aren't raised by the transport layer (connection failures, timeouts,
+        # protocol errors, ...) must propagate immediately, unmodified, and without being
+        # retried. Previously a bare `except Exception` treated *any* error - including ones
+        # unrelated to the HTTP request, such as Celery's `SoftTimeLimitExceeded` - as a
+        # retryable connection error, which silently discarded the original exception and any
+        # cleanup logic relying on it.
+        client = client.with_options(max_retries=4)
+
+        nb_calls = 0
+
+        def raise_non_transport_error(_request: httpx2.Request) -> httpx2.Response:
+            nonlocal nb_calls
+            nb_calls += 1
+            raise RuntimeError("not a transport error")
+
+        respx2_mock.post("/chat/completions").mock(side_effect=raise_non_transport_error)
+
+        with pytest.raises(RuntimeError, match="not a transport error") as exc_info:
+            client.chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-5.4",
+            )
+
+        assert not isinstance(exc_info.value, APIConnectionError)
+        assert nb_calls == 1
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
@@ -2505,7 +2539,7 @@ class TestAsyncOpenAI:
             if nb_retries < failures_before_success:
                 nb_retries += 1
                 if failure_mode == "exception":
-                    raise RuntimeError("oops")
+                    raise httpx2.ConnectError("oops")
                 return httpx2.Response(500)
             return httpx2.Response(200)
 
@@ -2523,6 +2557,38 @@ class TestAsyncOpenAI:
 
         assert response.retries_taken == failures_before_success
         assert int(response.http_request.headers.get("x-stainless-retry-count")) == failures_before_success
+
+    @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)
+    @pytest.mark.respx2(base_url=base_url)
+    async def test_non_transport_exceptions_are_not_retried(
+        self, async_client: AsyncOpenAI, respx2_mock: MockRouter
+    ) -> None:
+        # See the sync counterpart above for context: a non-transport exception must propagate
+        # immediately, unmodified, and without being retried.
+        client = async_client.with_options(max_retries=4)
+
+        nb_calls = 0
+
+        def raise_non_transport_error(_request: httpx2.Request) -> httpx2.Response:
+            nonlocal nb_calls
+            nb_calls += 1
+            raise RuntimeError("not a transport error")
+
+        respx2_mock.post("/chat/completions").mock(side_effect=raise_non_transport_error)
+
+        with pytest.raises(RuntimeError, match="not a transport error") as exc_info:
+            await client.chat.completions.create(
+                messages=[
+                    {
+                        "content": "string",
+                        "role": "developer",
+                    }
+                ],
+                model="gpt-5.4",
+            )
+
+        assert not isinstance(exc_info.value, APIConnectionError)
+        assert nb_calls == 1
 
     @pytest.mark.parametrize("failures_before_success", [0, 2, 4])
     @mock.patch("openai._base_client.BaseClient._calculate_retry_timeout", _low_retry_timeout)


### PR DESCRIPTION
## Summary

The request retry loop in `_base_client.py` catches bare `Exception` and treats it exactly like a connection failure: it retries (if retries remain) and otherwise wraps it in `APIConnectionError`. That means *any* exception raised while a request is in flight — even one that has nothing to do with the HTTP request — gets silently swallowed and retried.

Concretely, this breaks graceful shutdown for callers that run the client inside a Celery task with a soft time limit: Celery's `SoftTimeLimitExceeded` is a plain `Exception` subclass, so it gets caught here, retried, and the task's cleanup/shutdown logic that depends on that exception propagating never runs.

Fixes #2737.

## Root cause

```python
except OpenAIError as err:
    raise err
except Exception as err:              # <-- too broad
    if remaining_retries > 0:
        self._sleep_for_retry(...)
        continue
    raise APIConnectionError(request=request) from err
```

Both the sync (`SyncAPIClient._request`) and async (`AsyncAPIClient._request`) retry loops had this issue.

## Fix

- Added `request_exceptions()` to `src/openai/_httpx2.py`, following the same pattern as the existing `timeout_exceptions()` / `status_exceptions()` helpers: it returns `(httpx2.RequestError,)`, plus the legacy `httpx.RequestError` when a legacy `httpx.AsyncClient`/`Client` has been injected (per the documented escape hatch).
- `httpx2.RequestError` (mirroring `httpx`'s hierarchy) is the base class for all genuine transport-level failures — connection errors, protocol errors, proxy errors, timeouts, etc. — so this is the right level to retry on.
- Replaced both `except Exception as err:` blocks with `except request_exceptions() as err:`.

Unrelated exceptions (e.g. `SoftTimeLimitExceeded`, or any other exception raised by code running underneath the transport) now propagate immediately, unmodified, and without being retried or wrapped in `APIConnectionError`.

## Tests

- `tests/test_client.py`: the existing `test_retries_taken[exception-*]` parametrization (sync + async) simulated a retryable exception with a bare `RuntimeError(...)`. Since that's no longer retried under this fix, I changed it to `httpx2.ConnectError(...)` — a genuine transport error — so it still exercises the "retry on exception" path meaningfully.
- Added new regression tests (sync + async): `test_non_transport_exceptions_are_not_retried`, which raises a plain `RuntimeError` from the mocked transport and asserts it (a) is not retried (the mock is only called once) and (b) propagates as the original `RuntimeError`, not wrapped in `APIConnectionError`.

All of `tests/test_client.py` passes locally (198 passed, 2 pre-existing/unrelated failures in `test_proxy_environment_variables` that reproduce identically on `main` without this change, 2 skipped). `ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

## Notes for reviewers

- This only narrows the *retry-on-exception* branch. The `except OpenAIError` (re-raise) and `except timeout_exceptions()` (dedicated `APITimeoutError` path) branches above it are untouched.
- I deliberately didn't touch the separate empty-`except Exception:` blocks used for best-effort cleanup elsewhere in `_base_client.py` (e.g. around client teardown) — those are a distinct issue (#3428) with a different fix shape (logging rather than narrowing).