### PR TITLE
fix: wrap transport failures while consuming a stream

### DIFF
--- a/src/openai/_httpx2.py
+++ b/src/openai/_httpx2.py
@@ -17,6 +17,7 @@ class _LegacyHttpxModule(Protocol):
     Timeout: type[httpx2.Timeout]
     Limits: type[httpx2.Limits]
     TimeoutException: type[httpx2.TimeoutException]
+    TransportError: type[httpx2.TransportError]
     HTTPStatusError: type[httpx2.HTTPStatusError]
     StreamConsumed: type[httpx2.StreamConsumed]
     RequestNotRead: type[httpx2.RequestNotRead]
@@ -97,6 +98,11 @@ def normalize_legacy_httpx_auth(value: httpx2.Auth) -> httpx2.Auth:
 def timeout_exceptions() -> tuple[type[httpx2.TimeoutException], ...]:
     module = _loaded_legacy_httpx()
     return (httpx2.TimeoutException,) if module is None else (httpx2.TimeoutException, module.TimeoutException)
+
+
+def transport_exceptions() -> tuple[type[httpx2.TransportError], ...]:
+    module = _loaded_legacy_httpx()
+    return (httpx2.TransportError,) if module is None else (httpx2.TransportError, module.TransportError)
 
 
 def status_exceptions() -> tuple[type[httpx2.HTTPStatusError], ...]:

--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -11,7 +11,8 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 import httpx2
 
 from ._utils import is_mapping, extract_type_var_from_base
-from ._exceptions import APIError
+from ._httpx2 import timeout_exceptions, transport_exceptions
+from ._exceptions import APIError, APITimeoutError, APIConnectionError
 
 if TYPE_CHECKING:
     from ._client import OpenAI, AsyncOpenAI
@@ -106,6 +107,10 @@ class Stream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except timeout_exceptions() as err:
+            raise APITimeoutError(request=response.request) from err
+        except transport_exceptions() as err:
+            raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             response.close()
@@ -216,6 +221,10 @@ class AsyncStream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except timeout_exceptions() as err:
+            raise APITimeoutError(request=response.request) from err
+        except transport_exceptions() as err:
+            raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             await response.aclose()

--- a/src/openai/lib/streaming/_assistants.py
+++ b/src/openai/lib/streaming/_assistants.py
@@ -11,6 +11,7 @@ from ..._httpx2 import timeout_exceptions
 from ..._models import construct_type
 from ..._streaming import Stream, AsyncStream
 from ...types.beta import AssistantStreamEvent
