### PR TITLE
fix(helpers): propagate audio stream producer errors

### DIFF
--- a/src/openai/helpers/local_audio_player.py
+++ b/src/openai/helpers/local_audio_player.py
@@ -153,13 +153,26 @@ class LocalAudioPlayer:
         buffer_pos = 0
 
         producer_task = asyncio.create_task(buffer_producer())
+        playback_task = asyncio.create_task(event.wait())
 
-        with sd.OutputStream(
-            samplerate=SAMPLE_RATE,
-            channels=self.channels,
-            dtype=self.dtype,
-            callback=callback,
-        ):
-            await event.wait()
+        try:
+            with sd.OutputStream(
+                samplerate=SAMPLE_RATE,
+                channels=self.channels,
+                dtype=self.dtype,
+                callback=callback,
+            ):
+                done, _ = await asyncio.wait(
+                    (producer_task, playback_task),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if producer_task in done:
+                    producer_task.result()
+                await playback_task
 
-        await producer_task
+            await producer_task
+        finally:
+            for task in (producer_task, playback_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(producer_task, playback_task, return_exceptions=True)

--- a/tests/test_local_audio_player.py
+++ b/tests/test_local_audio_player.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from collections.abc import AsyncGenerator
+
+import pytest
+
+from openai.helpers import local_audio_player
+
+
+class SilentOutputStream:
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    def __enter__(self) -> SilentOutputStream:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+async def test_play_stream_propagates_producer_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def broken_stream() -> AsyncGenerator[None, None]:
+        if asyncio.current_task() is None:
+            yield None
+        raise RuntimeError("synthetic producer failure")
+
+    monkeypatch.setattr(local_audio_player.sd, "OutputStream", SilentOutputStream)
+
+    with pytest.raises(RuntimeError, match="synthetic producer failure"):
+        await asyncio.wait_for(
+            local_audio_player.LocalAudioPlayer().play_stream(broken_stream()),
+            timeout=1,
+        )


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`LocalAudioPlayer.play_stream()` currently waits only for the audio callback's completion event before it awaits the input producer task. If the supplied async generator raises, the producer task finishes with that exception but no one sets the playback event, so the public method hangs and asyncio reports that the task exception was never retrieved.

This change waits for playback completion and producer completion together. A producer failure is propagated immediately; normal producer completion still waits for the callback to consume the queued completion sentinel, so buffered playback behavior is unchanged. The cleanup path also cancels and retrieves either internal task when the caller exits early.

A hardware-free regression replaces `sounddevice.OutputStream` with a silent context manager and verifies that a synthetic input-generator failure reaches the caller instead of timing out.

Validation:

- `uv run --locked --all-extras pytest -q tests/test_local_audio_player.py tests/lib/test_audio.py` — 5 passed on Python 3.10.
- The same focused command with `uv run --isolated --python 3.14` — 5 passed.
- `./scripts/lint` with the repository-pinned Node.js 22.22.3 — Ruff passed; Pyright reported 0 errors; Mypy reported no issues in 1614 source files; import check passed.
- Reproduction against unmodified `main`: the same input timed out after 200 ms and emitted `Task exception was never retrieved` for the original `RuntimeError`.

The generated API audio tests require the repository's Steady mock server. They were not counted as passing in this environment; without that server they returned HTTP 502 before exercising this helper.

## Additional context & links

The affected file is under `src/openai/helpers/`, which `CONTRIBUTING.md` identifies as hand-maintained code. I searched open and closed issues and pull requests for `play_stream` producer failures and did not find an existing fix. Existing audio-helper PRs concern `get_running_loop()` or array shape handling rather than this failure path.
