### PR TITLE
fix: force additionalProperties=false on all objects in strict schemas

### DIFF
--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -46,8 +46,13 @@ def _ensure_strict_json_schema(
         for definition_name, definition_schema in definitions.items():
             _ensure_strict_json_schema(definition_schema, path=(*path, "definitions", definition_name), root=root)
 
+    # The API requires `additionalProperties: false` on every object, with no exceptions -
+    # so this is set unconditionally, overriding any existing value. Pydantic models with
+    # `extra="allow"` (or a `Dict[str, ...]`-shaped field) otherwise produce a schema with
+    # `additionalProperties` set to `True` or to a nested schema, either of which the API
+    # rejects with a 400 (`'additionalProperties' is required to be supplied and to be false`).
     typ = json_schema.get("type")
-    if typ == "object" and "additionalProperties" not in json_schema:
+    if typ == "object":
         json_schema["additionalProperties"] = False
 
     # object types

--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -47,22 +47,33 @@ def _ensure_strict_json_schema(
             _ensure_strict_json_schema(definition_schema, path=(*path, "definitions", definition_name), root=root)
 
     # The API requires `additionalProperties: false` on every object, with no exceptions.
-    # Pydantic models with `extra="allow"` produce `additionalProperties: True` here, which
-    # we can safely correct to `False` since that's the only value the API accepts. But a
-    # `Dict[str, ...]`-shaped field (or a mapping `RootModel`) produces a schema-valued
-    # `additionalProperties` describing the values' type - overwriting that with `False`
-    # would silently turn the field into an object that only accepts `{}`, rather than the
-    # mapping type it was declared as. Since the API has no way to represent an arbitrary-key
-    # mapping in a strict schema, we raise instead of silently producing a broken one.
+    #
+    # A Pydantic model with `extra="allow"` produces `additionalProperties: True` here. When
+    # the model also has at least one declared field, closing the object to exactly those
+    # fields is the closest representable approximation, and doesn't change what the
+    # *declared* fields accept - so that case is corrected to `False`.
+    #
+    # But `additionalProperties` can also describe a genuine arbitrary-key mapping that has no
+    # fixed shape at all: a `Dict[str, ...]`-shaped field or mapping `RootModel` produces a
+    # schema-valued `additionalProperties` (e.g. `{"type": "string"}`) describing the values'
+    # type; a `Dict[str, Any]`-shaped field, an `Any`-valued mapping `RootModel`, or a bare
+    # `extra="allow"` model with zero declared fields all produce `additionalProperties: True`
+    # with no (or no non-empty) `properties`. Overwriting any of these with `False` would
+    # silently turn the object into one that only accepts `{}`, rather than the mapping it was
+    # declared as - so the API has no way to represent it in a strict schema, and we raise
+    # instead of silently producing a broken one.
     typ = json_schema.get("type")
     if typ == "object":
         additional_properties = json_schema.get("additionalProperties", False)
-        if additional_properties not in (False, True):
+        properties = json_schema.get("properties")
+        has_declared_properties = is_dict(properties) and len(properties) > 0
+
+        if additional_properties is not False and not (additional_properties is True and has_declared_properties):
             raise TypeError(
-                "Objects with a typed `additionalProperties` value (e.g. from a "
-                "`Dict[str, ...]`-shaped field or a mapping `RootModel`) are not supported in "
-                f"strict schemas, since the API requires `additionalProperties: false` on "
-                f"every object; path={path}"
+                "Objects that accept arbitrary keys (e.g. a `Dict[str, ...]`-shaped field, a "
+                'mapping `RootModel`, or a bare `extra="allow"` model with no declared fields) '
+                "are not supported in strict schemas, since the API requires "
+                f"`additionalProperties: false` on every object; path={path}"
             )
         json_schema["additionalProperties"] = False
 

--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -46,13 +46,24 @@ def _ensure_strict_json_schema(
         for definition_name, definition_schema in definitions.items():
             _ensure_strict_json_schema(definition_schema, path=(*path, "definitions", definition_name), root=root)
 
-    # The API requires `additionalProperties: false` on every object, with no exceptions -
-    # so this is set unconditionally, overriding any existing value. Pydantic models with
-    # `extra="allow"` (or a `Dict[str, ...]`-shaped field) otherwise produce a schema with
-    # `additionalProperties` set to `True` or to a nested schema, either of which the API
-    # rejects with a 400 (`'additionalProperties' is required to be supplied and to be false`).
+    # The API requires `additionalProperties: false` on every object, with no exceptions.
+    # Pydantic models with `extra="allow"` produce `additionalProperties: True` here, which
+    # we can safely correct to `False` since that's the only value the API accepts. But a
+    # `Dict[str, ...]`-shaped field (or a mapping `RootModel`) produces a schema-valued
+    # `additionalProperties` describing the values' type - overwriting that with `False`
+    # would silently turn the field into an object that only accepts `{}`, rather than the
+    # mapping type it was declared as. Since the API has no way to represent an arbitrary-key
+    # mapping in a strict schema, we raise instead of silently producing a broken one.
     typ = json_schema.get("type")
     if typ == "object":
+        additional_properties = json_schema.get("additionalProperties", False)
+        if additional_properties not in (False, True):
+            raise TypeError(
+                "Objects with a typed `additionalProperties` value (e.g. from a "
+                "`Dict[str, ...]`-shaped field or a mapping `RootModel`) are not supported in "
+                f"strict schemas, since the API requires `additionalProperties: false` on "
+                f"every object; path={path}"
+            )
         json_schema["additionalProperties"] = False
 
     # object types

--- a/src/openai/lib/_pydantic.py
+++ b/src/openai/lib/_pydantic.py
@@ -48,17 +48,18 @@ def _ensure_strict_json_schema(
 
     # The API requires `additionalProperties: false` on every object, with no exceptions.
     #
-    # A Pydantic model with `extra="allow"` produces `additionalProperties: True` here. When
-    # the model also has at least one declared field, closing the object to exactly those
-    # fields is the closest representable approximation, and doesn't change what the
-    # *declared* fields accept - so that case is corrected to `False`.
+    # A Pydantic model with at least one declared property has a fixed shape to close the
+    # object around, so any non-`False` `additionalProperties` there - `True` for a plain
+    # `extra="allow"` model, or a schema for one with typed extras (`__pydantic_extra__`
+    # annotated to validate them) - is corrected to `False`. That only forbids keys beyond
+    # the ones already declared; it doesn't change what the *declared* fields accept.
     #
-    # But `additionalProperties` can also describe a genuine arbitrary-key mapping that has no
-    # fixed shape at all: a `Dict[str, ...]`-shaped field or mapping `RootModel` produces a
-    # schema-valued `additionalProperties` (e.g. `{"type": "string"}`) describing the values'
-    # type; a `Dict[str, Any]`-shaped field, an `Any`-valued mapping `RootModel`, or a bare
-    # `extra="allow"` model with zero declared fields all produce `additionalProperties: True`
-    # with no (or no non-empty) `properties`. Overwriting any of these with `False` would
+    # But `additionalProperties` can also describe a genuine arbitrary-key mapping with no
+    # fixed shape at all - no declared properties for it to be closed around: a
+    # `Dict[str, ...]`-shaped field or mapping `RootModel` produces a schema-valued
+    # `additionalProperties` describing the values' type; a `Dict[str, Any]`-shaped field, an
+    # `Any`-valued mapping `RootModel`, or a bare `extra="allow"` model with zero declared
+    # fields produce `additionalProperties: True`. Overwriting any of these with `False` would
     # silently turn the object into one that only accepts `{}`, rather than the mapping it was
     # declared as - so the API has no way to represent it in a strict schema, and we raise
     # instead of silently producing a broken one.
@@ -68,7 +69,7 @@ def _ensure_strict_json_schema(
         properties = json_schema.get("properties")
         has_declared_properties = is_dict(properties) and len(properties) > 0
 
-        if additional_properties is not False and not (additional_properties is True and has_declared_properties):
+        if additional_properties is not False and not has_declared_properties:
             raise TypeError(
                 "Objects that accept arbitrary keys (e.g. a `Dict[str, ...]`-shaped field, a "
                 'mapping `RootModel`, or a bare `extra="allow"` model with no declared fields) '

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, ConfigDict
 from inline_snapshot import snapshot
 
 import openai
@@ -409,3 +409,21 @@ def test_nested_inline_ref_expansion() -> None:
                 "additionalProperties": False,
             }
         )
+
+
+class ModelWithExtraAllowed(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(description="The name field.")
+
+
+def test_additional_properties_is_forced_false_even_when_extra_allow() -> None:
+    """A Pydantic model with `extra="allow"` produces `additionalProperties: True` from
+    Pydantic itself, but the API requires `additionalProperties: false` on every object with
+    no exceptions - so `to_strict_json_schema` must override it rather than leave it alone.
+    """
+    if PYDANTIC_V1:
+        pytest.skip("extra='allow' schema generation differs on Pydantic v1")
+
+    schema = to_strict_json_schema(ModelWithExtraAllowed)
+    assert schema["additionalProperties"] is False

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Dict
 
+import pytest
 from pydantic import Field, BaseModel, ConfigDict
 from inline_snapshot import snapshot
 
@@ -427,3 +429,19 @@ def test_additional_properties_is_forced_false_even_when_extra_allow() -> None:
 
     schema = to_strict_json_schema(ModelWithExtraAllowed)
     assert schema["additionalProperties"] is False
+
+
+class ModelWithDictField(BaseModel):
+    data: Dict[str, str] = Field(description="A mapping field.")
+
+
+def test_dict_field_raises_instead_of_silently_dropping_value_schema() -> None:
+    """A `Dict[str, ...]`-shaped field produces a schema-valued `additionalProperties`
+    describing the values' type (e.g. `{"type": "string"}`), not a boolean. The API can't
+    represent an arbitrary-key mapping in a strict schema, so `to_strict_json_schema` must
+    raise rather than silently overwrite that value with `False` - which would turn the field
+    into an object that only accepts `{}`, changing its meaning instead of reporting the
+    actual limitation.
+    """
+    with pytest.raises(TypeError, match="additionalProperties"):
+        to_strict_json_schema(ModelWithDictField)

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
-from pydantic import Field, BaseModel, ConfigDict
+from pydantic import Field, BaseModel, RootModel, ConfigDict
 from inline_snapshot import snapshot
 
 import openai
@@ -445,3 +445,51 @@ def test_dict_field_raises_instead_of_silently_dropping_value_schema() -> None:
     """
     with pytest.raises(TypeError, match="additionalProperties"):
         to_strict_json_schema(ModelWithDictField)
+
+
+class ModelWithDictAnyField(BaseModel):
+    data: Dict[str, Any] = Field(description="An unconstrained mapping field.")
+
+
+def test_dict_any_field_raises_instead_of_silently_allowing_only_empty_object() -> None:
+    """A `Dict[str, Any]`-shaped field produces `additionalProperties: True` with no declared
+    `properties` - the same boolean Pydantic uses for `extra="allow"`, but here there are no
+    declared fields to close the object around. Forcing `False` would silently accept only
+    `{}` instead of the arbitrary mapping the field was declared as, so this must raise just
+    like the schema-valued case above.
+    """
+    with pytest.raises(TypeError, match="additionalProperties"):
+        to_strict_json_schema(ModelWithDictAnyField)
+
+
+class EmptyModelWithExtraAllowed(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+def test_empty_extra_allow_model_raises_instead_of_forcing_empty_object() -> None:
+    """An `extra="allow"` model with zero declared fields behaves like an unconstrained
+    mapping - any keys are allowed - unlike the with-declared-fields case above, where closing
+    the object to the declared fields is a reasonable strict-schema approximation. With no
+    fields to close around, this must raise instead of silently accepting only `{}`.
+    """
+    if PYDANTIC_V1:
+        pytest.skip("extra='allow' schema generation differs on Pydantic v1")
+
+    with pytest.raises(TypeError, match="additionalProperties"):
+        to_strict_json_schema(EmptyModelWithExtraAllowed)
+
+
+def test_mapping_root_model_raises_instead_of_silently_dropping_value_schema() -> None:
+    """A mapping `RootModel` (e.g. `RootModel[Dict[str, str]]`) produces the same
+    schema-valued `additionalProperties` as a `Dict[str, ...]`-shaped field, just at the top
+    level of the schema instead of nested under a field - so it must raise for the same
+    reason.
+    """
+    if PYDANTIC_V1:
+        pytest.skip("RootModel is not available on Pydantic v1")
+
+    class MappingRootModel(RootModel[Dict[str, str]]):
+        pass
+
+    with pytest.raises(TypeError, match="additionalProperties"):
+        to_strict_json_schema(MappingRootModel)

--- a/tests/lib/test_pydantic.py
+++ b/tests/lib/test_pydantic.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Any, Dict
 
 import pytest
-from pydantic import Field, BaseModel, RootModel, ConfigDict
+from pydantic import Field, BaseModel, ConfigDict
 from inline_snapshot import snapshot
 
 import openai
@@ -458,8 +458,32 @@ def test_dict_any_field_raises_instead_of_silently_allowing_only_empty_object() 
     `{}` instead of the arbitrary mapping the field was declared as, so this must raise just
     like the schema-valued case above.
     """
+    if PYDANTIC_V1:
+        pytest.skip("Pydantic v1 omits `additionalProperties` entirely for `Dict[str, Any]`")
+
     with pytest.raises(TypeError, match="additionalProperties"):
         to_strict_json_schema(ModelWithDictAnyField)
+
+
+class ModelWithTypedExtra(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    __pydantic_extra__: Dict[str, int]  # type: ignore[misc]
+
+    name: str = Field(description="A declared field.")
+
+
+def test_typed_extra_is_forced_false_just_like_untyped_extra_allow() -> None:
+    """A Pydantic v2 model with `extra="allow"` and a typed `__pydantic_extra__` produces a
+    schema-valued `additionalProperties` (e.g. `{"type": "integer"}`) instead of `True`, but it
+    still has declared properties to close the object around, exactly like the untyped
+    `extra="allow"` case - so it must be forced to `False` too, not rejected just because the
+    value happens to be a schema rather than a boolean.
+    """
+    if PYDANTIC_V1:
+        pytest.skip("typed `__pydantic_extra__` is not available on Pydantic v1")
+
+    schema = to_strict_json_schema(ModelWithTypedExtra)
+    assert schema["additionalProperties"] is False
 
 
 class EmptyModelWithExtraAllowed(BaseModel):
@@ -487,6 +511,11 @@ def test_mapping_root_model_raises_instead_of_silently_dropping_value_schema() -
     """
     if PYDANTIC_V1:
         pytest.skip("RootModel is not available on Pydantic v1")
+
+    # Imported locally: `pydantic.RootModel` doesn't exist on Pydantic v1, and a module-level
+    # import would raise `ImportError` during test collection - before the `PYDANTIC_V1` skip
+    # above ever gets a chance to run - breaking collection for the entire file on that lane.
+    from pydantic import RootModel
 
     class MappingRootModel(RootModel[Dict[str, str]]):
         pass


### PR DESCRIPTION
## Summary

`to_strict_json_schema()` / `_ensure_strict_json_schema()` in `src/openai/lib/_pydantic.py` is supposed to normalize a Pydantic-generated JSON schema so it satisfies the Responses/Chat Completions strict-schema requirement that every object have `additionalProperties: false`. It only did this when the key was completely absent from the schema:

```python
if typ == "object" and "additionalProperties" not in json_schema:
    json_schema["additionalProperties"] = False
```

A Pydantic model with `model_config = ConfigDict(extra="allow")` already produces `additionalProperties: True` in its generated schema (that's exactly what `extra="allow"` means to Pydantic), so this branch never fired for it, and the schema was sent to the API with `additionalProperties: true` still in place.

Fixes #2740.

## Reproduction (from the issue)

```python
from pydantic import BaseModel, ConfigDict

class MyClass(BaseModel):
    model_config = ConfigDict(extra="allow")
    field: str

response = await client.beta.chat.completions.parse(
    model="gpt-4.1",
    messages=[{"role": "user", "content": "..."}],
    response_format=MyClass,
)
```

```
BadRequestError: Error code: 400 - {'error': {'message': "Invalid schema for response_format 'MyClass': In context=(), 'additionalProperties' is required to be supplied and to be false.", ...}}
```

## Fix

The discriminator that matters is **whether the schema has at least one declared property** - i.e. a fixed shape to close the object around:

```python
typ = json_schema.get("type")
if typ == "object":
    additional_properties = json_schema.get("additionalProperties", False)
    properties = json_schema.get("properties")
    has_declared_properties = is_dict(properties) and len(properties) > 0

    if additional_properties is not False and not has_declared_properties:
        raise TypeError(...)
    json_schema["additionalProperties"] = False
```

- **Has declared properties** (a real model with named fields) - any non-`False` `additionalProperties` there is corrected to `False`. This covers plain `extra="allow"` (`additionalProperties: True`) *and* `extra="allow"` with a typed `__pydantic_extra__` (`additionalProperties` is a schema, e.g. `{"type": "integer"}`) - forbidding keys beyond the declared ones doesn't change what those declared fields accept.
- **No declared properties** (a genuine arbitrary-key mapping with no fixed shape at all) - a `Dict[str, ...]`-shaped field, a mapping `RootModel`, a `Dict[str, Any]`-shaped field, an `Any`-valued mapping `RootModel`, or a bare `extra="allow"` model with zero fields. The API can't represent "any key, any/typed value" in a strict schema, so this now raises a clear `TypeError` instead of silently forcing `additionalProperties: false`, which would turn the object into one that only accepts `{}` - changing its declared contract instead of reporting the real limitation.

This can't regress a previously-working case: every schema shape this raises for was already going to be rejected by the API with a 400 before this fix - just with the API's own opaque error at request time, rather than this library's own clearer error before the request is even sent.

## Review history

This PR went through several rounds of automated review, each catching a real edge case:
1. **Schema-valued `additionalProperties`** (`Dict[str, str]`, mapping `RootModel`) - the first version forced `additionalProperties: False` unconditionally, silently discarding the value schema. Fixed by raising instead of overwriting non-boolean values.
2. **Boolean `additionalProperties: True` with no declared properties** (`Dict[str, Any]`, `Any`-valued mapping `RootModel`, bare `extra="allow"` with no fields) - indistinguishable from safe `extra="allow"`-with-fields by value alone. Fixed by keying the decision on declared properties instead of the boolean.
3. **Typed extras** (`extra="allow"` + typed `__pydantic_extra__`) produce a schema-valued `additionalProperties` *with* declared properties - the fix from (2) still rejected these since it special-cased `True`. Simplified further: the discriminator is declared properties alone, regardless of whether `additionalProperties` is `True` or a schema.
4. **Pydantic v1 test-collection crash**: a module-level `from pydantic import RootModel` in the new test raised `ImportError` during collection on the v1 lane (`RootModel` doesn't exist there), before the `PYDANTIC_V1` skip in the test body could run - breaking the whole file's collection under `./scripts/test-pydantic-v1`. Fixed by moving the import inside the test, after the skip.
5. **Unguarded v1 assumption**: a test assumed Pydantic v2's `additionalProperties: True` representation for `Dict[str, Any]`; Pydantic v1 omits the key entirely there, taking the missing-key path instead. Added a `PYDANTIC_V1` skip.

## Tests

`tests/lib/test_pydantic.py` now covers:
- `test_additional_properties_is_forced_false_even_when_extra_allow` - `extra="allow"` **with** a declared field -> `False`.
- `test_typed_extra_is_forced_false_just_like_untyped_extra_allow` - `extra="allow"` with a **typed** `__pydantic_extra__` (schema-valued `additionalProperties`) and a declared field -> `False`.
- `test_empty_extra_allow_model_raises_instead_of_forcing_empty_object` - `extra="allow"` with **zero** declared fields -> raises.
- `test_dict_field_raises_instead_of_silently_dropping_value_schema` - `Dict[str, str]` field -> raises.
- `test_dict_any_field_raises_instead_of_silently_allowing_only_empty_object` - `Dict[str, Any]` field -> raises (skipped on Pydantic v1, which represents this differently).
- `test_mapping_root_model_raises_instead_of_silently_dropping_value_schema` - `RootModel[Dict[str, str]]` -> raises (skipped on Pydantic v1, `RootModel` import is local to avoid breaking v1 collection).

Full `tests/lib/test_pydantic.py` suite: 9 passed. No existing snapshot changed - none of the current tests exercise a model with a non-boolean or fieldless-`True` `additionalProperties`, so this remains a pure bugfix with no behavior change for existing schemas.

`ruff check`, `ruff format --check`, and `mypy` are clean on the changed files.

## Notes for reviewers

This only touches the top-level normalization step in `_ensure_strict_json_schema`; the recursive walk into `properties`, `items`, `anyOf`, `allOf`, and `$ref` expansion is untouched, so nested objects (which already go through this same function recursively) get the same treatment for free.
