### PR TITLE
fix(helpers): use running loop in voice helpers

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -71,7 +71,7 @@ class LocalAudioPlayer:
         else:
             audio_content = await self._tts_response_to_buffer(input)
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         idx = 0
 
@@ -105,7 +105,7 @@ class LocalAudioPlayer:
         self,
         buffer_stream: AsyncGenerator[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None], None],
     ) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         buffer_queue: queue.Queue[Union[npt.NDArray[np.float32], npt.NDArray[np.int16], None]] = queue.Queue(maxsize=50)
 

--- a/src/openai/helpers/microphone.py
+++ b/src/openai/helpers/microphone.py
@@ -54,7 +54,7 @@ class Microphone(Generic[DType]):
     async def record(self, return_ndarray: None = ...) -> FileTypes: ...
 
     async def record(self, return_ndarray: Union[bool, None] = False) -> Union[npt.NDArray[DType], FileTypes]:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         event = asyncio.Event()
         self.buffer_chunks: list[npt.NDArray[DType]] = []
         start_time = time.perf_counter()


### PR DESCRIPTION
## Problem
The voice helper async methods are already running inside coroutines, but they call `asyncio.get_event_loop()` before using the loop for thread-safe callbacks and executor work. On modern Python, `asyncio.get_running_loop()` is the clearer API in this context and avoids depending on event-loop policy fallback behavior.

## Before / after
Before, `Microphone.record()`, `LocalAudioPlayer.play()`, and `LocalAudioPlayer.play_stream()` fetched the event loop with `get_event_loop()`.

After, those async methods capture the currently running loop with `get_running_loop()` while keeping the existing `call_soon_threadsafe()` and `run_in_executor()` behavior unchanged.

## Verification
- `python -m py_compile src/openai/helpers/microphone.py src/openai/helpers/local_audio_player.py`
- `git diff --check`

I did not run a hardware audio smoke test locally.