### PR TITLE
fix(streaming): wrap mid-stream transport errors as APITimeoutError/APIConnectionError

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -11,7 +11,8 @@ from typing_extensions import Self, Protocol, TypeGuard, override, get_origin, r
 import httpx2
 
 from ._utils import is_mapping, extract_type_var_from_base
-from ._exceptions import APIError
+from ._httpx2 import timeout_exceptions
+from ._exceptions import APIError, OpenAIError, APITimeoutError, APIConnectionError
 
 if TYPE_CHECKING:
     from ._client import OpenAI, AsyncOpenAI
@@ -106,6 +107,12 @@ class Stream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except timeout_exceptions() as err:
+            raise APITimeoutError(request=response.request) from err
+        except OpenAIError:
+            raise
+        except Exception as err:
+            raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             response.close()
@@ -216,6 +223,12 @@ class AsyncStream(Generic[_T]):
                         cast_to=cast_to,
                         response=response,
                     )
+        except timeout_exceptions() as err:
+            raise APITimeoutError(request=response.request) from err
+        except OpenAIError:
+            raise
+        except Exception as err:
+            raise APIConnectionError(request=response.request) from err
         finally:
             # Ensure the response is closed even if the consumer doesn't read all data
             await response.aclose()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -5,8 +5,59 @@ from typing import Iterator, AsyncIterator
 import httpx2
 import pytest
 
-from openai import OpenAI, AsyncOpenAI
+from openai import OpenAI, AsyncOpenAI, APITimeoutError
 from openai._streaming import Stream, AsyncStream, ServerSentEvent
+
+FIRST_CHUNK = (
+    b'data: {"id":"c1","object":"chat.completion.chunk","created":0,"model":"gpt-5.2",'
+    b'"choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}\n\n'
+)
+
+
+class _DiesMidStream(httpx2.SyncByteStream):
+    def __iter__(self) -> Iterator[bytes]:
+        yield FIRST_CHUNK
+        raise httpx2.ReadTimeout("timed out while reading the stream")
+
+
+class _AsyncDiesMidStream(httpx2.AsyncByteStream):
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        yield FIRST_CHUNK
+        raise httpx2.ReadTimeout("timed out while reading the stream")
+
+
+def test_sync_stream_wraps_mid_stream_transport_error() -> None:
+    def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, stream=_DiesMidStream())
+
+    client = OpenAI(
+        api_key="My API Key",
+        http_client=httpx2.Client(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+
+    with pytest.raises(APITimeoutError):
+        for _ in client.chat.completions.create(
+            model="gpt-5.2", messages=[{"role": "user", "content": "hi"}], stream=True
+        ):
+            pass
+
+
+async def test_async_stream_wraps_mid_stream_transport_error() -> None:
+    async def handler(request: httpx2.Request) -> httpx2.Response:
+        return httpx2.Response(200, headers={"content-type": "text/event-stream"}, stream=_AsyncDiesMidStream())
+
+    client = AsyncOpenAI(
+        api_key="My API Key",
+        http_client=httpx2.AsyncClient(transport=httpx2.MockTransport(handler)),
+        max_retries=0,
+    )
+
+    with pytest.raises(APITimeoutError):
+        async for _ in await client.chat.completions.create(
+            model="gpt-5.2", messages=[{"role": "user", "content": "hi"}], stream=True
+        ):
+            pass
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`_base_client` wraps the initial send — `httpx.TimeoutException` becomes `APITimeoutError`, other transport errors become `APIConnectionError`, and both go through the retry loop. Once the response is streaming, `Stream.__stream__` / `AsyncStream.__stream__` in `_streaming.py` iterated the response with no exception handling at all, so a read timeout or a dropped connection mid-stream surfaced as the raw `httpx.ReadTimeout` / `httpx.RemoteProtocolError`, not an `openai.APIError`.

That means `except openai.APIError` around a streaming call misses the most common streaming failure, and `max_retries` is never consulted for it.

The fix wraps the iteration loop in both `__stream__` methods with the same pattern `_base_client.py` already uses for the initial request: `timeout_exceptions()` → `APITimeoutError`, an already-raised `OpenAIError` (the in-stream `error`-event case a few lines up) re-raised as-is so it isn't double-wrapped, anything else → `APIConnectionError`. Whether a partially-consumed stream can itself be retried is a separate question — this only fixes the catch side, matching what the non-streaming path already does.

Also fixed in `anthropic-sdk-python` (same generated base, same gap): https://github.com/anthropics/anthropic-sdk-python/issues/1919

## Additional context & links

Closes #3811

Verified against the repro script from the issue (mock transport that yields one chunk then raises `ReadTimeout`): before the fix, `isinstance(e, openai.APIError)` is `False`; after, it raises `APITimeoutError` and `isinstance` is `True`.

Added `test_sync_stream_wraps_mid_stream_transport_error` and `test_async_stream_wraps_mid_stream_transport_error` to `tests/test_streaming.py` — both confirmed to fail on the unfixed code (raw `httpx2.ReadTimeout` escapes) and pass with the fix. Full `tests/test_streaming.py` suite (22 tests) passes. The broader test run has unrelated pre-existing collection errors from missing optional dev deps (`rich`, `botocore`, etc.) in this environment — not touched by this change.