### PR TITLE
fix(querystring): preserve empty string values

### DIFF
--- a/src/openai/_qs.py
+++ b/src/openai/_qs.py
@@ -112,10 +112,9 @@ class Querystring:
                     f"Unknown array_format value: {array_format}, choose from {', '.join(get_args(ArrayFormat))}"
                 )
 
-        serialised = self._primitive_value_to_str(value)
-        if not serialised:
+        if value is None:
             return []
-        return [(key, serialised)]
+        return [(key, self._primitive_value_to_str(value))]
 
     def _primitive_value_to_str(self, value: PrimitiveData) -> str:
         # copied from httpx

--- a/tests/test_qs_empty_values.py
+++ b/tests/test_qs_empty_values.py
@@ -1,0 +1,19 @@
+from urllib.parse import unquote
+
+from openai._qs import stringify
+
+
+def test_empty_string_scalar_is_preserved() -> None:
+    assert stringify({"filter": ""}) == "filter="
+
+
+def test_none_scalar_is_still_omitted() -> None:
+    assert stringify({"filter": None}) == ""
+
+
+def test_nested_empty_string_is_preserved() -> None:
+    assert unquote(stringify({"filter": {"name": ""}})) == "filter[name]="
+
+
+def test_empty_string_in_repeat_array_is_preserved() -> None:
+    assert stringify({"filter": ["", "active"]}) == "filter=&filter=active"


### PR DESCRIPTION
## Summary

- preserve explicit empty-string query values instead of dropping them
- keep `None` query values omitted
- add scalar, nested, and repeated-array regression coverage

Fixes #3837

## Tests

Regression coverage added in `tests/test_qs_empty_values.py`. The connected development host was unavailable for a local suite run.