+from ..._exceptions import APITimeoutError
 from ...types.beta.threads import (
     Run,
     Text,
@@ -25,7 +26,7 @@ from ...types.beta.threads.runs import RunStep, ToolCall, RunStepDelta, ToolCall
 
 
 def _timeout_exceptions() -> tuple[type[Exception], ...]:
-    return (*timeout_exceptions(), asyncio.TimeoutError)
+    return (*timeout_exceptions(), asyncio.TimeoutError, APITimeoutError)
 
 
 class AssistantEventHandler:

--- a/tests/test_httpx2.py
+++ b/tests/test_httpx2.py
@@ -638,11 +638,13 @@ async def test_assistant_stream_timeout_callbacks_preserve_httpx2_family() -> No
         with sync_client.beta.threads.runs.stream(  # pyright: ignore[reportDeprecated]
             assistant_id="asst_test", thread_id="thread_test", event_handler=sync_handler
         ) as stream:
-            with pytest.raises(httpx2.ReadTimeout, match="assistant stream timeout"):
+            with pytest.raises(APITimeoutError) as sync_exc_info:
                 stream.until_done()
 
+    assert isinstance(sync_exc_info.value.__cause__, httpx2.ReadTimeout)
     assert sync_handler.timed_out
-    assert isinstance(sync_handler.exception, httpx2.ReadTimeout)
+    assert isinstance(sync_handler.exception, APITimeoutError)
+    assert isinstance(sync_handler.exception.__cause__, httpx2.ReadTimeout)
 
     async_handler = AsyncHandler()
     async with AsyncOpenAI(
@@ -654,11 +656,13 @@ async def test_assistant_stream_timeout_callbacks_preserve_httpx2_family() -> No
         async with async_client.beta.threads.runs.stream(  # pyright: ignore[reportDeprecated]
             assistant_id="asst_test", thread_id="thread_test", event_handler=async_handler
         ) as async_stream:
-            with pytest.raises(httpx2.ReadTimeout, match="assistant stream timeout"):
+            with pytest.raises(APITimeoutError) as async_exc_info:
                 await async_stream.until_done()
 
+    assert isinstance(async_exc_info.value.__cause__, httpx2.ReadTimeout)
     assert async_handler.timed_out
-    assert isinstance(async_handler.exception, httpx2.ReadTimeout)
+    assert isinstance(async_handler.exception, APITimeoutError)
+    assert isinstance(async_handler.exception.__cause__, httpx2.ReadTimeout)
 
 
 async def test_sigv4_provider_preserves_httpx2_family_and_rejects_one_shot_bodies() -> None:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,7 +5,7 @@ from typing import Iterator, AsyncIterator
 import httpx2
 import pytest
 
-from openai import OpenAI, AsyncOpenAI
+from openai import OpenAI, APIError, AsyncOpenAI, APITimeoutError, APIConnectionError
 from openai._streaming import Stream, AsyncStream, ServerSentEvent
 
 
@@ -216,6 +216,35 @@ async def test_multi_byte_character_multiple_chunks(
     assert sse.json() == {"content": "известни"}
 
 
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+@pytest.mark.parametrize(
+    "failure,expected",
+    [
+        (httpx2.ReadTimeout("timed out while reading the stream"), APITimeoutError),
+        (httpx2.RemoteProtocolError("peer closed connection"), APIConnectionError),
+    ],
+    ids=["timeout", "connection"],
+)
+async def test_transport_error_mid_stream(
+    sync: bool,
+    failure: httpx2.TransportError,
+    expected: type[APIError],
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> None:
+    def body() -> Iterator[bytes]:
+        yield b'data: {"foo":true}\n'
+        yield b"\n"
+        raise failure
+
+    stream = make_stream(content=body(), sync=sync, client=client, async_client=async_client)
+
+    with pytest.raises(expected) as exc_info:
+        await consume_stream(stream)
+
+    assert exc_info.value.__cause__ is failure
+
+
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:
     for chunk in iter:
         yield chunk
@@ -246,3 +275,30 @@ def make_event_iterator(
     return AsyncStream(
         cast_to=object, client=async_client, response=httpx2.Response(200, content=to_aiter(content))
     )._iter_events()
+
+
+def make_stream(
+    content: Iterator[bytes],
+    *,
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> Stream[object] | AsyncStream[object]:
+    request = httpx2.Request("POST", "https://example.test/v1/chat/completions")
+
+    if sync:
+        return Stream(cast_to=object, client=client, response=httpx2.Response(200, content=content, request=request))
+
+    return AsyncStream(
+        cast_to=object, client=async_client, response=httpx2.Response(200, content=to_aiter(content), request=request)
+    )
+
+
+async def consume_stream(stream: Stream[object] | AsyncStream[object]) -> None:
+    if isinstance(stream, AsyncStream):
+        async for _ in stream:
+            pass
+        return
+
+    for _ in stream:
+        pass


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`_base_client` wraps failures from the initial send, but `Stream` and `AsyncStream` iterate the response body with nothing around the loop. A read timeout or a dropped connection part-way through a stream therefore surfaces as a raw `httpx2.ReadTimeout` or `httpx2.RemoteProtocolError`, so `except openai.APIError` around a streaming call misses the most common streaming failure.

Both stream classes now catch transport failures raised while the body is consumed and re-raise them as `APITimeoutError` or `APIConnectionError`, keeping the original exception as `__cause__`. `transport_exceptions()` sits next to the existing compat helpers in `_httpx2.py`, so a loaded legacy `httpx` is covered the same way as `timeout_exceptions()`.

Two knock-on changes come with that. The assistants event handler decides whether to fire `on_timeout()` from the same exception set, so `APITimeoutError` was added there to keep that callback firing on a stream read timeout. And `test_assistant_stream_timeout_callbacks_preserve_httpx2_family` asserted the raw `httpx2.ReadTimeout`; it now asserts the wrapper and checks `__cause__`, which still pins the httpx2 family.

Raw byte streaming through `with_streaming_response` is untouched and still surfaces httpx exceptions directly. Whether a partly consumed stream can be retried is a separate question and is not addressed here.

## Additional context & links

Closes #3811

Validation:
- 3,153 tests passed, 120 skipped, across the suite excluding `tests/api_resources`, `tests/lib/test_fine_tuning_positional_arguments.py` and `tests/test_uv_workflows.py`, which need the mock server or network
- `test_transport_error_mid_stream` covers sync and async against both a timeout and a protocol error; all four cases fail on main
- Ruff check and format, mypy, and Pyright passed
- Custom-code budget: 6,626 / 10,000 lines
