### PR TITLE
fix(streaming): validate SSE retry digits

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -404,10 +404,8 @@ class SSEDecoder:
             else:
                 self._last_event_id = value
         elif fieldname == "retry":
-            try:
+            if value.isascii() and value.isdigit():
                 self._retry = int(value)
-            except (TypeError, ValueError):
-                pass
         else:
             pass  # Field is ignored.
 

--- a/tests/test_sse_retry_validation.py
+++ b/tests/test_sse_retry_validation.py
@@ -1,0 +1,25 @@
+import pytest
+
+from openai._streaming import SSEDecoder
+
+
+@pytest.mark.parametrize("value", ["-1", "+1000", "١٠٠٠", "1.0", "1_000"])
+def test_invalid_retry_value_is_ignored(value: str) -> None:
+    decoder = SSEDecoder()
+    decoder.decode("retry: 2500")
+    decoder.decode(f"retry: {value}")
+    decoder.decode("data: {}")
+
+    event = decoder.decode("")
+    assert event is not None
+    assert event.retry == 2500
+
+
+def test_ascii_retry_digits_are_accepted() -> None:
+    decoder = SSEDecoder()
+    decoder.decode("retry: 0010")
+    decoder.decode("data: {}")
+
+    event = decoder.decode("")
+    assert event is not None
+    assert event.retry == 10


### PR DESCRIPTION
## Summary

- accept SSE `retry` values only when every character is an ASCII digit
- preserve an earlier valid retry value when a later invalid field is ignored
- add coverage for signed, Unicode, decimal, underscore, and zero-padded values

Fixes #3834

## Tests

Regression coverage added in `tests/test_sse_retry_validation.py`. The connected development host was unavailable for a local suite run.