### PR TITLE
fix(qs): keep an explicit empty-string scalar distinct from None

### DIFF
--- a/src/openai/_qs.py
+++ b/src/openai/_qs.py
@@ -112,10 +112,9 @@ class Querystring:
                     f"Unknown array_format value: {array_format}, choose from {', '.join(get_args(ArrayFormat))}"
                 )
 
-        serialised = self._primitive_value_to_str(value)
-        if not serialised:
+        if value is None:
             return []
-        return [(key, serialised)]
+        return [(key, self._primitive_value_to_str(value))]
 
     def _primitive_value_to_str(self, value: PrimitiveData) -> str:
         # copied from httpx

--- a/tests/test_qs.py
+++ b/tests/test_qs.py
@@ -22,6 +22,14 @@ def test_basic() -> None:
     assert stringify({"a": None}) == ""
 
 
+def test_empty_string_scalar_is_kept_distinct_from_none() -> None:
+    # An explicit empty string is a real value ("a=") and must not be
+    # conflated with omitting the key entirely (None).
+    assert unquote(stringify({"a": ""})) == "a="
+    assert stringify({"a": None}) == ""
+    assert unquote(stringify({"a": "", "b": 1})) == "a=&b=1"
+
+
 @pytest.mark.parametrize("method", ["class", "function"])
 def test_nested_dotted(method: str) -> None:
     if method == "class":


### PR DESCRIPTION
## Description

Querystring.stringify() drops an explicit empty-string scalar because _stringify_item() checks the serialized value with a truthiness test:

```python
stringify({"filter": ""})  # -> "" (currently)
```

_primitive_value_to_str serializes both None and "" to the same "" string, so the truthiness check `if not serialised: return []` conflates an explicit empty value with omitting the key entirely. In a URL query, filter= is distinct from no filter parameter at all.

Fix: check `value is None` before serializing, rather than checking the serialized string's truthiness afterward. The array ("comma" format) path was already correct here, since it filters on `item is not None`, only the scalar path had the bug.

Closes #3837

## Verification

Added test_empty_string_scalar_is_kept_distinct_from_none to tests/test_qs.py. Confirmed it fails on unfixed main (`stringify({"a": ""})` returns `""` instead of `"a="`) and passes with the fix. Full tests/test_qs.py suite: 12 passed.