### PR TITLE
fix(streaming): wrap midstream transport errors in APITimeoutError / APIConnectionError (#3811)

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -11,7 +11,16 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 import httpx2
 
 from ._utils import is_mapping, extract_type_var_from_base
-from ._exceptions import APIError
+from ._httpx2 import timeout_exceptions, _loaded_legacy_httpx
+from ._exceptions import APIError, APITimeoutError, APIConnectionError
+
+
+def _transport_exceptions() -> tuple[type[BaseException], ...]:
+    module = _loaded_legacy_httpx()
+    if module is None:
+        return (httpx2.TransportError,)
+    return (httpx2.TransportError, module.TransportError)
+
 
 if TYPE_CHECKING:
     from ._client import OpenAI, AsyncOpenAI
@@ -59,6 +68,7 @@ class Stream(Generic[_T]):
         process_data = self._client._process_response_data
         iterator = self._iter_events()
 
+        request = response.request
         try:
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
@@ -106,6 +116,10 @@ class Stream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except timeout_exceptions() as err:
+            raise APITimeoutError(request=request) from err
+        except _transport_exceptions() as err:
+            raise APIConnectionError(request=request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             response.close()
@@ -169,6 +183,7 @@ class AsyncStream(Generic[_T]):
         process_data = self._client._process_response_data
         iterator = self._iter_events()
 
+        request = response.request
         try:
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
@@ -216,6 +231,10 @@ class AsyncStream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except timeout_exceptions() as err:
+            raise APITimeoutError(request=request) from err
+        except _transport_exceptions() as err:
+            raise APIConnectionError(request=request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             await response.aclose()

--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -11,6 +11,7 @@ from ..._httpx2 import timeout_exceptions
 from ..._models import construct_type
 from ..._streaming import Stream, AsyncStream
 from ...types.beta import AssistantStreamEvent
+from ..._exceptions import APITimeoutError, APIConnectionError
 from ...types.beta.threads import (
     Run,
     Text,
@@ -410,6 +411,15 @@ class AssistantEventHandler:
                 self._emit_sse_event(event)
 
                 yield event
+        except APITimeoutError as exc:
+            cause = exc.__cause__ if isinstance(exc.__cause__, _timeout_exceptions()) else exc
+            self.on_timeout()
+            self.on_exception(cause)
+            raise cause from None
+        except APIConnectionError as exc:
+            cause = exc.__cause__ if isinstance(exc.__cause__, Exception) else exc
+            self.on_exception(cause)
+            raise cause from None
         except _timeout_exceptions() as exc:
             self.on_timeout()
             self.on_exception(exc)
@@ -842,6 +852,15 @@ class AsyncAssistantEventHandler:
                 await self._emit_sse_event(event)
 
                 yield event
+        except APITimeoutError as exc:
+            cause = exc.__cause__ if isinstance(exc.__cause__, _timeout_exceptions()) else exc
+            await self.on_timeout()
+            await self.on_exception(cause)
+            raise cause from None
+        except APIConnectionError as exc:
+            cause = exc.__cause__ if isinstance(exc.__cause__, Exception) else exc
+            await self.on_exception(cause)
+            raise cause from None
         except _timeout_exceptions() as exc:
             await self.on_timeout()
             await self.on_exception(exc)

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -710,3 +710,105 @@ async def test_sigv4_provider_preserves_httpx2_family_and_rejects_one_shot_bodie
     assert "Credential=fixture-access-key/" in async_requests[0].headers["authorization"]
     assert sync_requests[0].headers["x-amz-security-token"] == "fixture-session-token"
     assert async_requests[0].headers["x-amz-security-token"] == "fixture-session-token"
+
+
+class _DiesMidStreamSync(httpx2.SyncByteStream):
+    @override
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        yield b'data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"x","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}\n\n'
+        raise httpx2.ReadTimeout("timed out while reading the stream")
+
+
+class _DiesMidStreamAsync(httpx2.AsyncByteStream):
+    @override
+    async def __aiter__(self):  # type: ignore[no-untyped-def]
+        yield b'data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"x","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}\n\n'
+        raise httpx2.RemoteProtocolError("peer closed connection without sending complete message body")
+
+
+def test_chat_stream_midstream_timeout_wrapped() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200, headers={"content-type": "text/event-stream"}, stream=_DiesMidStreamSync(), request=request
+        )
+
+    with OpenAI(
+        api_key="test",
+        base_url="https://example.test/v1",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False),
+        max_retries=0,
+    ) as client:
+        with pytest.raises(APITimeoutError) as exc_info:
+            for _ in client.chat.completions.create(
+                model="x", messages=[{"role": "user", "content": "hi"}], stream=True
+            ):
+                pass
+        assert isinstance(exc_info.value.__cause__, httpx2.ReadTimeout)
+
+
+async def test_chat_stream_midstream_connection_error_wrapped() -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(
+            200, headers={"content-type": "text/event-stream"}, stream=_DiesMidStreamAsync(), request=request
+        )
+
+    async with AsyncOpenAI(
+        api_key="test",
+        base_url="https://example.test/v1",
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False),
+        max_retries=0,
+    ) as client:
+        with pytest.raises(APIConnectionError) as exc_info:
+            async for _ in await client.chat.completions.create(
+                model="x", messages=[{"role": "user", "content": "hi"}], stream=True
+            ):
+                pass
+        assert isinstance(exc_info.value.__cause__, httpx2.RemoteProtocolError)
+
+
+def test_chat_stream_midstream_connection_error_wrapped_sync() -> None:
+    class _DiesSync(httpx2.SyncByteStream):
+        @override
+        def __iter__(self):  # type: ignore[no-untyped-def]
+            yield b'data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"x","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}\n\n'
+            raise httpx2.RemoteProtocolError("peer closed connection without sending complete message body")
+
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, stream=_DiesSync(), request=request)
+
+    with OpenAI(
+        api_key="test",
+        base_url="https://example.test/v1",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler), trust_env=False),
+        max_retries=0,
+    ) as client:
+        with pytest.raises(APIConnectionError) as exc_info:
+            for _ in client.chat.completions.create(
+                model="x", messages=[{"role": "user", "content": "hi"}], stream=True
+            ):
+                pass
+        assert isinstance(exc_info.value.__cause__, httpx2.RemoteProtocolError)
+
+
+async def test_chat_stream_midstream_timeout_wrapped_async() -> None:
+    class _DiesAsync(httpx2.AsyncByteStream):
+        @override
+        async def __aiter__(self):  # type: ignore[no-untyped-def]
+            yield b'data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"x","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}\n\n'
+            raise httpx2.ReadTimeout("timed out while reading the stream")
+
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, stream=_DiesAsync(), request=request)
+
+    async with AsyncOpenAI(
+        api_key="test",
+        base_url="https://example.test/v1",
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler), trust_env=False),
+        max_retries=0,
+    ) as client:
+        with pytest.raises(APITimeoutError) as exc_info:
+            async for _ in await client.chat.completions.create(
+                model="x", messages=[{"role": "user", "content": "hi"}], stream=True
+            ):
+                pass
+        assert isinstance(exc_info.value.__cause__, httpx2.ReadTimeout)


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Problem

