### PR TITLE
fix(examples): use uv in remaining Python launchers

### DIFF
--- a/examples/async_demo.py
+++ b/examples/async_demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 from openai import OpenAI
 

--- a/examples/streaming.py
+++ b/examples/streaming.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 

--- a/examples/video.py
+++ b/examples/video.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S poetry run python
+#!/usr/bin/env -S uv run python
 
 import asyncio
 


### PR DESCRIPTION
Change the shebangs in `examples/async_demo.py`, `examples/demo.py`, `examples/streaming.py`, and `examples/video.py` from `poetry run python` to `uv run python`, matching the repository's contributor setup and example instructions.