### PR TITLE
fix(streaming): preserve first SSE event after BOM

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -327,6 +327,7 @@ class SSEDecoder:
     _event: str | None
     _retry: int | None
     _last_event_id: str | None
+    _first_line: bool
 
     def __init__(self) -> None:
         self._reset()
@@ -336,6 +337,7 @@ class SSEDecoder:
         self._data = []
         self._last_event_id = None
         self._retry = None
+        self._first_line = True
 
     def _decode_lines(self, lines: Iterator[bytes]) -> Iterator[ServerSentEvent]:
         for raw_line in lines:
@@ -367,6 +369,10 @@ class SSEDecoder:
 
     def decode(self, line: str) -> ServerSentEvent | None:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
+
+        if self._first_line:
+            self._first_line = False
+            line = line.removeprefix("\ufeff")
 
         if not line:
             if not self._event and not self._data and not self._last_event_id and self._retry is None:

--- a/tests/test_sse_framing.py
+++ b/tests/test_sse_framing.py
@@ -46,6 +46,14 @@ async def test_every_chunk_boundary(sync: bool, ending: bytes) -> None:
 
 
 @pytest.mark.parametrize("sync", [True, False])
+@pytest.mark.parametrize("fragment_size", [1, 2, 100000])
+async def test_leading_utf8_bom(sync: bool, fragment_size: int) -> None:
+    frame = b"\xef\xbb\xbfdata:first\n\ndata:second\n\n"
+    events = await _decode(SSEDecoder(), _fragment(frame, fragment_size), sync)
+    assert [event.data for event in events] == ["first", "second"]
+
+
+@pytest.mark.parametrize("sync", [True, False])
 async def test_many_complete_events(sync: bool) -> None:
     events = await _decode(SSEDecoder(), [b"data:ok\n\n" * 2000], sync)
     assert [event.data for event in events] == ["ok"] * 2000


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Strip the single leading UTF-8 byte-order mark allowed by the SSE format before interpreting the first line.

Today `SSEDecoder` decodes each completed line independently. A valid stream beginning with a BOM therefore presents its first field as `\ufeffdata` instead of `data`, so the decoder silently drops the first event. The WHATWG event-stream interpretation algorithm explicitly strips one leading UTF-8 BOM.

The decoder now tracks the first line of each stream and removes only a leading BOM there. The regression covers synchronous and asynchronous decoding with the three BOM bytes both contiguous and split across input chunks.

## Additional context & links

- Specification: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
- Before: `BOM + data:first + blank line + data:second` yielded only `second`
- After: it yields `first`, then `second`

Validation:

- `uv run --locked --all-extras pytest tests/test_sse_framing.py` — 48 passed
- `./scripts/test-pydantic-v1 tests/test_sse_framing.py` — 48 passed
- `./scripts/lint` — Ruff, Pyright, Mypy, and import checks passed
- Castiron custom-code budget check — passed (6,626 / 10,000 lines)
- `git diff --check origin/main...HEAD` — passed