When consuming a streaming response (e.g. `client.chat.completions.create(..., stream=True)`), transport errors that occur mid-stream (such as a read timeout or dropped socket connection) escaped as raw `httpx.ReadTimeout`, `httpx2.ReadTimeout`, or `httpx2.RemoteProtocolError`.

Because these exceptions are not subclasses of `openai.APIError` (they do not inherit from `APIConnectionError` or `APITimeoutError`), standard exception-handling blocks around API calls:

```python
try:
    for chunk in client.chat.completions.create(..., stream=True):
        ...
except openai.APIError as err:
    ...
```

fail to catch the most common streaming failures, breaking client resilience and leaving mid-stream errors inconsistent with the initial request-send path.

## Root Cause

`Stream.__stream__()` and `AsyncStream.__stream__()` in `src/openai/_streaming.py` iterated over SSE events without exception-wrapping blocks. Unlike `_base_client.py` (which maps `timeout_exceptions()` to `APITimeoutError` and transport exceptions to `APIConnectionError`), the streaming iterator let raw `httpx2` / legacy `httpx` exceptions bubble out directly to the consumer.

## Solution

1. In `src/openai/_streaming.py`, wrapped the iteration loop in `Stream.__stream__()` and `AsyncStream.__stream__()`:
   - `except timeout_exceptions() as err:` -> `raise APITimeoutError(request=request) from err`
   - `except _transport_exceptions() as err:` -> `raise APIConnectionError(request=request) from err`
   - `_transport_exceptions()` covers `httpx2.TransportError` and `httpx.TransportError` (when legacy httpx is loaded), matching the `timeout_exceptions()` pattern.
   - `response.close()` / `await response.aclose()` is safely retained in the `finally:` block.
2. In `src/openai/lib/streaming/_assistants.py`, handled `APITimeoutError` and `APIConnectionError` in `AssistantEventHandler` and `AsyncAssistantEventHandler`, unwrapping `exc.__cause__` so that existing `on_timeout()` and `on_exception()` callbacks receive the underlying transport exception family, preserving the contract tested by `test_assistant_stream_timeout_callbacks_preserve_httpx2_family`.

## Testing

Added 4 new test cases to `tests/test_httpx2.py`:
- `test_chat_stream_midstream_timeout_wrapped` (sync `ReadTimeout` -> `APITimeoutError`)
- `test_chat_stream_midstream_connection_error_wrapped` (async `RemoteProtocolError` -> `APIConnectionError`)
- `test_chat_stream_midstream_connection_error_wrapped_sync` (sync `RemoteProtocolError` -> `APIConnectionError`)
- `test_chat_stream_midstream_timeout_wrapped_async` (async `ReadTimeout` -> `APITimeoutError`)

Verified:
- Fails pre-fix (`httpx2.ReadTimeout` and `httpx2.RemoteProtocolError` escape raw).
- Passes post-fix with `__cause__` correctly chained.
- `tests/test_httpx2.py` and `tests/test_streaming.py` pass cleanly (41 passed, 1 skipped).

## Verification

- Targeted tests: 4 passed in `tests/test_httpx2.py`
- Integration tests: 41 passed across `tests/test_httpx2.py` and `tests/test_streaming.py`
- Type checking: Verified against `_constants.py`, `_httpx2.py`, and `_exceptions.py`
- Lint: `ruff check` passed with 0 errors
- Formatter: `ruff format --check` passed (3 files checked)

## Impact

Consumers iterating over streams can now reliably catch `openai.APIError`, `openai.APIConnectionError`, and `openai.APITimeoutError` for all midstream transport failures, consistent with the rest of the SDK.

Fixes #3811
