### PR TITLE
docs: use the vision guide image in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ With an image URL:
 
 ```python
 prompt = "What is in this image?"
-img_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d5/2023_06_08_Raccoon1.jpg/1599px-2023_06_08_Raccoon1.jpg"
+img_url = "https://api.nga.gov/iiif/a2e6da57-3cd1-4235-b20e-95dcaefed6c8/full/!800,800/0/default.jpg"
 
 response = client.responses.create(
     model="gpt-5.5",


### PR DESCRIPTION
## Summary

The README vision example points to a Wikimedia thumbnail URL that can fail during the API's image download. Replace it with the National Gallery of Art image already used in the [OpenAI vision guide](https://developers.openai.com/api/docs/guides/images-vision), preserving the current Responses API example and model.

Fixes #2776.

## Image provenance

The image UUID `a2e6da57-3cd1-4235-b20e-95dcaefed6c8` is listed with `openaccess=1` in the National Gallery's [official published-image catalog](https://github.com/NationalGalleryOfArt/opendata/blob/main/data/published_images.csv). The Gallery's [open-access policy](https://www.nga.gov/terms-and-notices) releases these images under CC0 for commercial and non-commercial use. The URL is hosted directly by the Gallery and matches the official OpenAI docs example.

## Validation

- Ran the exact updated README URL example against the live Responses API with SDK 3.13.0 and `gpt-5.5`: status `completed`, with a description of the seated woman in the portrait.
- `git diff --check` passed.
- Reviewed the full diff: one image URL replacement in README.md.
