### PR TITLE
fix(streaming): validate SSE retry field per spec instead of leniently int()-ing it

### DIFF
--- a/src/openai/_streaming.py
+++ b/src/openai/_streaming.py
@@ -419,10 +419,11 @@ class SSEDecoder:
             else:
                 self._last_event_id = value
         elif fieldname == "retry":
-            try:
+            # Per the SSE spec, a retry field is valid only if it consists entirely
+            # of ASCII digits; anything else (a sign, whitespace, a decimal point)
+            # must be ignored rather than parsed leniently by int().
+            if value.isascii() and value.isdigit():
                 self._retry = int(value)
-            except (TypeError, ValueError):
-                pass
         else:
             pass  # Field is ignored.
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -9,7 +9,7 @@ import httpx2
 import pytest
 
 from openai import OpenAI, AsyncOpenAI, APITimeoutError, APIConnectionError
-from openai._streaming import Stream, AsyncStream, ServerSentEvent
+from openai._streaming import SSEDecoder, Stream, AsyncStream, ServerSentEvent
 
 
 @pytest.fixture(
@@ -406,6 +406,27 @@ async def test_async_stream_aclosing(raise_error: bool) -> None:
                     break
 
         assert response.is_closed
+
+
+@pytest.mark.parametrize("value", ["-1", "+1000", "1.5", " 100", "100 ", "1e3", ""])
+def test_sse_decoder_ignores_invalid_retry_value(value: str) -> None:
+    decoder = SSEDecoder()
+    decoder.decode(f"retry: {value}")
+    decoder.decode("data: ok")
+    sse = decoder.decode("")
+
+    assert sse is not None
+    assert sse.retry is None
+
+
+def test_sse_decoder_accepts_valid_retry_value() -> None:
+    decoder = SSEDecoder()
+    decoder.decode("retry: 3000")
+    decoder.decode("data: ok")
+    sse = decoder.decode("")
+
+    assert sse is not None
+    assert sse.retry == 3000
 
 
 async def to_aiter(iter: Iterator[bytes]) -> AsyncIterator[bytes]:


### PR DESCRIPTION
## Description

SSEDecoder.decode() used int(value) for the retry field, which accepts -1, +1000, leading/trailing whitespace, and other forms the SSE spec doesn't allow. Per the spec, the retry field is only valid when it consists entirely of ASCII digits.

retry: -1 was silently accepted as retry == -1 instead of the field being ignored.

Fix: validate with value.isascii() and value.isdigit() before assigning, matching the spec's [0-9]+ grammar exactly instead of parsing leniently.

Closes #3834

## Verification

Added test_sse_decoder_ignores_invalid_retry_value (parametrized over -1, +1000, 1.5, leading/trailing whitespace, 1e3, and empty) and test_sse_decoder_accepts_valid_retry_value directly against SSEDecoder.decode(). Confirmed 4 of the invalid-value cases genuinely fail on unfixed main (-1, +1000, and the two whitespace variants all currently parse successfully) and pass with the fix. Full tests/test_streaming.py suite: 28 passed.