### PR TITLE
fix(lib): treat null message content as empty in parse_response

### DIFF
--- a/src/openai/lib/_parsing/_responses.py
+++ b/src/openai/lib/_parsing/_responses.py
@@ -61,7 +61,7 @@ def parse_response(
     for output in response.output or []:
         if output.type == "message":
             content_list: List[ParsedContent[TextFormatT]] = []
-            for item in output.content:
+            for item in output.content or []:
                 if item.type != "output_text":
                     content_list.append(item)
                     continue

--- a/tests/lib/responses/test_null_output.py
+++ b/tests/lib/responses/test_null_output.py
@@ -7,7 +7,10 @@ import pytest
 from pydantic import BaseModel
 
 from openai import OpenAI, AsyncOpenAI
-from openai.types.responses import ToolParam
+from openai._types import omit
+from openai._models import construct_type_unchecked
+from openai.types.responses import Response, ToolParam
+from openai.lib._parsing._responses import parse_response
 
 
 class Answer(BaseModel):
@@ -123,3 +126,29 @@ async def test_stream_recovers_finalized_output(sync: bool, terminal_output: str
         assert tool.type == "function_call" and tool.status == "completed"
         assert tool.id == "fc_test"
         assert tool.parsed_arguments == {"answer": 4}
+
+
+def test_parse_response_with_null_message_content() -> None:
+    response = construct_type_unchecked(
+        type_=Response,
+        value={
+            "id": "resp_test",
+            "status": "completed",
+            "output": [
+                {
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "content": None,
+                }
+            ],
+        },
+    )
+
+    parsed = parse_response(text_format=omit, input_tools=omit, response=response)
+
+    assert len(parsed.output) == 1
+    message = parsed.output[0]
+    assert message.type == "message"
+    assert message.content == []


### PR DESCRIPTION
## Changes being requested

- [x] I understand that this repository is auto-generated and my pull request may not be merged

Fixes #3840

`parse_response()` in `src/openai/lib/_parsing/_responses.py` iterates `output.content` without a null guard, so a message output item with `content: null` raises `TypeError: 'NoneType' object is not iterable` instead of parsing:

```python
client.responses.parse(model="...", input="...")
# API returns output: [{"id": ..., "type": "message", "role": "assistant",
#   "status": "completed", "content": null}]
# -> TypeError: 'NoneType' object is not iterable
```

Null reaches the parser because stream events are built without validation, and the same payload also passes the non-streaming path (reproduced with a mocked transport, both sync and async). This is the same class of bug as null `output`, fixed in #3345.

The fix applies the same `or []` idiom used at line 61 for null `output` (one line). The change is in `src/openai/lib/`, which per CONTRIBUTING.md is handwritten and never modified by the generator, so no custom-code budget impact.

## Additional context & links

- Follow-up to #3325 / #3345 (null `output`), one level deeper: message `content`.
- Regression test added in `tests/lib/responses/test_null_output.py` next to the existing null-output tests, mirroring the `test_parse_response_with_null_output` pattern from #3345.
- Verification: reproduced the `TypeError` on current `main`; new test fails without the fix and passes with it; full `tests/lib/responses/` suite passes (96 passed); `ruff check` clean on both files; `git diff --check` clean. Diff is 2 files, +31/−2.