### PR TITLE
examples: fix broken Session import in the push-to-talk app

### DIFF
--- a/examples/realtime/push_to_talk_app.py
+++ b/examples/realtime/push_to_talk_app.py
@@ -41,7 +41,7 @@ from textual.reactive import reactive
 from textual.containers import Container
 
 from openai import AsyncOpenAI
-from openai.types.realtime.session import Session
+from openai.types.realtime.session_created_event import Session
 from openai.resources.realtime.realtime import AsyncRealtimeConnection
 
 


### PR DESCRIPTION
`examples/realtime/push_to_talk_app.py` imports `from openai.types.realtime.session import Session` — that module doesn't exist, so the linked TUI example raises `ModuleNotFoundError` at startup. The `Session` type is exported by `openai.types.realtime.session_created_event` (`Session: TypeAlias = Union[RealtimeSessionCreateRequest, RealtimeTranscriptionSessionCreateRequest]`), which is the type of `event.session` used at lines 182/187. Import repointed there.

Both `src/openai/lib/` and `examples/` are outside the generator's scope.