### PR TITLE
Skip empty SSE control events

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -63,6 +63,8 @@ class Stream(Generic[_T]):
             for sse in iterator:
                 if sse.data.startswith("[DONE]"):
                     break
+                if not sse.data:
+                    continue
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):
@@ -173,6 +175,8 @@ class AsyncStream(Generic[_T]):
             async for sse in iterator:
                 if sse.data.startswith("[DONE]"):
                     break
+                if not sse.data:
+                    continue
 
                 # we have to special case the Assistants `thread.` events since we won't have an "event" key in the data
                 if sse.event and sse.event.startswith("thread."):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -58,6 +58,31 @@ async def test_event_missing_data(sync: bool, client: OpenAI, async_client: Asyn
     await assert_empty_iter(iterator)
 
 
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_stream_skips_empty_sse_events(
+    sync: bool,
+    client: OpenAI,
+    async_client: AsyncOpenAI,
+) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"id: control-only\n"
+        yield b"retry: 1000\n"
+        yield b"\n"
+        yield b'data: {"foo":true}\n'
+        yield b"\n"
+
+    if sync:
+        stream = Stream(cast_to=object, client=client, response=httpx2.Response(200, content=body()))
+        assert list(stream) == [{"foo": True}]
+    else:
+        stream = AsyncStream(
+            cast_to=object,
+            client=async_client,
+            response=httpx2.Response(200, content=to_aiter(body())),
+        )
+        assert [item async for item in stream] == [{"foo": True}]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 async def test_multiple_events(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:


### PR DESCRIPTION
Fixes #3833

## Changes being requested

- [x] I understand that this repository is auto-generated and my pull request may not be merged

Ignore SSE records that contain control metadata but no data before attempting JSON decoding. This keeps `Stream` and `AsyncStream` moving to the next valid event while leaving the decoder metadata behavior unchanged.

## Additional context & links

The regression test covers both synchronous and asynchronous streams with `id`/`retry` control fields followed by a valid JSON event.

## Validation

- `uvx --from uv==0.12.1 uv run --locked pytest tests/test_streaming.py -q` (22 passed)
- `uvx --from uv==0.12.1 uv run --locked ruff check src/openai/_streaming.py tests/test_streaming.py`
- `uvx --from uv==0.12.1 uv run --locked ruff format --check src/openai/_streaming.py tests/test_streaming.py`