### PR TITLE
fix(streaming): skip control-only SSE blocks with no data

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -369,7 +369,7 @@ class SSEDecoder:
         # See: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation  # noqa: E501
 
         if not line:
-            if not self._event and not self._data and not self._last_event_id and self._retry is None:
+            if not self._event and not self._data:
                 return None
 
             sse = ServerSentEvent(

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -60,6 +60,28 @@ async def test_event_missing_data(sync: bool, client: OpenAI, async_client: Asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
+async def test_control_only_blocks_are_skipped(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
+    def body() -> Iterator[bytes]:
+        yield b"retry: 1000\n"
+        yield b"\n"
+        yield b"id: 1\n"
+        yield b"\n"
+        yield b'data: {"foo":true}\n'
+        yield b"\n"
+        yield b"\n"
+
+    iterator = make_event_iterator(content=body(), sync=sync, client=client, async_client=async_client)
+
+    sse = await iter_next(iterator)
+    assert sse.id == "1"
+    assert sse.retry == 1000
+    assert sse.json() == {"foo": True}
+
+    await assert_empty_iter(iterator)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync", [True, False], ids=["sync", "async"])
 async def test_multiple_events(sync: bool, client: OpenAI, async_client: AsyncOpenAI) -> None:
     def body() -> Iterator[bytes]:
         yield b"event: ping\n"


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

An SSE block carrying only `retry:` or `id:` has no data, but the blank-line guard in `SSEDecoder.decode()` also looked at `_last_event_id` and `_retry`, so it dispatched an event with empty data anyway. `Stream.__stream__()` runs every event through `sse.json()`, and that empty event ends an otherwise valid stream with a JSON decoding error before the next data event is read. `_last_event_id` is kept across events on purpose, so once a stream has sent an `id:` field, any later blank line hits the same path.

The guard now dispatches only when an event name or data is buffered. Both fields stay on the decoder, so the next real event still reports the current id and retry.

## Additional context & links

Closes #3833

`tests/test_streaming.py::test_control_only_blocks_are_skipped` fails on main and passes with this change. The streaming and SSE framing suites pass, and ruff check and format are clean on both touched files.
